### PR TITLE
Fix LUIS_MODEL.json so it can be imported successfully.

### DIFF
--- a/CSharp/Blog-LUISActionBinding/LUIS_MODEL.json
+++ b/CSharp/Blog-LUISActionBinding/LUIS_MODEL.json
@@ -45,13 +45,13 @@
     {
       "name": "Checkin",
       "children": [
-        "datetime"
+        "datetimeV2"
       ]
     },
     {
       "name": "Checkout",
       "children": [
-        "datetime"
+        "datetimeV2"
       ]
     },
     {
@@ -63,7 +63,7 @@
   ],
   "closedLists": [],
   "bing_entities": [
-    "datetime",
+    "datetimeV2",
     "geography"
   ],
   "actions": [],

--- a/Node/blog-LUISActionBinding/LUIS_MODEL.json
+++ b/Node/blog-LUISActionBinding/LUIS_MODEL.json
@@ -45,13 +45,13 @@
     {
       "name": "Checkin",
       "children": [
-        "datetime"
+        "datetimeV2"
       ]
     },
     {
       "name": "Checkout",
       "children": [
-        "datetime"
+        "datetimeV2"
       ]
     },
     {
@@ -63,7 +63,7 @@
   ],
   "closedLists": [],
   "bing_entities": [
-    "datetime",
+    "datetimeV2",
     "geography"
   ],
   "actions": [],


### PR DESCRIPTION
LUIS app import fails because 'datetime' has been replaced with 'datetimeV2'. Fixed LUIS_MODEL.json to specify 'datetimeV2'.