### PR TITLE
C# Multilingual Sample

### DIFF
--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/MultiLingualBot.bot
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/MultiLingualBot.bot
@@ -1,0 +1,16 @@
+{
+    "name": "MultiLingualBot",
+    "description": "",
+    "services": [
+        {
+            "type": "endpoint",
+            "name": "$safeprojectname",
+            "id": "http://localhost:3978/api/messages",
+            "appId": "",
+            "appPassword": "",
+            "endpoint": "http://localhost:3978/api/messages"
+        }
+    ],
+    "secretKey": "",
+    "version": "2.0"
+}

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/MultiLingualBot.cs
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/MultiLingualBot.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Options;
+using MultiLingualBot.Translation;
+
+namespace MultiLingualBot
+{
+    /// <summary>
+    /// Main entry point and orchestration for bot.
+    /// </summary>
+    public class MultiLingualBot : IBot
+    {
+        private readonly MultiLingualBotAccessors _accessors;
+
+        private DialogSet Dialogs { get; set; }
+
+        private const string English = "en";
+        private const string Spanish = "es";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MultiLingualBot"/> class.
+        /// </summary>
+        /// <param name="accessors">Bot State Accessors.</param>
+        public MultiLingualBot(MultiLingualBotAccessors accessors)
+        {
+            _accessors = accessors;
+        }
+
+        /// <summary>
+        /// Run every turn of the conversation. Handles orchestration of messages.
+        /// </summary>
+        /// <param name="turnContext">Bot Turn Context.</param>
+        /// <param name="cancellationToken">Task CancellationToken.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        {
+            if (turnContext.Activity.Type == ActivityTypes.Message)
+            {
+                string userLanguage = await _accessors.LanguagePreference.GetAsync(turnContext, () => TranslationSettings.DefaultLanguage) ?? TranslationSettings.DefaultLanguage;
+
+                bool translate = userLanguage != TranslationSettings.DefaultLanguage;
+
+                if (IsLanguageChangeRequested(turnContext.Activity.Text))
+                {
+                    // If the user requested a language change through the suggested actions with values "es" or "en",
+                    // simply change the user's language preference in the user state.
+                    // The translation middleware will catch this setting and translate both ways to the user's
+                    // selected language.
+                    // If Spanish was selected by the user, the reply below will actually be shown in spanish to the user.
+                    await _accessors.LanguagePreference.SetAsync(turnContext, turnContext.Activity.Text);
+                    var reply = turnContext.Activity.CreateReply($"Your current language code is: {turnContext.Activity.Text}");
+
+                    await turnContext.SendActivityAsync(reply, cancellationToken);
+
+                    // Save the user profile updates into the user state.
+                    await _accessors.UserState.SaveChangesAsync(turnContext, false, cancellationToken);
+                }
+                else
+                {
+                    // Show the user the possible options for language. If the user chooses a different language
+                    // than the default, then the translation middleware will pick it up from the user state and
+                    // translate messages both ways, i.e. user to bot and bot to user.
+                    var reply = turnContext.Activity.CreateReply("Choose your language:");
+                    reply.SuggestedActions = new SuggestedActions()
+                    {
+                        Actions = new List<CardAction>()
+                        {
+                            new CardAction() { Title = "Español", Type = ActionTypes.PostBack, Value = Spanish },
+                            new CardAction() { Title = "English", Type = ActionTypes.PostBack, Value = English },
+                        },
+                    };
+
+                    await turnContext.SendActivityAsync(reply);
+                }
+            }
+        }
+
+        private static bool IsLanguageChangeRequested(string utterance)
+        {
+            if (string.IsNullOrEmpty(utterance))
+            {
+                return false;
+            }
+
+            utterance = utterance.ToLower().Trim();
+            return utterance == Spanish || utterance == English;
+        }
+    }
+}

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/MultiLingualBot.cs
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/MultiLingualBot.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,7 +31,7 @@ namespace MultiLingualBot
         /// <param name="accessors">Bot State Accessors.</param>
         public MultiLingualBot(MultiLingualBotAccessors accessors)
         {
-            _accessors = accessors;
+            _accessors = accessors ?? throw new ArgumentNullException(nameof(accessors));
         }
 
         /// <summary>
@@ -41,6 +42,11 @@ namespace MultiLingualBot
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken)
         {
+            if (turnContext == null)
+            {
+                throw new ArgumentNullException(nameof(turnContext));
+            }
+
             if (turnContext.Activity.Type == ActivityTypes.Message)
             {
                 string userLanguage = await _accessors.LanguagePreference.GetAsync(turnContext, () => TranslationSettings.DefaultLanguage) ?? TranslationSettings.DefaultLanguage;

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/MultiLingualBot.csproj
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/MultiLingualBot.csproj
@@ -1,0 +1,111 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <CodeAnalysisRuleSet>MultiLingualBot.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="CogSvcModels\**" />
+    <Compile Remove="DeploymentScripts\data\**" />
+    <Compile Remove="DeploymentScripts\Json\**" />
+    <Compile Remove="MainDialog\**" />
+    <Content Remove="CogSvcModels\**" />
+    <Content Remove="DeploymentScripts\data\**" />
+    <Content Remove="DeploymentScripts\Json\**" />
+    <Content Remove="MainDialog\**" />
+    <EmbeddedResource Remove="CogSvcModels\**" />
+    <EmbeddedResource Remove="DeploymentScripts\data\**" />
+    <EmbeddedResource Remove="DeploymentScripts\Json\**" />
+    <EmbeddedResource Remove="MainDialog\**" />
+    <None Remove="CogSvcModels\**" />
+    <None Remove="DeploymentScripts\data\**" />
+    <None Remove="DeploymentScripts\Json\**" />
+    <None Remove="MainDialog\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Dialogs\TestCancelDialog.cs" />
+    <Compile Remove="Dialogs\TestDialog.cs" />
+    <Compile Remove="Translation\Translator.cs" />
+    <Compile Remove="Translation\TranslatorMiddleware.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
+    <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="0.12.1-preview" />
+    <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.0.0.38762" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.0.0.38762" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.0.0.38762" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.0.0.38762" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.0.0.38762" />
+    <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.0.0.38762" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.0.0.38762" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.0.0.38762" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.0.0.38762" />
+    <PackageReference Include="Microsoft.Graph" Version="1.10.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="Dialogs\Cancel\Resources\CancelStrings.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>CancelStrings.resx</DependentUpon>
+    </Compile>
+    <Compile Update="Dialogs\Escalate\Resources\EscalateStrings.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>EscalateStrings.resx</DependentUpon>
+    </Compile>
+    <Compile Update="Dialogs\Main\Resources\MainStrings.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>MainStrings.resx</DependentUpon>
+    </Compile>
+    <Compile Update="Dialogs\Onboarding\Resources\OnboardingStrings.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>OnboardingStrings.resx</DependentUpon>
+    </Compile>
+    <Compile Update="Dialogs\SignIn\Resources\SignInStrings.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>SignInStrings.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Dialogs\Cancel\Resources\CancelStrings.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>CancelStrings.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Dialogs\Escalate\Resources\EscalateStrings.resx">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>EscalateStrings.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Dialogs\Main\Resources\MainStrings.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>MainStrings.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Dialogs\Onboarding\Resources\OnboardingStrings.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>OnboardingStrings.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Dialogs\SignIn\Resources\SignInStrings.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>SignInStrings.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <WCFMetadata Include="Connected Services" />
+  </ItemGroup>
+
+</Project>

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/MultiLingualBot.csproj
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/MultiLingualBot.csproj
@@ -28,58 +28,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Update="Dialogs\Cancel\Resources\CancelStrings.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>CancelStrings.resx</DependentUpon>
-    </Compile>
-    <Compile Update="Dialogs\Escalate\Resources\EscalateStrings.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>EscalateStrings.resx</DependentUpon>
-    </Compile>
-    <Compile Update="Dialogs\Main\Resources\MainStrings.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>MainStrings.resx</DependentUpon>
-    </Compile>
-    <Compile Update="Dialogs\Onboarding\Resources\OnboardingStrings.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>OnboardingStrings.resx</DependentUpon>
-    </Compile>
-    <Compile Update="Dialogs\SignIn\Resources\SignInStrings.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>SignInStrings.resx</DependentUpon>
-    </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Update="Dialogs\Cancel\Resources\CancelStrings.resx">
-      <Generator>PublicResXFileCodeGenerator</Generator>
-      <LastGenOutput>CancelStrings.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <EmbeddedResource Update="Dialogs\Escalate\Resources\EscalateStrings.resx">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>EscalateStrings.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <EmbeddedResource Update="Dialogs\Main\Resources\MainStrings.resx">
-      <Generator>PublicResXFileCodeGenerator</Generator>
-      <LastGenOutput>MainStrings.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <EmbeddedResource Update="Dialogs\Onboarding\Resources\OnboardingStrings.resx">
-      <Generator>PublicResXFileCodeGenerator</Generator>
-      <LastGenOutput>OnboardingStrings.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <EmbeddedResource Update="Dialogs\SignIn\Resources\SignInStrings.resx">
-      <Generator>PublicResXFileCodeGenerator</Generator>
-      <LastGenOutput>SignInStrings.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-  </ItemGroup>
-
-  <ItemGroup>
     <WCFMetadata Include="Connected Services" />
   </ItemGroup>
 

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/MultiLingualBot.csproj
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/MultiLingualBot.csproj
@@ -6,32 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="CogSvcModels\**" />
-    <Compile Remove="DeploymentScripts\data\**" />
-    <Compile Remove="DeploymentScripts\Json\**" />
-    <Compile Remove="MainDialog\**" />
-    <Content Remove="CogSvcModels\**" />
-    <Content Remove="DeploymentScripts\data\**" />
-    <Content Remove="DeploymentScripts\Json\**" />
-    <Content Remove="MainDialog\**" />
-    <EmbeddedResource Remove="CogSvcModels\**" />
-    <EmbeddedResource Remove="DeploymentScripts\data\**" />
-    <EmbeddedResource Remove="DeploymentScripts\Json\**" />
-    <EmbeddedResource Remove="MainDialog\**" />
-    <None Remove="CogSvcModels\**" />
-    <None Remove="DeploymentScripts\data\**" />
-    <None Remove="DeploymentScripts\Json\**" />
-    <None Remove="MainDialog\**" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Remove="Dialogs\TestCancelDialog.cs" />
-    <Compile Remove="Dialogs\TestDialog.cs" />
-    <Compile Remove="Translation\Translator.cs" />
-    <Compile Remove="Translation\TranslatorMiddleware.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="0.12.1-preview" />
@@ -46,6 +20,7 @@
     <PackageReference Include="Microsoft.Bot.Connector" Version="4.0.0.38762" />
     <PackageReference Include="Microsoft.Bot.Schema" Version="4.0.0.38762" />
     <PackageReference Include="Microsoft.Graph" Version="1.10.0" />
+    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/MultiLingualBot.ruleset
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/MultiLingualBot.ruleset
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Microsoft Managed Recommended Rules" Description="These rules focus on the most critical problems in your code, including potential security holes, application crashes, and other important logic and design errors. It is recommended to include this rule set in any custom rule set you create for your projects." ToolsVersion="15.0">
+  <Localization ResourceAssembly="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.dll" ResourceBaseName="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.Localized">
+    <Name Resource="MinimumRecommendedRules_Name" />
+    <Description Resource="MinimumRecommendedRules_Description" />
+  </Localization>
+  <Rules AnalyzerId="AsyncUsageAnalyzers" RuleNamespace="AsyncUsageAnalyzers">
+    <Rule Id="AvoidAsyncVoid" Action="Warning" />
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1011" Action="None" />
+    <Rule Id="SA1101" Action="None" />
+    <Rule Id="SA1129" Action="None" />
+    <Rule Id="SA1200" Action="None" />
+    <Rule Id="SA1305" Action="Warning" />
+    <Rule Id="SA1309" Action="None" />
+    <Rule Id="SA1412" Action="Warning" />
+    <Rule Id="SA1600" Action="None" />
+    <Rule Id="SA1609" Action="Warning" />
+    <Rule Id="SA1633" Action="None" />
+  </Rules>
+</RuleSet>

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/MultiLingualBotAccessors.cs
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/MultiLingualBotAccessors.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+
+namespace MultiLingualBot
+{
+    /// <summary>
+    /// The accessors we will be using in the bot logic. Having a class like this just allows them to be easily
+    /// handed to the IBot instance through the dependency injection.
+    /// </summary>
+    public class MultiLingualBotAccessors
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BotAccessors"/> class.
+        /// Contains the <see cref="ConversationState"/> and associated <see cref="IStatePropertyAccessor{T}"/>.
+        /// </summary>
+        /// <param name="conversationState">The state object that stores the dialog state.</param>
+        /// <param name="userState">The state object that stores the user state.</param>
+        public MultiLingualBotAccessors(ConversationState conversationState, UserState userState)
+        {
+            ConversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
+            UserState = userState ?? throw new ArgumentNullException(nameof(userState));
+        }
+
+        public IStatePropertyAccessor<DialogState> ConversationDialogState { get; set; }
+
+        /// <summary>
+        /// User language preference to drive translation.
+        /// </summary>
+        public IStatePropertyAccessor<string> LanguagePreference { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="ConversationState"/> object for the conversation.
+        /// </summary>
+        /// <value>The <see cref="ConversationState"/> object.</value>
+        public ConversationState ConversationState { get; }
+
+        /// <summary>
+        /// Gets the <see cref="UserState"/> object for the conversation.
+        /// </summary>
+        /// <value>The <see cref="UserState"/> object.</value>
+        public UserState UserState { get; }
+    }
+}

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/MultiLingualBotState.cs
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/MultiLingualBotState.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Builder.Dialogs;
+
+namespace MultiLingualBot
+{
+    /// <summary>
+    /// Custom state model can be defined here.
+    /// </summary>
+    public class MultiLingualBotState : DialogState
+    {
+    }
+}

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/Program.cs
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/Program.cs
@@ -6,25 +6,13 @@ using Microsoft.AspNetCore.Hosting;
 
 namespace MultiLingualBot
 {
-    /// <summary>
-    /// Entry point for Bot application.
-    /// </summary>
     public class Program
     {
-        /// <summary>
-        /// Entry point for Bot application.
-        /// </summary>
-        /// <param name="args">Arguments to bot application.</param>
         public static void Main(string[] args)
         {
             BuildWebHost(args).Run();
         }
 
-        /// <summary>
-        /// Builds a web host to expose the bot application.
-        /// </summary>
-        /// <param name="args">Arguments to the web host.</param>
-        /// <returns>Built <see cref="IWebHost" /> to expose the bot application.</returns>
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseApplicationInsights()

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/Program.cs
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/Program.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+namespace MultiLingualBot
+{
+    /// <summary>
+    /// Entry point for Bot application.
+    /// </summary>
+    public class Program
+    {
+        /// <summary>
+        /// Entry point for Bot application.
+        /// </summary>
+        /// <param name="args">Arguments to bot application.</param>
+        public static void Main(string[] args)
+        {
+            BuildWebHost(args).Run();
+        }
+
+        /// <summary>
+        /// Builds a web host to expose the bot application.
+        /// </summary>
+        /// <param name="args">Arguments to the web host.</param>
+        /// <returns>Built <see cref="IWebHost" /> to expose the bot application.</returns>
+        public static IWebHost BuildWebHost(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseApplicationInsights()
+                .UseStartup<Startup>()
+                .Build();
+    }
+}

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/Startup.cs
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/Startup.cs
@@ -81,8 +81,17 @@ namespace MultiLingualBot
                 var userState = new UserState(dataStore);
                 options.State.Add(userState);
 
+                // Translation key from settings
+                var translatorKey = Configuration.GetValue<string>("translatorKey");
+
+                if (string.IsNullOrEmpty(translatorKey))
+                {
+                    throw new InvalidOperationException("Microsoft Text Translation API key is missing. Please add your translation key to the 'translatorKey' setting.");
+                }
+
                 // Translation middleware setup
-                var translator = new MicrosoftTranslator(Configuration.GetValue<string>("translatorKey"));
+                var translator = new MicrosoftTranslator(translatorKey);
+
                 var translationMiddleware = new TranslationMiddleware(translator, userState.CreateProperty<string>("LanguagePreference"));
                 options.Middleware.Add(translationMiddleware);
             });

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/Startup.cs
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/Startup.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.AI.Luis;
+using Microsoft.Bot.Builder.BotFramework;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Integration;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using MultiLingualBot.Translation;
+using System;
+using System.Linq;
+
+namespace MultiLingualBot
+{
+    /// <summary>
+    /// The Startup class configures services and the app's request pipeline.
+    /// </summary>
+    public class Startup
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Startup"/> class.
+        /// This method gets called by the runtime. Use this method to add services to the container.
+        /// For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940.
+        /// </summary>
+        /// <param name="env">Provides information about the web hosting environment an application is running in.</param>
+        /// <seealso cref="https://docs.microsoft.com/en-us/aspnet/core/fundamentals/startup?view=aspnetcore-2.1"/>
+        public Startup(IHostingEnvironment env)
+        {
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddEnvironmentVariables();
+
+            this.Configuration = builder.Build();
+        }
+
+        /// <summary>
+        /// Gets the configuration that represents a set of key/value application configuration properties.
+        /// </summary>
+        /// <value>
+        /// The <see cref="IConfiguration"/> that represents a set of key/value application configuration properties.
+        /// </value>
+        public IConfiguration Configuration { get; }
+
+        /// <summary>
+        /// This method gets called by the runtime. Use this method to add services to the container.
+        /// </summary>
+        /// <param name="services">Specifies the contract for a <see cref="IServiceCollection"/> of service descriptors.</param>
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // Loads .bot configuration file and adds a singleton that your Bot can access through dependency injection.
+            var botConfig = BotConfiguration.LoadAsync(@".\MultiLingualBot.bot").GetAwaiter().GetResult();
+            services.AddSingleton(sp => botConfig);
+
+            services.AddBot<MultiLingualBot>(options =>
+            {
+                // Memory Storage is for local bot debugging only. When the bot
+                // is restarted, anything stored in memory will be gone.
+                IStorage dataStore = new MemoryStorage();
+
+                // For production bots use the Azure Blob or
+                // Azure CosmosDB storage providers, as seen below. To the Azure
+                // based storage providers, add the Microsoft.Bot.Builder.Azure
+                // Nuget package to your solution. That package is found at:
+                // https://www.nuget.org/packages/Microsoft.Bot.Builder.Azure/
+                // Uncomment this line to use Azure Blob Storage
+                // IStorage dataStore = new Microsoft.Bot.Builder.Azure.AzureBlobStorage("AzureBlobConnectionString", "containerName");
+
+                // Create and add conversation state.
+                var convoState = new ConversationState(dataStore);
+                options.State.Add(convoState);
+
+                // Create and add user state.
+                var userState = new UserState(dataStore);
+                options.State.Add(userState);
+
+                // Translation middleware setup
+                var translator = new MicrosoftTranslator(Configuration.GetValue<string>("translatorKey"));
+                var translationMiddleware = new TranslationMiddleware(translator, userState.CreateProperty<string>("LanguagePreference"));
+                options.Middleware.Add(translationMiddleware);
+            });
+
+            services.AddSingleton(sp =>
+            {
+                // We need to grab the conversationState we added on the options in the previous step
+                var options = sp.GetRequiredService<IOptions<BotFrameworkOptions>>().Value;
+                if (options == null)
+                {
+                    throw new InvalidOperationException("BotFrameworkOptions must be configured prior to setting up the State Accessors");
+                }
+
+                var conversationState = options.State.OfType<ConversationState>().FirstOrDefault();
+                if (conversationState == null)
+                {
+                    throw new InvalidOperationException("ConversationState must be defined and added before adding conversation-scoped state accessors.");
+                }
+
+                var userState = options.State.OfType<UserState>().FirstOrDefault();
+                if (userState == null)
+                {
+                    throw new InvalidOperationException("UserState must be defined and added before adding user-scoped state accessors.");
+                }
+
+                // The dialogs will need a state store accessor. Creating it here once (on-demand) allows the dependency injection
+                // to hand it to our IBot class that is create per-request.
+                var accessors = new MultiLingualBotAccessors(conversationState, userState)
+                {
+                    ConversationDialogState = conversationState.CreateProperty<DialogState>("DialogState"),
+                    LanguagePreference = userState.CreateProperty<string>("LanguagePreference"),
+                };
+
+                return accessors;
+            });
+        }
+
+        /// <summary>
+        /// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        /// </summary>
+        /// <param name="app">Application Builder.</param>
+        /// <param name="env">Hosting Environment.</param>
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseDefaultFiles()
+                .UseStaticFiles()
+                .UseBotFramework();
+        }
+    }
+}

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/Translation/MicrosoftTranslator.cs
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/Translation/MicrosoftTranslator.cs
@@ -8,36 +8,33 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MultiLingualBot.Translation
 {
-    public interface ITranslator
-    {
-        Task<string> TranslateAsync(string text, string targetLocale);
-    }
-
-    public class MicrosoftTranslator : ITranslator
+    public class MicrosoftTranslator
     {
         private const string host = "https://api.cognitive.microsofttranslator.com";
         private const string path = "/translate?api-version=3.0";
         private const string uriParams = "&to=";
 
-        private readonly string _key = "ENTER KEY HERE";
+        private readonly string _key;
+
+        private static HttpClient _client = new HttpClient();
 
         public MicrosoftTranslator(string key)
         {
-            _key = key;
+            _key = key ?? throw new ArgumentNullException(nameof(key));
         }
 
-        public async Task<string> TranslateAsync(string text, string targetLocale)
+        public async Task<string> TranslateAsync(string text, string targetLocale, CancellationToken cancellationToken = default(CancellationToken))
         {
             // From Cognitive Services translation documentation:
             // https://docs.microsoft.com/en-us/azure/cognitive-services/translator/quickstart-csharp-translate
             var body = new object[] { new { Text = text } };
             var requestBody = JsonConvert.SerializeObject(body);
 
-            using (var client = new HttpClient())
             using (var request = new HttpRequestMessage())
             {
                 var uri = host + path + uriParams + targetLocale;
@@ -46,7 +43,7 @@ namespace MultiLingualBot.Translation
                 request.Content = new StringContent(requestBody, Encoding.UTF8, "application/json");
                 request.Headers.Add("Ocp-Apim-Subscription-Key", _key);
 
-                var response = await client.SendAsync(request);
+                var response = await _client.SendAsync(request, cancellationToken);
                 var responseBody = await response.Content.ReadAsStringAsync();
                 var result = JsonConvert.DeserializeObject<TranslatorResponse[]>(responseBody);
 

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/Translation/MicrosoftTranslator.cs
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/Translation/MicrosoftTranslator.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using MultiLingualBot.Translation.Model;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MultiLingualBot.Translation
+{
+    public interface ITranslator
+    {
+        Task<string> TranslateAsync(string text, string targetLocale);
+    }
+
+    public class MicrosoftTranslator : ITranslator
+    {
+        private const string host = "https://api.cognitive.microsofttranslator.com";
+        private const string path = "/translate?api-version=3.0";
+        private const string uriParams = "&to=";
+
+        private readonly string _key = "ENTER KEY HERE";
+
+        public MicrosoftTranslator(string key)
+        {
+            _key = key;
+        }
+
+        public async Task<string> TranslateAsync(string text, string targetLocale)
+        {
+            // From Cognitive Services translation documentation:
+            // https://docs.microsoft.com/en-us/azure/cognitive-services/translator/quickstart-csharp-translate
+            var body = new object[] { new { Text = text } };
+            var requestBody = JsonConvert.SerializeObject(body);
+
+            using (var client = new HttpClient())
+            using (var request = new HttpRequestMessage())
+            {
+                var uri = host + path + uriParams + targetLocale;
+                request.Method = HttpMethod.Post;
+                request.RequestUri = new Uri(uri);
+                request.Content = new StringContent(requestBody, Encoding.UTF8, "application/json");
+                request.Headers.Add("Ocp-Apim-Subscription-Key", _key);
+
+                var response = await client.SendAsync(request);
+                var responseBody = await response.Content.ReadAsStringAsync();
+                var result = JsonConvert.DeserializeObject<TranslatorResponse[]>(responseBody);
+
+                return result?.FirstOrDefault()?.Translations?.FirstOrDefault()?.Text;
+            }
+        }
+    }
+}

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/Translation/Model/TranslatorResponse.cs
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/Translation/Model/TranslatorResponse.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace MultiLingualBot.Translation.Model
+{
+    /// <summary>
+    /// Array of translated results from Translator API v3.
+    /// </summary>
+    internal class TranslatorResponse
+    {
+        [JsonProperty("translations")]
+        public IEnumerable<TranslatorResult> Translations { get; set; }
+    }
+}

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/Translation/Model/TranslatorResult.cs
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/Translation/Model/TranslatorResult.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+
+namespace MultiLingualBot.Translation.Model
+{
+    /// <summary>
+    /// Translation result from Translator API v3.
+    /// </summary>
+    internal class TranslatorResult
+    {
+        [JsonProperty("text")]
+        public string Text { get; set; }
+
+        [JsonProperty("to")]
+        public string To { get; set; }
+    }
+}

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/Translation/TranslationMiddleware.cs
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/Translation/TranslationMiddleware.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MultiLingualBot.Translation
+{
+    /// <summary>
+    /// Middleware for translating text between the user and bot.
+    /// Uses the Microsoft Translator Text API.
+    /// </summary>
+    public class TranslationMiddleware : IMiddleware
+    {
+        private readonly ITranslator _translator;
+        private readonly IStatePropertyAccessor<string> _languageStateProperty;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TranslationMiddleware"/> class.
+        /// </summary>
+        /// <param name="translator">Translator implementation to be used for text translation.</param>
+        /// <param name="languageStateProperty">State property for current language.</param>
+        public TranslationMiddleware(ITranslator translator, IStatePropertyAccessor<string> languageStateProperty)
+        {
+            _translator = translator;
+            _languageStateProperty = languageStateProperty;
+        }
+
+        /// <summary>
+        /// Processess an incoming activity.
+        /// </summary>
+        /// <param name="context">Context object containing information for a single turn of conversation with a user.</param>
+        /// <param name="next">The delegate to call to continue the bot middleware pipeline.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var translate = await ShouldTranslateAsync(turnContext);
+
+            if (translate)
+            {
+                if (turnContext.Activity.Type == ActivityTypes.Message)
+                {
+                    turnContext.Activity.Text = await _translator.TranslateAsync(turnContext.Activity.Text, TranslationSettings.DefaultLanguage);
+                }
+            }
+
+            turnContext.OnSendActivities(async (newContext, activities, nextSend) =>
+            {
+                string userLanguage = await _languageStateProperty.GetAsync(turnContext, () => TranslationSettings.DefaultLanguage) ?? TranslationSettings.DefaultLanguage;
+                bool shouldTranslate = userLanguage != TranslationSettings.DefaultLanguage;
+
+                // Translate messages sent to the user to user language
+                if (shouldTranslate)
+                {
+                    List<Task> tasks = new List<Task>();
+                    foreach (Activity currentActivity in activities.Where(a => a.Type == ActivityTypes.Message))
+                    {
+                        tasks.Add(TranslateMessageActivityAsync(currentActivity.AsMessageActivity(), userLanguage));
+                    }
+
+                    if (tasks.Any())
+                    {
+                        await Task.WhenAll(tasks).ConfigureAwait(false);
+                    }
+                }
+
+                return await nextSend();
+            });
+
+            turnContext.OnUpdateActivity(async (newContext, activity, nextUpdate) =>
+            {
+                string userLanguage = await _languageStateProperty.GetAsync(turnContext, () => TranslationSettings.DefaultLanguage) ?? TranslationSettings.DefaultLanguage;
+                bool shouldTranslate = userLanguage != TranslationSettings.DefaultLanguage;
+
+                // Translate messages sent to the user to user language
+                if (activity.Type == ActivityTypes.Message)
+                {
+                    if (shouldTranslate)
+                    {
+                        await TranslateMessageActivityAsync(activity.AsMessageActivity(), userLanguage);
+                    }
+                }
+
+                return await nextUpdate();
+            });
+
+            await next(cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task TranslateMessageActivityAsync(IMessageActivity activity, string targetLocale)
+        {
+            if (activity.Type == ActivityTypes.Message)
+            {
+                activity.Text = await _translator.TranslateAsync(activity.Text, targetLocale);
+            }
+        }
+
+        private async Task<bool> ShouldTranslateAsync(ITurnContext turnContext)
+        {
+            string userLanguage = await _languageStateProperty.GetAsync(turnContext, () => TranslationSettings.DefaultLanguage) ?? TranslationSettings.DefaultLanguage;
+            return userLanguage != TranslationSettings.DefaultLanguage;
+        }
+    }
+}

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/Translation/TranslationSettings.cs
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/Translation/TranslationSettings.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace MultiLingualBot.Translation
+{
+    /// <summary>
+    /// General translation settings and constants.
+    /// </summary>
+    public static class TranslationSettings
+    {
+        public const string DefaultLanguage = "en";
+    }
+}

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/appsettings.json
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/appsettings.json
@@ -1,0 +1,3 @@
+﻿{
+  "translatorKey":  "<Your translation key here>"
+}

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/readme.md
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/readme.md
@@ -1,6 +1,4 @@
-﻿This sample shows how to create complex conversation flows such as interruptions and cancellations, to build user-friendly, effective bots.
-
-# Concepts introduced in this sample
+﻿# Concepts introduced in this sample
 
 Translation Middleware: We create a translation middleware than can translate text from bot to user and from user to bot, allowing the creation of multi-lingual bots. 
 The middleware is driven by user state. This means that users can specify their language preference, and the middleware automatically will intercept messages back and forth and present them to the user in their preferred language.
@@ -31,13 +29,6 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 To consume the Microsoft Translator Text API, first obtain a key following the instructions in the [Microsoft Translator Text API documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/translator-text-how-to-signup). 
 Paste the key in the ```translationKey``` placeholder within the appsettings.json file.
 
-## Install BotBuilder tools
-
-- In a terminal, navigate to the samples folder (`BotBuilder-Samples\csharp_dotnetcore\18.Multi-Lingual-Bot`) 
-
-    ```bash
-    cd BotBuilder-Samples\csharp_dotnetcore\18.Multi-Lingual-Bot
-    ```
 
 ## Visual Studio
 - Navigate to the samples folder (`BotBuilder-Samples\csharp_dotnetcore\18.Multi-Lingual-Bot`) and open MessageRoutingBot.csproj in Visual Studio 
@@ -53,12 +44,12 @@ Paste the key in the ```translationKey``` placeholder within the appsettings.jso
 
 - Install the Bot Framework Emulator from [here](https://aka.ms/botframeworkemulator).
 
-### Connect to bot using Bot Framework Emulator **V4**
+### Connect to bot using Bot Framework Emulator V4
 - Launch Bot Framework Emulator
 - File -> Open bot and navigate to `BotBuilder-Samples\csharp_dotnetcore\18.Multi-Lingual-Bot` folder
 - Select MessageRouting.bot file
 
 # Further reading
 
-- [Azure Bot Service Introduction](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
+- [Azure Bot Service](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 - [Microsoft Translator Text API](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/)

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/readme.md
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/readme.md
@@ -1,0 +1,64 @@
+﻿This sample shows how to create complex conversation flows such as interruptions and cancellations, to build user-friendly, effective bots.
+
+# Concepts introduced in this sample
+
+Translation Middleware: We create a translation middleware than can translate text from bot to user and from user to bot, allowing the creation of multi-lingual bots. 
+The middleware is driven by user state. This means that users can specify their language preference, and the middleware automatically will intercept messages back and forth and present them to the user in their preferred language.
+Users can change their language preference anytime, and since this gets written to the user state, the middleware will read this state and instantly modify its behavior to honor the newly selected preferred langugage.
+
+The [Microsoft Translator Text API](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/), Microsoft Translator Text API is a cloud-based machine translation service. With this API you can translate text in near real-time from any app or service through a simple REST API call. 
+The API uses the most modern neural machine translation technology, as well as offering statistical machine translation technology.
+
+## Overview
+
+In this sample, we create a simple bot that prompts user for their preferred language, and stores the user's preferred language selection in the user state. 
+We also create a middleware that reads user preferred language, and if it is different from the default language (English), calls the Microsoft Translator Text API to translate to and from the user's preferred langugage.
+This means that the bot always receives utterances in English, while users writes and gets responses in their selected language.
+
+Note that this is a very simple example, but shows very powerful principles. 
+The translation middleware allows us to intercept and traslate messages, and the user preferences stored in the user state at the application level allows us to influence the middleware behavior.
+A more ellaborated next step would be to use the Microsoft Translator Text API to detect language, and if the user changes language, automatically switch to that language, without explicitly prompting but running detection on every step.
+
+# To try this sample
+
+- Clone the samples repository
+```bash
+git clone https://github.com/Microsoft/botbuilder-samples.git
+```
+
+## Microsoft Translator Text API
+
+To consume the Microsoft Translator Text API, first obtain a key following the instructions in the [Microsoft Translator Text API documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/translator-text-how-to-signup). 
+Paste the key in the ```translationKey``` placeholder within the appsettings.json file.
+
+## Install BotBuilder tools
+
+- In a terminal, navigate to the samples folder (`BotBuilder-Samples\csharp_dotnetcore\18.Multi-Lingual-Bot`) 
+
+    ```bash
+    cd BotBuilder-Samples\csharp_dotnetcore\18.Multi-Lingual-Bot
+    ```
+
+## Visual Studio
+- Navigate to the samples folder (`BotBuilder-Samples\csharp_dotnetcore\18.Multi-Lingual-Bot`) and open MessageRoutingBot.csproj in Visual Studio 
+- Hit F5
+
+## Visual Studio Code
+- Open `BotBuilder-Samples\csharp_dotnetcore\18.Multi-Lingual-Bot` sample folder.
+- Bring up a terminal, navigate to BotBuilder-Samples\18.Multi-Lingual-Bot folder
+- type 'dotnet run'
+
+## Testing the bot using Bot Framework Emulator
+[Microsoft Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
+
+- Install the Bot Framework Emulator from [here](https://aka.ms/botframeworkemulator).
+
+### Connect to bot using Bot Framework Emulator **V4**
+- Launch Bot Framework Emulator
+- File -> Open bot and navigate to `BotBuilder-Samples\csharp_dotnetcore\18.Multi-Lingual-Bot` folder
+- Select MessageRouting.bot file
+
+# Further reading
+
+- [Azure Bot Service Introduction](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
+- [Microsoft Translator Text API](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/)

--- a/csharp_dotnetcore/18.Multi-Lingual-Bot/wwwroot/default.htm
+++ b/csharp_dotnetcore/18.Multi-Lingual-Bot/wwwroot/default.htm
@@ -1,0 +1,25 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <title></title>
+    <meta charset="utf-8" />
+
+</head>
+<body style="font-family:'Segoe UI'">
+    <h1>MultiLingual bot sample</h1>
+    <p>Describe your bot here and your terms of use etc.</p>
+    <p>To debug you bot using the Bot Framework Emulator, paste this URL into the Emulator window:</p>
+    <div style="padding-left: 50px;" id="botBaseUrl"></div>
+    <p>Visit <a href="https://www.botframework.com/">Bot Framework</a> to register your bot. When you register, remember to set the endpoint to:</p>
+    <div style="padding-left: 50px;">
+        https://<strong>{your domain name}</strong>/api/messages
+    </div>
+    <script>
+        var urlDiv = document.getElementById("botBaseUrl");
+        var aTag = document.createElement('a');
+        aTag.setAttribute('href', location.protocol + "//" + location.host + "/api/messages");
+        aTag.innerHTML = location.protocol + "//" + location.host + "/api/messages";
+        urlDiv.appendChild(aTag);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Instead of the complex translation bots that were around, I chose to write an extremely simplistic multilingual bot. The goal of this sample is to showcase middleware as a way of automatically translating messages from adn to the bot, so the users interacts in their preferred language but the bot is written in english. Here we show the user suggested actions to choose their language, and then we switch to their language of choice for some trivial conversation. This also shows how to save user preferences at the application level, and ahve the middleware behave differently (by translating to a certain language) depending on user state settings (the language preference). 