### PR TITLE
Use Top scoring Intent instead of first intent

### DIFF
--- a/CSharp/Blog-LUISActionBinding/Microsoft.Cognitive.LUIS.ActionBinding/LuisActionResolver.cs
+++ b/CSharp/Blog-LUISActionBinding/Microsoft.Cognitive.LUIS.ActionBinding/LuisActionResolver.cs
@@ -87,8 +87,8 @@
             }
 
             var result = await service.QueryAsync(paramValue.ToString(), token);
-            var queryIntent = result.Intents.FirstOrDefault();
-            if (!Intents.None.Equals(queryIntent.Intent, StringComparison.InvariantCultureIgnoreCase))
+            var queryIntent = result.TopScoringIntent;
+            if (queryIntent != null && !Intents.None.Equals(queryIntent.Intent, StringComparison.InvariantCultureIgnoreCase))
             {
                 var newIntentName = default(string);
                 var newAction = new LuisActionResolver(action.GetType().Assembly).ResolveActionFromLuisIntent(result, out newIntentName);


### PR DESCRIPTION
LUIS Result from a query returns intents and entities and scores. The code used the firstOrDefault Intent instead of the most likely intent which is TopScoringIntent. Also checking intent for null value is important to prevent crash on null exception when no intent is returned.