### PR TITLE
C# templates reference a node .env file instead of appsettings.json

### DIFF
--- a/samples/csharp_dotnetcore/02.echo-with-counter/Startup.cs
+++ b/samples/csharp_dotnetcore/02.echo-with-counter/Startup.cs
@@ -73,7 +73,7 @@ namespace Microsoft.BotBuilderSamples
                 {
                     var msg = "Error reading bot file. Please ensure you have valid botFilePath and botFileSecret set for your environment.\n" +
                         " - The botFileSecret is available under appsettings for your Azure Bot Service bot.\n" +
-                        " - If you are running this bot locally, consider adding a .env file with botFilePath and botFileSecret.\n" +
+                        " - If you are running this bot locally, consider adding a appsettings.json file with botFilePath and botFileSecret.\n" +
                         " - See https://aka.ms/about-bot-file to learn more about .bot file its use and bot configuration.\n\n";
                     logger.LogError(msg);
                     throw new InvalidOperationException(msg);

--- a/samples/csharp_dotnetcore/13.basic-bot/Startup.cs
+++ b/samples/csharp_dotnetcore/13.basic-bot/Startup.cs
@@ -70,7 +70,7 @@ namespace Microsoft.BotBuilderSamples
             {
                 var msg = "Error reading bot file. Please ensure you have valid botFilePath and botFileSecret set for your environment.\n" +
                     " - The botFileSecret is available under appsettings for your Azure Bot Service bot.\n" +
-                    " - If you are running this bot locally, consider adding a .env file with botFilePath and botFileSecret.\n" +
+                    " - If you are running this bot locally, consider adding a appsettings.json file with botFilePath and botFileSecret.\n" +
                     " - See https://aka.ms/about-bot-file to learn more about .bot file its use and bot configuration.\n\n";
                 throw new InvalidOperationException(msg);
             }


### PR DESCRIPTION
## Proposed Changes
When checking for botFilePath and botFileSecret, the error message mentions a node specific environment file rather than the C# one. i.e.
"consider adding a .env file with botFilePath and botFileSecret."

.env is node specific, it should be appsettings.json