### PR TITLE
Echobot Fixes

### DIFF
--- a/csharp_dotnetcore/2.EchoBot-With-Counter/BotConfiguration.bot
+++ b/csharp_dotnetcore/2.EchoBot-With-Counter/BotConfiguration.bot
@@ -5,7 +5,7 @@
     "services": [
       {
         "id": "http://localhost:3978/api/messages",
-        "name": "EchoBotWithCounter",
+        "name": "development",
         "type": "endpoint",
         "appId": "",
         "appPassword": "",

--- a/csharp_dotnetcore/2.EchoBot-With-Counter/EchoWithCounterBot.cs
+++ b/csharp_dotnetcore/2.EchoBot-With-Counter/EchoWithCounterBot.cs
@@ -66,6 +66,9 @@ namespace Microsoft.BotBuilderSamples
                 // Bump the turn count for this conversation.
                 state.TurnCount++;
 
+                // Set the property using the accessor
+                await _accessors.CounterState.SetAsync(turnContext, state);
+
                 // Save the new turn count into the conversation state.
                 await _accessors.ConversationState.SaveChangesAsync(turnContext);
 

--- a/csharp_dotnetcore/2.EchoBot-With-Counter/Program.cs
+++ b/csharp_dotnetcore/2.EchoBot-With-Counter/Program.cs
@@ -31,7 +31,7 @@ namespace Microsoft.BotBuilderSamples
                 // Logging Options.
                 // Consider using Application Insights for your logging and metrics needs.
                 // https://azure.microsoft.com/en-us/services/application-insights/
-                //.UseApplicationInsights()
+                // .UseApplicationInsights()
                 .UseStartup<Startup>()
                 .Build();
     }

--- a/csharp_dotnetcore/2.EchoBot-With-Counter/Startup.cs
+++ b/csharp_dotnetcore/2.EchoBot-With-Counter/Startup.cs
@@ -56,7 +56,7 @@ namespace Microsoft.BotBuilderSamples
             services.AddBot<EchoWithCounterBot>(options =>
             {
                 // Load the connected services from .bot file.
-                var botConfig = BotConfiguration.Load(@".\EchoBotWithCounter.bot");
+                var botConfig = BotConfiguration.Load(@".\BotConfiguration.bot");
                 var service = botConfig.Services.FirstOrDefault(s => s.Type == "endpoint");
                 var endpointService = service as EndpointService;
                 if (endpointService == null)

--- a/csharp_webapi/2.EchoBot-With-Counter/EchoBot.csproj
+++ b/csharp_webapi/2.EchoBot-With-Counter/EchoBot.csproj
@@ -54,57 +54,23 @@
     <Reference Include="CommonServiceLocator, Version=2.0.3.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
       <HintPath>packages\Unity.5.8.6\lib\net46\CommonServiceLocator.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AI.DependencyCollector, Version=2.7.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.ApplicationInsights.DependencyCollector.2.7.2\lib\net45\Microsoft.AI.DependencyCollector.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AI.PerfCounterCollector, Version=2.7.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.7.2\lib\net45\Microsoft.AI.PerfCounterCollector.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.7.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.7.2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AI.Web, Version=2.7.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.ApplicationInsights.Web.2.7.2\lib\net45\Microsoft.AI.Web.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AI.WindowsServer, Version=2.7.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.ApplicationInsights.WindowsServer.2.7.2\lib\net45\Microsoft.AI.WindowsServer.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.7.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.ApplicationInsights.2.7.2\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ApplicationInsights.TraceListener, Version=2.7.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.ApplicationInsights.TraceListener.2.7.2\lib\net45\Microsoft.ApplicationInsights.TraceListener.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNet.TelemetryCorrelation.1.0.3\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Azure.CognitiveServices.Language.LUIS, Version=0.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime.0.9.0-preview\lib\net452\Microsoft.Azure.CognitiveServices.Language.LUIS.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring.2.0.0\lib\net452\Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Builder, Version=4.0.0.39458, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Bot.Builder.4.0.0.39458\lib\netstandard2.0\Microsoft.Bot.Builder.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bot.Builder, Version=4.0.0.38905, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Bot.Builder.4.0.0.38905\lib\netstandard2.0\Microsoft.Bot.Builder.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Bot.Builder.Integration.AspNet.WebApi, Version=4.0.0.39458, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Bot.Builder.Integration.AspNet.WebApi.4.0.0.39458\lib\net461\Microsoft.Bot.Builder.Integration.AspNet.WebApi.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bot.Builder.Integration.AspNet.WebApi, Version=4.0.0.38905, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Bot.Builder.Integration.AspNet.WebApi.4.0.0.38905\lib\net461\Microsoft.Bot.Builder.Integration.AspNet.WebApi.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Configuration, Version=4.0.0.39458, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Bot.Configuration.4.0.0.39458\lib\netstandard2.0\Microsoft.Bot.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bot.Configuration, Version=4.0.0.38905, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Bot.Configuration.4.0.0.38905\lib\netstandard2.0\Microsoft.Bot.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Connector, Version=4.0.0.39458, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Bot.Connector.4.0.0.39458\lib\netstandard2.0\Microsoft.Bot.Connector.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bot.Connector, Version=4.0.0.38905, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Bot.Connector.4.0.0.38905\lib\netstandard2.0\Microsoft.Bot.Connector.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Bot.Schema, Version=4.0.0.38905, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Bot.Schema.4.0.0.38905\lib\netstandard2.0\Microsoft.Bot.Schema.dll</HintPath>
-      <Private>True</Private>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Bot.Schema, Version=4.0.0.39458, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Bot.Schema.4.0.0.39458\lib\netstandard2.0\Microsoft.Bot.Schema.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Extensions.Configuration, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
@@ -134,9 +100,6 @@
     <Reference Include="Microsoft.Extensions.Primitives, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.Extensions.Primitives.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.IdentityModel.Logging.5.2.1\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.IdentityModel.Protocol.Extensions, Version=1.0.40306.1554, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.4.403061554\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
     </Reference>
@@ -146,11 +109,8 @@
     <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=5.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.IdentityModel.Protocols.OpenIdConnect.5.2.1\lib\net451\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.IdentityModel.Tokens.5.2.1\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Rest.ClientRuntime.2.3.12\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
+      <HintPath>packages\Microsoft.Rest.ClientRuntime.2.3.13\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime.Azure, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.Rest.ClientRuntime.Azure.3.3.13\lib\net452\Microsoft.Rest.ClientRuntime.Azure.dll</HintPath>
@@ -167,9 +127,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
-    </Reference>
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.5.2.1\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Memory.4.5.1\lib\netstandard2.0\System.Memory.dll</HintPath>

--- a/csharp_webapi/2.EchoBot-With-Counter/EchoWithCounterBot.cs
+++ b/csharp_webapi/2.EchoBot-With-Counter/EchoWithCounterBot.cs
@@ -50,6 +50,9 @@ namespace EchoBotWithCounter
                 // Bump the turn count for this conversation.
                 state.TurnCount++;
 
+                // Set the state
+                await _accessors.CounterState.SetAsync(turnContext, state);
+
                 // Save the new turn count into the conversation state.
                 await _accessors.ConversationState.SaveChangesAsync(turnContext);
 

--- a/csharp_webapi/2.EchoBot-With-Counter/Web.config
+++ b/csharp_webapi/2.EchoBot-With-Counter/Web.config
@@ -301,15 +301,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bot.Builder" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.38762" newVersion="4.0.0.38762" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.39458" newVersion="4.0.0.39458" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bot.Schema" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.38762" newVersion="4.0.0.38762" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.39458" newVersion="4.0.0.39458" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bot.Connector" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.38762" newVersion="4.0.0.38762" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.39458" newVersion="4.0.0.39458" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/csharp_webapi/2.EchoBot-With-Counter/packages.config
+++ b/csharp_webapi/2.EchoBot-With-Counter/packages.config
@@ -7,12 +7,12 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.6" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.6" targetFramework="net461" />
   <package id="Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime" version="0.9.0-preview" targetFramework="net461" />
-  <package id="Microsoft.Bot.Builder" version="4.0.0.38905" targetFramework="net461" />
+  <package id="Microsoft.Bot.Builder" version="4.0.0.39458" targetFramework="net461" />
   <package id="Microsoft.Bot.Builder.AI.Luis" version="4.0.0.38905" targetFramework="net461" />
-  <package id="Microsoft.Bot.Builder.Integration.AspNet.WebApi" version="4.0.0.38905" targetFramework="net461" />
-  <package id="Microsoft.Bot.Configuration" version="4.0.0.38905" targetFramework="net461" />
-  <package id="Microsoft.Bot.Connector" version="4.0.0.38905" targetFramework="net461" />
-  <package id="Microsoft.Bot.Schema" version="4.0.0.38905" targetFramework="net461" />
+  <package id="Microsoft.Bot.Builder.Integration.AspNet.WebApi" version="4.0.0.39458" targetFramework="net461" />
+  <package id="Microsoft.Bot.Configuration" version="4.0.0.39458" targetFramework="net461" />
+  <package id="Microsoft.Bot.Connector" version="4.0.0.39458" targetFramework="net461" />
+  <package id="Microsoft.Bot.Schema" version="4.0.0.39458" targetFramework="net461" />
   <package id="Microsoft.Extensions.Configuration" version="2.1.1" targetFramework="net461" />
   <package id="Microsoft.Extensions.Configuration.Abstractions" version="2.1.1" targetFramework="net461" />
   <package id="Microsoft.Extensions.Configuration.Binder" version="2.1.1" targetFramework="net461" />
@@ -27,7 +27,7 @@
   <package id="Microsoft.IdentityModel.Protocols" version="5.2.1" targetFramework="net461" />
   <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.2.1" targetFramework="net461" />
   <package id="Microsoft.IdentityModel.Tokens" version="5.2.1" targetFramework="net461" />
-  <package id="Microsoft.Rest.ClientRuntime" version="2.3.12" targetFramework="net461" />
+  <package id="Microsoft.Rest.ClientRuntime" version="2.3.13" targetFramework="net461" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.13" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />


### PR DESCRIPTION
- Asp.net Core attempting to load wrong bot config!
 Apparently we are standardizing on "BotConfiguration.bot" - but code was pointing at old name.  We probably need to check other samples.
- Fix BotConfiguration.bot endpoint name
We need to name local endpoint in bot config "development" to work with Azure deployment stuff.  This probably should be adopted across the board.
- Update packages on WebApi
 Latest Package references
 Remove remnants of Application Insights
- Fix set on accessor
 Set wasn't called on accessor!

 