### PR TITLE
Updating AzureDeploy.Json to allow RBAC Subscriptions owners to deploy to Azure App Service.

### DIFF
--- a/CSharp/Blog-LUISActionBinding/azuredeploy.json
+++ b/CSharp/Blog-LUISActionBinding/azuredeploy.json
@@ -80,8 +80,18 @@
       },
       "properties": {
         "name": "[parameters('siteName')]",
-        "serverFarm": "[parameters('hostingPlanName')]",
-         "appSettings": [
+        "serverFarm": "[parameters('hostingPlanName')]"
+      },
+      "resources": [
+        {
+          "apiVersion": "2016-08-01",
+          "type": "config",
+          "name": "web",
+          "dependsOn": [
+            "[concat('Microsoft.Web/Sites/', parameters('siteName'))]"
+          ],
+          "properties": {
+                     "appSettings": [
               {
                 "name": "Project",
                 "value": "[parameters('Project')]"
@@ -103,16 +113,6 @@
                 "value": "[parameters('LUIS_ModelId')]"
               }
             ]
-      },
-      "resources": [
-        {
-          "apiVersion": "2016-08-01",
-          "type": "config",
-          "name": "web",
-          "dependsOn": [
-            "[concat('Microsoft.Web/Sites/', parameters('siteName'))]"
-          ],
-          "properties": {
           }
         },
         {

--- a/CSharp/Blog-LUISActionBinding/azuredeploy.json
+++ b/CSharp/Blog-LUISActionBinding/azuredeploy.json
@@ -81,8 +81,7 @@
       "properties": {
         "name": "[parameters('siteName')]",
         "serverFarm": "[parameters('hostingPlanName')]",
-        "properties" : {
-          "siteConfig":{
+        "siteConfig":{
             "appSettings":[
               {
                 "name": "Project",
@@ -105,8 +104,7 @@
                 "value": "[parameters('LUIS_ModelId')]"
               }
             ]
-          }
-        }
+         }      
       },
       "resources": [
         {

--- a/CSharp/Blog-LUISActionBinding/azuredeploy.json
+++ b/CSharp/Blog-LUISActionBinding/azuredeploy.json
@@ -84,7 +84,7 @@
       },
       "resources": [
         {
-          "apiVersion": "2015-08-01",
+          "apiVersion": "2016-08-01",
           "type": "config",
           "name": "web",
           "dependsOn": [

--- a/CSharp/Blog-LUISActionBinding/azuredeploy.json
+++ b/CSharp/Blog-LUISActionBinding/azuredeploy.json
@@ -116,7 +116,7 @@
           }
         },
         {
-          "apiVersion": "2014-06-01",
+          "apiVersion": "2014-04-01",
           "name": "web",
           "type": "sourcecontrols",
           "dependsOn": [

--- a/CSharp/Blog-LUISActionBinding/azuredeploy.json
+++ b/CSharp/Blog-LUISActionBinding/azuredeploy.json
@@ -84,7 +84,7 @@
       },
       "resources": [
         {
-          "apiVersion": "2014-06-01",
+          "apiVersion": "2014-04-01",
           "type": "config",
           "name": "web",
           "dependsOn": [

--- a/CSharp/Blog-LUISActionBinding/azuredeploy.json
+++ b/CSharp/Blog-LUISActionBinding/azuredeploy.json
@@ -80,7 +80,7 @@
       },
       "properties": {
         "name": "[parameters('siteName')]",
-        "serverFarm": "[parameters('hostingPlanName')]"
+        "serverFarm": "[parameters('hostingPlanName')]",
          "appSettings": [
               {
                 "name": "Project",

--- a/CSharp/Blog-LUISActionBinding/azuredeploy.json
+++ b/CSharp/Blog-LUISActionBinding/azuredeploy.json
@@ -80,18 +80,10 @@
       },
       "properties": {
         "name": "[parameters('siteName')]",
-        "serverFarm": "[parameters('hostingPlanName')]"
-      },
-      "resources": [
-        {
-          "apiVersion": "2016-08-01",
-          "type": "config",
-          "name": "web",
-          "dependsOn": [
-            "[concat('Microsoft.Web/Sites/', parameters('siteName'))]"
-          ],
-          "properties": {
-                     "appSettings": [
+        "serverFarm": "[parameters('hostingPlanName')]",
+        "properties" : {
+          "siteConfig":{
+            "appSettings":[
               {
                 "name": "Project",
                 "value": "[parameters('Project')]"
@@ -114,7 +106,9 @@
               }
             ]
           }
-        },
+        }
+      },
+      "resources": [
         {
           "apiVersion": "2016-03-01",
           "name": "web",

--- a/CSharp/Blog-LUISActionBinding/azuredeploy.json
+++ b/CSharp/Blog-LUISActionBinding/azuredeploy.json
@@ -110,6 +110,14 @@
       },
       "resources": [
         {
+          "apiVersion": "2016-08-01",
+          "type":"config",
+          "name":"web",
+          "dependsOn": [
+            "[concat('Microsoft.Web/Sites/', parameters('siteName'))]" 
+          ]
+        },
+        {
           "apiVersion": "2016-03-01",
           "name": "web",
           "type": "sourcecontrols",

--- a/CSharp/Blog-LUISActionBinding/azuredeploy.json
+++ b/CSharp/Blog-LUISActionBinding/azuredeploy.json
@@ -84,7 +84,7 @@
       },
       "resources": [
         {
-          "apiVersion": "2014-04-01",
+          "apiVersion": "2014-06-01",
           "type": "config",
           "name": "web",
           "dependsOn": [

--- a/CSharp/Blog-LUISActionBinding/azuredeploy.json
+++ b/CSharp/Blog-LUISActionBinding/azuredeploy.json
@@ -114,7 +114,7 @@
           "name": "web",
           "type": "sourcecontrols",
           "dependsOn": [
-            "[resourceId('Microsoft.Web/Sites', parameters('siteName'))]",
+            "[resourceId('Microsoft.Web/Sites', parameters('siteName'))]"
           ],
           "properties": {
             "RepoUrl": "[parameters('repoUrl')]",

--- a/CSharp/Blog-LUISActionBinding/azuredeploy.json
+++ b/CSharp/Blog-LUISActionBinding/azuredeploy.json
@@ -110,20 +110,11 @@
       },
       "resources": [
         {
-          "apiVersion": "2016-08-01",
-          "type":"config",
-          "name":"web",
-          "dependsOn": [
-            "[concat('Microsoft.Web/Sites/', parameters('siteName'))]" 
-          ]
-        },
-        {
           "apiVersion": "2016-03-01",
           "name": "web",
           "type": "sourcecontrols",
           "dependsOn": [
             "[resourceId('Microsoft.Web/Sites', parameters('siteName'))]",
-            "[concat('Microsoft.Web/Sites/', parameters('siteName'), '/config/web')]"
           ],
           "properties": {
             "RepoUrl": "[parameters('repoUrl')]",

--- a/CSharp/Blog-LUISActionBinding/azuredeploy.json
+++ b/CSharp/Blog-LUISActionBinding/azuredeploy.json
@@ -116,7 +116,7 @@
           }
         },
         {
-          "apiVersion": "2014-04-01",
+          "apiVersion": "2016-03-01",
           "name": "web",
           "type": "sourcecontrols",
           "dependsOn": [

--- a/CSharp/Blog-LUISActionBinding/azuredeploy.json
+++ b/CSharp/Blog-LUISActionBinding/azuredeploy.json
@@ -81,17 +81,7 @@
       "properties": {
         "name": "[parameters('siteName')]",
         "serverFarm": "[parameters('hostingPlanName')]"
-      },
-      "resources": [
-        {
-          "apiVersion": "2016-08-01",
-          "type": "config",
-          "name": "web",
-          "dependsOn": [
-            "[concat('Microsoft.Web/Sites/', parameters('siteName'))]"
-          ],
-          "properties": {
-            "appSettings": [
+         "appSettings": [
               {
                 "name": "Project",
                 "value": "[parameters('Project')]"
@@ -113,6 +103,16 @@
                 "value": "[parameters('LUIS_ModelId')]"
               }
             ]
+      },
+      "resources": [
+        {
+          "apiVersion": "2016-08-01",
+          "type": "config",
+          "name": "web",
+          "dependsOn": [
+            "[concat('Microsoft.Web/Sites/', parameters('siteName'))]"
+          ],
+          "properties": {
           }
         },
         {

--- a/CSharp/Blog-LUISActionBinding/azuredeploy.json
+++ b/CSharp/Blog-LUISActionBinding/azuredeploy.json
@@ -84,7 +84,7 @@
       },
       "resources": [
         {
-          "apiVersion": "2014-04-01",
+          "apiVersion": "2015-08-01",
           "type": "config",
           "name": "web",
           "dependsOn": [

--- a/CSharp/Blog-LUISActionBinding/azuredeploy.json
+++ b/CSharp/Blog-LUISActionBinding/azuredeploy.json
@@ -116,7 +116,7 @@
           }
         },
         {
-          "apiVersion": "2014-04-01",
+          "apiVersion": "2014-06-01",
           "name": "web",
           "type": "sourcecontrols",
           "dependsOn": [


### PR DESCRIPTION
The existing template gives an error when users who are owners on the subscription try to deploy. 
Users who are in this state would see this message in the activity log.

This change updates the API versions and moves the App Settings into the main site properties.
This allows both the RBAC create to succeed and also to have the SourceControls element get the Project hint  from App Settings to build correctly in Kudu. 