### PR TITLE
Score is a float number when returned from Bing

### DIFF
--- a/CSharp/intelligence-LUIS/Services/BingSpellCheckResponse.cs
+++ b/CSharp/intelligence-LUIS/Services/BingSpellCheckResponse.cs
@@ -20,7 +20,7 @@
     public class Suggestion
     {
         public string suggestion { get; set; }
-        public int score { get; set; }
+        public double score { get; set; }
     }
 
     public class Error


### PR DESCRIPTION
Updated score in Suggestion class to be a float point number represented as a double, to mach Bing Spell Check API return values.