### PR TITLE
Adding root dialog when DialogStack is empty

### DIFF
--- a/CSharp/core-proactiveMessages/startNewDialog/ConversationStarter.cs
+++ b/CSharp/core-proactiveMessages/startNewDialog/ConversationStarter.cs
@@ -28,7 +28,16 @@ namespace startNewDialog
 
                 //This is our dialog stack
                 var task = scope.Resolve<IDialogTask>();
-                
+
+                //Do we have a root dialog yet?
+                if (task.Frames.Count == 0)
+                {
+                    var root = Chain.Loop(new RootDialog());
+                    task.Call(root, null);
+
+                    await task.PollAsync(CancellationToken.None);
+                }
+
                 //interrupt the stack. This means that we're stopping whatever conversation that is currently happening with the user
                 //Then adding this stack to run and once it's finished, we will be back to the original conversation
                 var dialog = new SurveyDialog();

--- a/CSharp/core-proactiveMessages/startNewDialogWithPrompt/ConversationStarter.cs
+++ b/CSharp/core-proactiveMessages/startNewDialogWithPrompt/ConversationStarter.cs
@@ -27,6 +27,15 @@ namespace startNewDialogWithPrompt
                 await botData.LoadAsync(CancellationToken.None);
                 var task = scope.Resolve<IDialogTask>();
 
+                //Do we have a root dialog yet?
+                if (task.Frames.Count == 0)
+                {
+                    var root = Chain.Loop(new RootDialog());
+                    task.Call(root, null);
+
+                    await task.PollAsync(CancellationToken.None);
+                }
+
                 //interrupt the stack
                 var dialog =new SurveyDialog();
                 task.Call(dialog.Void<object, IMessageActivity>(), null);


### PR DESCRIPTION
If you send a proactive message in a new conversation the frame stack will be empty. When the interrupting dialog ends and you try to send a new message to the bot in the same conversation, you will get an error because there's nothing waiting to process that message. After hours trying to fix this, I figured you need to add a loop to the root dialog before the interruption.