### PR TITLE
Update README.md in core-CreateNewConversation sample

### DIFF
--- a/CSharp/core-CreateNewConversation/README.md
+++ b/CSharp/core-CreateNewConversation/README.md
@@ -55,8 +55,8 @@ public static async Task StartSurvey(ConversationReference conversationReference
         var botData = scope.Resolve<IBotData>();
         await botData.LoadAsync(token);
 
-        // resolve the dialog stack
-        IDialogStack stack = stack = scope.Resolve<IDialogStack>();
+        // resolve the dialog task
+        IDialogTask task = scope.Resolve<IDialogTask>();
 
         // make a dialog to push on the top of the stack
         var child = scope.Resolve<SurveyDialog>();
@@ -68,10 +68,10 @@ public static async Task StartSurvey(ConversationReference conversationReference
         try
         {
             // put the interrupting dialog on the stack
-            stack.Call(interruption, null);
+            task.Call(interruption, null);
 
             // start running the interrupting dialog
-            await stack.PollAsync(token);
+            await task.PollAsync(token);
         }
         finally
         {


### PR DESCRIPTION
This change updates the README.md of the core-CreateNewComversation sample to reflect changes made in the SurveyTriggerer.cs. The current version of SurveyTriggerer.cs uses IDialogTask instead of IDialogStack, and additionally, the original version contained a typo on line 53: `IDialogStack stack = stack = scope.Resolve<IDialogStack>();`