### PR TITLE
Changed URL to ensure authentication happens with skype

### DIFF
--- a/CSharp/core-ReceiveAttachment/ReceiveAttachmentDialog.cs
+++ b/CSharp/core-ReceiveAttachment/ReceiveAttachmentDialog.cs
@@ -28,7 +28,7 @@
                 {
                     // Skype & MS Teams attachment URLs are secured by a JwtToken, so we need to pass the token from our bot.
                     if ((message.ChannelId.Equals("skype", StringComparison.InvariantCultureIgnoreCase) || message.ChannelId.Equals("msteams", StringComparison.InvariantCultureIgnoreCase)) 
-                        && new Uri(attachment.ContentUrl).Host.EndsWith("skype.com"))
+                        && new Uri(attachment.ContentUrl).Host.EndsWith("trafficmanager.net"))
                     {
                         var token = await new MicrosoftAppCredentials().GetTokenAsync();
                         httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);


### PR DESCRIPTION
If you use Skype or Teams, the URL to download the attachment is changed from *.skype.com to *.trafficmanager.net. Changed the if condition to download the attachment by performing authorization if the URL host ends with trafficmanager.net