### PR TITLE
C# CreateNewConversation Sample update to NuGet Package 3.2.1

### DIFF
--- a/CSharp/core-CreateNewConversation/Controllers/MessagesController.cs
+++ b/CSharp/core-CreateNewConversation/Controllers/MessagesController.cs
@@ -37,7 +37,7 @@
                     var conversation = await client.Conversations.CreateDirectConversationAsync(activity.Recipient, activity.From);
 
                     var cookie = scope.Resolve<ResumptionCookie>();
-                    cookie.ConversationId = conversation.Id;
+                    cookie.Address = new Address(cookie.Address.BotId, cookie.Address.ChannelId, cookie.Address.UserId, conversation.Id, cookie.Address.ServiceUrl);
 
                     var postToBot = scope.Resolve<IPostToBot>();
                     await postToBot.PostAsync(activity, token);

--- a/CSharp/core-CreateNewConversation/CreateNewConversationBot.csproj
+++ b/CSharp/core-CreateNewConversation/CreateNewConversationBot.csproj
@@ -54,17 +54,21 @@
       <HintPath>packages\Chronic.Signed.0.3.2\lib\net40\Chronic.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Bot.Builder, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Bot.Builder.3.1.0\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Builder, Version=3.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Bot.Builder.3.2.1\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Bot.Connector, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Bot.Builder.3.1.0\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Connector, Version=3.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Bot.Builder.3.2.1\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.IdentityModel.Protocol.Extensions, Version=1.0.2.33, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.2.206221351\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Rest.ClientRuntime.2.3.2\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -87,6 +91,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />

--- a/CSharp/core-CreateNewConversation/README.md
+++ b/CSharp/core-CreateNewConversation/README.md
@@ -27,7 +27,7 @@ using (var scope = DialogModule.BeginLifetimeScope(this.scope, activity))
     var conversation = await client.Conversations.CreateDirectConversationAsync(activity.Recipient, activity.From);
 
     var cookie = scope.Resolve<ResumptionCookie>();
-    cookie.ConversationId = conversation.Id;
+    cookie.Address = new Address(cookie.Address.BotId, cookie.Address.ChannelId, cookie.Address.UserId, conversation.Id, cookie.Address.ServiceUrl);
 
     var postToBot = scope.Resolve<IPostToBot>();
     await postToBot.PostAsync(activity, token);

--- a/CSharp/core-CreateNewConversation/packages.config
+++ b/CSharp/core-CreateNewConversation/packages.config
@@ -7,9 +7,9 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.1.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.2.1" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.2.206221351" targetFramework="net46" />
-  <package id="Microsoft.Rest.ClientRuntime" version="1.8.2" targetFramework="net46" />
+  <package id="Microsoft.Rest.ClientRuntime" version="2.3.2" targetFramework="net46" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.2.206221351" targetFramework="net46" />


### PR DESCRIPTION
Take into account there's an issue related to this post: http://stackoverflow.com/questions/39566151/botframework-slack-ignores-new-conversationid

