### PR TITLE
Added PublishProfile folder to ignore for Azure deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,7 @@ DocProject/Help/html
 
 # Click-Once directory
 publish/
+PublishProfiles/
 
 # Publish Web Output
 *.[Pp]ublish.xml


### PR DESCRIPTION
VS keeps track of App Service publish profiles under PublishProfiles. Adding this to .gitignore