### PR TITLE
update csproj to always copy any .bot file when publishing

### DIFF
--- a/samples/csharp_dotnetcore/02.echo-with-counter/EchoBotWithCounter.csproj
+++ b/samples/csharp_dotnetcore/02.echo-with-counter/EchoBotWithCounter.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
 
-  <ItemGroup>
-    <Content Include="BotConfiguration.bot">
+ <ItemGroup>
+    <None Update="*.bot">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    </None>
   </ItemGroup>
 
 

--- a/samples/csharp_dotnetcore/03.welcome-user/WelcomeUser.csproj
+++ b/samples/csharp_dotnetcore/03.welcome-user/WelcomeUser.csproj
@@ -18,4 +18,10 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
 
+ <ItemGroup>
+    <None Update="*.bot">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  
 </Project>

--- a/samples/csharp_dotnetcore/04.simple-prompt/SimplePromptBot.csproj
+++ b/samples/csharp_dotnetcore/04.simple-prompt/SimplePromptBot.csproj
@@ -5,10 +5,10 @@
     <CodeAnalysisRuleSet>BotBuilder.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Content Include="BotConfiguration.bot">
+ <ItemGroup>
+    <None Update="*.bot">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    </None>
   </ItemGroup>  
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/MultiTurnPromptsBot.csproj
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/MultiTurnPromptsBot.csproj
@@ -5,10 +5,10 @@
     <CodeAnalysisRuleSet>BotBuilder.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Content Include="BotConfiguration.bot">
+ <ItemGroup>
+    <None Update="*.bot">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    </None>
   </ItemGroup>
     
   <ItemGroup>

--- a/samples/csharp_dotnetcore/06.using-cards/CardsBot.csproj
+++ b/samples/csharp_dotnetcore/06.using-cards/CardsBot.csproj
@@ -5,6 +5,12 @@
     <CodeAnalysisRuleSet>BotBuilder.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
+   <ItemGroup>
+    <None Update="*.bot">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
@@ -15,6 +21,5 @@
     <PackageReference Include="Microsoft.Bot.Configuration" Version="4.0.7" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
-
 
 </Project>

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/AdaptiveCardsBot.csproj
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/AdaptiveCardsBot.csproj
@@ -4,6 +4,12 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <CodeAnalysisRuleSet>BotBuilder.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  
+ <ItemGroup>
+    <None Update="*.bot">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.0.3" />

--- a/samples/csharp_dotnetcore/08.suggested-actions/SuggestedActionsBot.csproj
+++ b/samples/csharp_dotnetcore/08.suggested-actions/SuggestedActionsBot.csproj
@@ -5,6 +5,12 @@
     <CodeAnalysisRuleSet>BotBuilder.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
+ <ItemGroup>
+    <None Update="*.bot">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />

--- a/samples/csharp_dotnetcore/09.message-routing/MessageRoutingBot.csproj
+++ b/samples/csharp_dotnetcore/09.message-routing/MessageRoutingBot.csproj
@@ -29,6 +29,12 @@
     <Compile Remove="Dialogs\TestDialog.cs" />
   </ItemGroup>
 
+   <ItemGroup>
+    <None Update="*.bot">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />

--- a/samples/csharp_dotnetcore/10.prompt-validations/PromptValidationsBot.csproj
+++ b/samples/csharp_dotnetcore/10.prompt-validations/PromptValidationsBot.csproj
@@ -5,6 +5,12 @@
     <CodeAnalysisRuleSet>BotBuilder.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
+ <ItemGroup>
+    <None Update="*.bot">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />

--- a/samples/csharp_dotnetcore/11.qnamaker/QnABot.csproj
+++ b/samples/csharp_dotnetcore/11.qnamaker/QnABot.csproj
@@ -5,10 +5,10 @@
     <CodeAnalysisRuleSet>BotBuilder.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Content Include="BotConfiguration.bot">
+ <ItemGroup>
+    <None Update="*.bot">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/12.nlp-with-luis/LuisBot.csproj
+++ b/samples/csharp_dotnetcore/12.nlp-with-luis/LuisBot.csproj
@@ -5,12 +5,12 @@
 	  <CodeAnalysisRuleSet>LuisBot.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Content Include="BotConfiguration.bot">
+ <ItemGroup>
+    <None Update="*.bot">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    </None>
   </ItemGroup>
-
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.7" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.0.7" />

--- a/samples/csharp_dotnetcore/13.basic-bot/BasicBot.csproj
+++ b/samples/csharp_dotnetcore/13.basic-bot/BasicBot.csproj
@@ -29,8 +29,8 @@
     <WCFMetadata Include="Connected Services" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="BotConfiguration.bot">
+ <ItemGroup>
+    <None Update="*.bot">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/samples/csharp_dotnetcore/14.nlp-with-dispatch/NLP-With-Dispatch-Bot.csproj
+++ b/samples/csharp_dotnetcore/14.nlp-with-dispatch/NLP-With-Dispatch-Bot.csproj
@@ -7,6 +7,12 @@
     <CodeAnalysisRuleSet>NLP-With-Dispatch-Bot.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
+   <ItemGroup>
+    <None Update="*.bot">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.7" />

--- a/samples/csharp_dotnetcore/15.handling-attachments/HandlingAttachmentsBot.csproj
+++ b/samples/csharp_dotnetcore/15.handling-attachments/HandlingAttachmentsBot.csproj
@@ -5,6 +5,12 @@
     <CodeAnalysisRuleSet>BotBuilder.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
+   <ItemGroup>
+    <None Update="*.bot">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.0.7" />

--- a/samples/csharp_dotnetcore/16.proactive-messages/ProactiveBot.csproj
+++ b/samples/csharp_dotnetcore/16.proactive-messages/ProactiveBot.csproj
@@ -5,10 +5,10 @@
     <CodeAnalysisRuleSet>BotBuilder.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Content Include="BotConfiguration.bot">
+ <ItemGroup>
+    <None Update="*.bot">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/17.multilingual-bot/MultiLingualBot.csproj
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/MultiLingualBot.csproj
@@ -30,4 +30,10 @@
     <WCFMetadata Include="Connected Services" />
   </ItemGroup>
 
+   <ItemGroup>
+    <None Update="*.bot">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/samples/csharp_dotnetcore/18.bot-authentication/AuthenticationBot.csproj
+++ b/samples/csharp_dotnetcore/18.bot-authentication/AuthenticationBot.csproj
@@ -4,6 +4,12 @@
     <CodeAnalysisRuleSet>BotBuilder.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
+   <ItemGroup>
+    <None Update="*.bot">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.0.7" />

--- a/samples/csharp_dotnetcore/19.custom-dialogs/Custom-Dialogs.csproj
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/Custom-Dialogs.csproj
@@ -5,10 +5,10 @@
     <CodeAnalysisRuleSet>Custom-Dialog-Bot.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Content Include="BotConfiguration.bot">
+ <ItemGroup>
+    <None Update="*.bot">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/20.qna-with-appinsights/QnABotAppInsights.csproj
+++ b/samples/csharp_dotnetcore/20.qna-with-appinsights/QnABotAppInsights.csproj
@@ -5,13 +5,11 @@
     <CodeAnalysisRuleSet>QnABot.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-
-  <ItemGroup>
-    <Content Include="BotConfiguration.bot">
+ <ItemGroup>
+    <None Update="*.bot">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    </None>
   </ItemGroup>
-
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
@@ -27,6 +25,5 @@
   <ItemGroup>
     <WCFMetadata Include="Connected Services" />
   </ItemGroup>
-
 
 </Project>

--- a/samples/csharp_dotnetcore/21.luis-with-appinsights/LuisBotAppInsights.csproj
+++ b/samples/csharp_dotnetcore/21.luis-with-appinsights/LuisBotAppInsights.csproj
@@ -5,13 +5,11 @@
 	<CodeAnalysisRuleSet>LuisBot.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-
-  <ItemGroup>
-    <Content Include="BotConfiguration.bot">
+ <ItemGroup>
+    <None Update="*.bot">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    </None>
   </ItemGroup>
-
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
@@ -27,6 +25,5 @@
   <ItemGroup>
     <WCFMetadata Include="Connected Services" />
   </ItemGroup>
-
 
 </Project>

--- a/samples/csharp_dotnetcore/22.conversation-history/ConversationHistory.csproj
+++ b/samples/csharp_dotnetcore/22.conversation-history/ConversationHistory.csproj
@@ -5,13 +5,11 @@
     <CodeAnalysisRuleSet>BotBuilder.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-
-  <ItemGroup>
-    <Content Include="BotConfiguration.bot">
+ <ItemGroup>
+    <None Update="*.bot">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    </None>
   </ItemGroup>
-
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.7" />
@@ -22,6 +20,5 @@
     <PackageReference Include="Microsoft.Bot.Configuration" Version="4.0.7" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
-
 
 </Project>

--- a/samples/csharp_dotnetcore/23.facebook-events/Facebook-Events-Bot.csproj
+++ b/samples/csharp_dotnetcore/23.facebook-events/Facebook-Events-Bot.csproj
@@ -22,5 +22,10 @@
     <WCFMetadata Include="Connected Services" />
   </ItemGroup>
 
+ <ItemGroup>
+    <None Update="*.bot">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/BotAuthenticationMSGraph.csproj
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/BotAuthenticationMSGraph.csproj
@@ -16,4 +16,10 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
 
+ <ItemGroup>
+    <None Update="*.bot">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  
 </Project>

--- a/samples/csharp_dotnetcore/52.enterprise-bot/EnterpriseBot.csproj
+++ b/samples/csharp_dotnetcore/52.enterprise-bot/EnterpriseBot.csproj
@@ -9,6 +9,11 @@
     <CodeAnalysisRuleSet>BotBuilder.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
+ <ItemGroup>
+    <None Update="*.bot">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />


### PR DESCRIPTION
## Proposed Changes
Update all C# csproj files to always copy **any** .bot file during publish scenario. This way, when using msbot clone services, which creates a new .bot file, it is easy to publish and not forget to include the new .bot file. 

Add the following for any csproj that had no entry and override specific botConfiguration.bot. 
```
 <ItemGroup>
    <None Update="*.bot">
      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
    </None>
  </ItemGroup>
```

## Testing
- launch VS
- any .bot file is now marked with alwayscopy
- tested welcome bot, running locally and work with emulator