### PR TITLE
Create .env file for local debugging for custom dialogs bot sample

### DIFF
--- a/samples/javascript_nodejs/19.custom-dialogs/.env
+++ b/samples/javascript_nodejs/19.custom-dialogs/.env
@@ -1,0 +1,2 @@
+botFilePath=custom-dialogs.bot
+botFileSecret=


### PR DESCRIPTION
Fixes Failure to run sample 19 locally.

## Proposed Changes
I've added a .env file to sample 19.custom-dialogs in order to bring it to parity with other samples. The `.env` file is required to run and test locally out of the box. 

<img width="539" alt="fix" src="https://user-images.githubusercontent.com/6576516/46031281-4c7dfb00-c0ad-11e8-8423-14ea58cd50e4.PNG">

  - 
  -
  -


## Testing
Ran the bot locally and ran it through its functionality.