### PR TITLE
Add a line of code to force TLS1.2 to fix issue 279

### DIFF
--- a/CSharp/core-DirectLineWebSockets/DirectLineClient/Program.cs
+++ b/CSharp/core-DirectLineWebSockets/DirectLineClient/Program.cs
@@ -40,6 +40,8 @@
             using (var webSocketClient = new WebSocket(conversation.StreamUrl))
             {
                 webSocketClient.OnMessage += WebSocketClient_OnMessage;
+                // You have to specify TLS version to 1.2 or connection will be failed in handshake.
+                webSocketClient.SslConfiguration.EnabledSslProtocols = System.Security.Authentication.SslProtocols.Tls12;
                 webSocketClient.Connect();
 
                 while (true)


### PR DESCRIPTION
Add a line of code to force TLS1.2 communication from WebSocket client to server.
