### PR TITLE
Fix console-echo to pull from npm, update typescript samples to use 4.0.6

### DIFF
--- a/samples/javascript_typescript/01.console-echo/package-lock.json
+++ b/samples/javascript_typescript/01.console-echo/package-lock.json
@@ -6,55 +6,55 @@
   "dependencies": {
     "@types/caseless": {
       "version": "0.12.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/caseless/-/@types/caseless-0.12.1.tgz",
-      "integrity": "sha1-l5TGnIOF0BkqzEcaVA0fjg0WIYo="
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
+      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A=="
     },
     "@types/filenamify": {
       "version": "2.0.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/filenamify/-/@types/filenamify-2.0.1.tgz",
-      "integrity": "sha1-KnWtJm9PuC4RPvf9xS4DVcJ8Kz0="
+      "resolved": "https://registry.npmjs.org/@types/filenamify/-/filenamify-2.0.1.tgz",
+      "integrity": "sha512-QpmNRLMBSQtvd1eV8dodwiUCtSJRhg0EhV+9Xwpch1DhiXPh75qx6aRxVfHvzhQdPzrFJx9v+hpiC0FIVyPQOA=="
     },
     "@types/form-data": {
       "version": "2.2.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/form-data/-/@types/form-data-2.2.1.tgz",
-      "integrity": "sha1-7is7jqoRwJOCiZU2BrdFtzjFSx4=",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
+      "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/is-stream": {
       "version": "1.1.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/is-stream/-/@types/is-stream-1.1.0.tgz",
-      "integrity": "sha1-uE17sgeiEPKvm+1DHcD76cQUO+E=",
+      "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/jsonwebtoken": {
       "version": "7.2.5",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/jsonwebtoken/-/@types/jsonwebtoken-7.2.5.tgz",
-      "integrity": "sha1-QTFZ1XDsRfw+fafqP3vKb7kwDnI=",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.5.tgz",
+      "integrity": "sha512-8CIcK1Vzq4w5TJyJYkLVhqASmCo1FSO1XIPQM1qv+Xo2nnb9RoRHxx8pkIzSZ4Tm9r3V4ZyFbF/fBewNPdclwA==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "9.6.31",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/node/-/@types/node-9.6.31.tgz",
-      "integrity": "sha1-TRcimH+NgItMGU3OuMITvZLwKOU="
+      "version": "9.6.32",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.32.tgz",
+      "integrity": "sha512-5+L3wQ+FHoQ589EaH6rYICleuj8gnunq+1CJkM9fxklirErIOv+kxm3s/vecYnpJOYnFowE5uUizcb3hgjHUug=="
     },
     "@types/node-fetch": {
       "version": "1.6.9",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/node-fetch/-/@types/node-fetch-1.6.9.tgz",
-      "integrity": "sha1-p1D7D0zylgv3K0YuTIaQgCLdacU=",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-1.6.9.tgz",
+      "integrity": "sha512-n2r6WLoY7+uuPT7pnEtKJCmPUGyJ+cbyBR8Avnu4+m1nzz7DwBVuyIvvlBzCZ/nrpC7rIgb3D6pNavL7rFEa9g==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/request": {
       "version": "2.47.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/request/-/@types/request-2.47.1.tgz",
-      "integrity": "sha1-JUENOvvawEyRqUrZ78mCQQBzWCQ=",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.1.tgz",
+      "integrity": "sha512-TV3XLvDjQbIeVxJ1Z3oCTDk/KuYwwcNKVwz2YaT0F5u86Prgc4syDAp6P96rkTQQ4bIdh+VswQIC9zS6NjY7/g==",
       "requires": {
         "@types/caseless": "*",
         "@types/form-data": "*",
@@ -64,13 +64,13 @@
     },
     "@types/tough-cookie": {
       "version": "2.3.3",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/tough-cookie/-/@types/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-fyJtZ9ZU7JBw51X0ba6/AUYo6dk="
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ=="
     },
     "@types/uuid": {
       "version": "3.4.4",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/uuid/-/@types/uuid-3.4.4.tgz",
-      "integrity": "sha1-evaTYPpl7w3stB/RUL9MpcDO/fU=",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.4.tgz",
+      "integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
       "requires": {
         "@types/node": "*"
       }
@@ -83,7 +83,7 @@
     },
     "adal-node": {
       "version": "0.1.28",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/adal-node/-/adal-node-0.1.28.tgz",
+      "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.1.28.tgz",
       "integrity": "sha1-RoxLs+u9lrEnBmn0ucuk4AZepIU=",
       "requires": {
         "@types/node": "^8.0.47",
@@ -98,15 +98,15 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.10.29",
-          "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/node/-/@types/node-8.10.29.tgz",
-          "integrity": "sha1-s6E7WN17BoK/G0ICK+9KWpcY9oc="
+          "version": "8.10.30",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.30.tgz",
+          "integrity": "sha512-Le8HGMI5gjFSBqcCuKP/wfHC19oURzkU2D+ERIescUoJd+CmNEMYBib9LQ4zj1HHEZOJQWhw2ZTnbD8weASh/Q=="
         }
       }
     },
     "ajv": {
       "version": "5.5.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ajv/-/ajv-5.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
         "co": "^4.6.0",
@@ -184,15 +184,15 @@
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
         "safer-buffer": "~2.1.0"
       }
     },
     "assert": {
       "version": "1.4.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/assert/-/assert-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
       "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
       "requires": {
         "util": "0.10.3"
@@ -200,7 +200,7 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assign-symbols": {
@@ -211,8 +211,8 @@
     },
     "async": {
       "version": "2.6.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/async/-/async-2.6.0.tgz",
-      "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "requires": {
         "lodash": "^4.14.0"
       }
@@ -225,7 +225,7 @@
     },
     "async-file": {
       "version": "2.0.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/async-file/-/async-file-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/async-file/-/async-file-2.0.2.tgz",
       "integrity": "sha1-Aq0HhWrDcX6DayCuxaTP4AxG3yM=",
       "requires": {
         "rimraf": "^2.5.2"
@@ -233,7 +233,7 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
@@ -244,13 +244,13 @@
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.8.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8="
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -367,12 +367,12 @@
     },
     "base64url": {
       "version": "2.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/base64url/-/base64url-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
       "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "optional": true,
       "requires": {
@@ -387,47 +387,45 @@
     },
     "boom": {
       "version": "4.3.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/boom/-/boom-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
         "hoek": "4.x.x"
       }
     },
     "botbuilder": {
-      "version": "4.0.0-preview1.1163",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/botbuilder/-/botbuilder-4.0.0-preview1.1163.tgz",
-      "integrity": "sha1-LxsOpuBwHE0CH+pTpU7i+UhSRyY=",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.0.6.tgz",
+      "integrity": "sha512-QvtaoCCfUUsWkWtbVBOSdmblPy7g/SjSRBpkcR9i2us7dgJvhlM0alhta3OvnUSGyMPrpV7k5aBCErtubxzdng==",
       "requires": {
         "@types/filenamify": "^2.0.1",
         "@types/node": "^9.3.0",
-        "assert": "^1.4.1",
         "async-file": "^2.0.2",
-        "botbuilder-core": "4.0.0-preview1.1163",
-        "botframework-connector": "4.0.0-preview1.1163",
+        "botbuilder-core": "^4.0.6",
+        "botframework-connector": "^4.0.6",
         "filenamify": "^2.0.0",
-        "readline": "^1.3.0",
         "rimraf": "^2.6.2"
       }
     },
     "botbuilder-core": {
-      "version": "4.0.0-preview1.1163",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/botbuilder-core/-/botbuilder-core-4.0.0-preview1.1163.tgz",
-      "integrity": "sha1-U+GnfTXhU5iePMnAXRWYfCkOafE=",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.0.6.tgz",
+      "integrity": "sha512-23OE1MOQStQDIL2379O9gMgq/t4LcgXzr9+odFTK8WYpl9FSTelwntb8PIeW4fToqV/palQbmCDLNrFtQ/X7ug==",
       "requires": {
         "assert": "^1.4.1",
-        "botframework-schema": "4.0.0-preview1.1163"
+        "botframework-schema": "^4.0.6"
       }
     },
     "botframework-connector": {
-      "version": "4.0.0-preview1.1163",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/botframework-connector/-/botframework-connector-4.0.0-preview1.1163.tgz",
-      "integrity": "sha1-bpN/AYc1hFj9qx7lS1mpygdjkCM=",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.0.6.tgz",
+      "integrity": "sha512-0AOJ91u9+9yJo68VNeeplM+ivWoQgfMswc5EE0h1+r2GYlqMNMDoWaLxKnD1ZG4jUdCVpUXwzpYvaWFSBFa9AQ==",
       "requires": {
         "@types/jsonwebtoken": "7.2.5",
         "@types/node": "^9.3.0",
         "@types/request": "^2.47.0",
         "base64url": "^2.0.0",
-        "botframework-schema": "4.0.0-preview1.1163",
+        "botframework-schema": "^4.0.6",
         "jsonwebtoken": "8.0.1",
         "ms-rest-azure": "^2.5.0",
         "ms-rest-js": "0.2.8",
@@ -436,9 +434,9 @@
       }
     },
     "botframework-schema": {
-      "version": "4.0.0-preview1.1163",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/botframework-schema/-/botframework-schema-4.0.0-preview1.1163.tgz",
-      "integrity": "sha1-Pw6oeHdWrQgOx8ZE+SlEIT9cVDs=",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.0.6.tgz",
+      "integrity": "sha512-FoOSWio0ZkpE3nCGsv5Yz5GbmT29uuFBwTsK9t0+MTv7pAmM+MDrqG3A1Ed99N0oQXr59yacEvx5Zdaeb6Xw5Q==",
       "requires": {
         "@types/node": "^9.3.0"
       }
@@ -498,7 +496,7 @@
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "builtin-modules": {
@@ -538,7 +536,7 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
@@ -610,7 +608,7 @@
     },
     "co": {
       "version": "4.6.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/co/-/co-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "collection-visit": {
@@ -639,9 +637,9 @@
       "dev": true
     },
     "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -710,7 +708,7 @@
     },
     "cryptiles": {
       "version": "3.1.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/cryptiles/-/cryptiles-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
         "boom": "5.x.x"
@@ -718,8 +716,8 @@
       "dependencies": {
         "boom": {
           "version": "5.2.0",
-          "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
             "hoek": "4.x.x"
           }
@@ -734,7 +732,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -742,7 +740,7 @@
     },
     "date-utils": {
       "version": "1.2.21",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/date-utils/-/date-utils-1.2.21.tgz",
+      "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
       "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
     },
     "debug": {
@@ -817,7 +815,7 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "diff": {
@@ -848,7 +846,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "optional": true,
       "requires": {
@@ -858,7 +856,7 @@
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.10",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
       "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -874,7 +872,7 @@
     },
     "es6-denodeify": {
       "version": "0.1.5",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/es6-denodeify/-/es6-denodeify-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/es6-denodeify/-/es6-denodeify-0.1.5.tgz",
       "integrity": "sha1-MdTV/pxVA+ElRgQ5MQ4WoqPznB8="
     },
     "escape-string-regexp": {
@@ -976,8 +974,8 @@
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -1067,23 +1065,23 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "1.1.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fetch-cookie": {
       "version": "0.7.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/fetch-cookie/-/fetch-cookie-0.7.2.tgz",
-      "integrity": "sha1-W+US9xIbC80uNENQrXF3J6w7Gl0=",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-0.7.2.tgz",
+      "integrity": "sha512-Udm6ls1tV/pR9+EOjTYW2aGBadN03zOgVwu6grybxOg9ufACq7wE1HY/jh06DOykXH9FLYJC2RbUD3kJZcJBRg==",
       "requires": {
         "es6-denodeify": "^0.1.1",
         "tough-cookie": "^2.3.1"
@@ -1110,13 +1108,13 @@
     },
     "filename-reserved-regex": {
       "version": "2.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
       "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
     },
     "filenamify": {
       "version": "2.1.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/filenamify/-/filenamify-2.1.0.tgz",
-      "integrity": "sha1-iPr0lfsbR6v9YSMAACoWIoxnfuk=",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
+      "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
       "requires": {
         "filename-reserved-regex": "^2.0.0",
         "strip-outer": "^1.0.0",
@@ -1154,17 +1152,27 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/form-data/-/form-data-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
         "mime-types": "^2.1.12"
+      },
+      "dependencies": {
+        "combined-stream": {
+          "version": "1.0.6",
+          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        }
       }
     },
     "fragment-cache": {
@@ -1730,7 +1738,7 @@
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -1806,12 +1814,12 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.0.3",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/har-validator/-/har-validator-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
         "ajv": "^5.1.0",
@@ -1875,8 +1883,8 @@
     },
     "hawk": {
       "version": "6.0.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
         "boom": "4.x.x",
         "cryptiles": "3.x.x",
@@ -1886,12 +1894,12 @@
     },
     "hoek": {
       "version": "4.2.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs="
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -2133,7 +2141,7 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-windows": {
@@ -2162,7 +2170,7 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "js-tokens": {
@@ -2183,28 +2191,28 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.3.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsonwebtoken": {
       "version": "8.0.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jsonwebtoken/-/jsonwebtoken-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.0.1.tgz",
       "integrity": "sha1-UNrvjQqMfeLNBrwQE7dbBMzz8M8=",
       "requires": {
         "jws": "^3.1.4",
@@ -2221,7 +2229,7 @@
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "requires": {
         "assert-plus": "1.0.0",
@@ -2232,8 +2240,8 @@
     },
     "jwa": {
       "version": "1.1.6",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jwa/-/jwa-1.1.6.tgz",
-      "integrity": "sha1-hyQOdsmAjb3hh4PPImTvSSnuUOY=",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
+      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.10",
@@ -2242,8 +2250,8 @@
     },
     "jws": {
       "version": "3.1.5",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jws/-/jws-3.1.5.tgz",
-      "integrity": "sha1-gNEtBbKT0ehB58uLTmnlYa3Pg08=",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
       "requires": {
         "jwa": "^1.1.5",
         "safe-buffer": "^5.0.1"
@@ -2265,9 +2273,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -2277,37 +2285,37 @@
     },
     "lodash.includes": {
       "version": "4.3.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
     },
     "lodash.isboolean": {
       "version": "3.0.3",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
     },
     "lodash.isinteger": {
       "version": "4.0.4",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
     },
     "lodash.isnumber": {
       "version": "3.0.3",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.isstring": {
       "version": "4.0.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.once": {
       "version": "4.1.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.once/-/lodash.once-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lowercase-keys": {
@@ -2379,13 +2387,13 @@
     },
     "mime-db": {
       "version": "1.36.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/mime-db/-/mime-db-1.36.0.tgz",
-      "integrity": "sha1-UCBHjbPH/pOq17vMTc+GnEM2M5c="
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
     },
     "mime-types": {
       "version": "2.1.20",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/mime-types/-/mime-types-2.1.20.tgz",
-      "integrity": "sha1-kwy3GdVx6QNzhSD4RwkRVIyizBk=",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "requires": {
         "mime-db": "~1.36.0"
       }
@@ -2427,24 +2435,24 @@
     },
     "moment": {
       "version": "2.22.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/moment/-/moment-2.22.2.tgz",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
       "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
     "ms": {
       "version": "2.1.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "ms-rest": {
-      "version": "2.3.6",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ms-rest/-/ms-rest-2.3.6.tgz",
-      "integrity": "sha1-mYT+kyjNB+MXK1INtd/wrLaPH3o=",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/ms-rest/-/ms-rest-2.3.7.tgz",
+      "integrity": "sha512-zZwuckC/Uv8F1Jr1bW+U1tsDTErWhtH6W4mpxvRrta4YrKwkFeLMt53RsaDOWTqMFsVpjNuCfznV1uxeGUF3/g==",
       "requires": {
         "duplexer": "^0.1.1",
         "is-buffer": "^1.1.6",
         "is-stream": "^1.1.0",
         "moment": "^2.21.0",
-        "request": "^2.87.0",
+        "request": "^2.88.0",
         "through": "^2.3.8",
         "tunnel": "0.0.5",
         "uuid": "^3.2.1"
@@ -2452,8 +2460,8 @@
       "dependencies": {
         "har-validator": {
           "version": "5.1.0",
-          "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/har-validator/-/har-validator-5.1.0.tgz",
-          "integrity": "sha1-RGV/VoiiLP1LckhugbOj+xF0LCk=",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+          "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
           "requires": {
             "ajv": "^5.3.0",
             "har-schema": "^2.0.0"
@@ -2461,13 +2469,13 @@
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
-          "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
         },
         "request": {
           "version": "2.88.0",
-          "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/request/-/request-2.88.0.tgz",
-          "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
           "requires": {
             "aws-sign2": "~0.7.0",
             "aws4": "^1.8.0",
@@ -2493,8 +2501,8 @@
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "requires": {
             "psl": "^1.1.24",
             "punycode": "^1.4.1"
@@ -2503,21 +2511,74 @@
       }
     },
     "ms-rest-azure": {
-      "version": "2.5.7",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ms-rest-azure/-/ms-rest-azure-2.5.7.tgz",
-      "integrity": "sha1-jUpo7ZONIUiLpuZrRSX+Loy9+y0=",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/ms-rest-azure/-/ms-rest-azure-2.5.9.tgz",
+      "integrity": "sha512-qonobzWLS7Jl6qwgTuA/SfyCtnv7olvCRKrcF8nzXSj68ds4Oj3K64ntzgQajroKa0hKVMcPUFbTk1IYMGvu8w==",
       "requires": {
         "adal-node": "^0.1.28",
         "async": "2.6.0",
         "moment": "^2.22.2",
         "ms-rest": "^2.3.2",
+        "request": "^2.88.0",
         "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "har-validator": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+          "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+          "requires": {
+            "ajv": "^5.3.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "request": {
+          "version": "2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        }
       }
     },
     "ms-rest-js": {
       "version": "0.2.8",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ms-rest-js/-/ms-rest-js-0.2.8.tgz",
-      "integrity": "sha1-mk4QQyexPtf2puUFri4WrVTD2DQ=",
+      "resolved": "http://registry.npmjs.org/ms-rest-js/-/ms-rest-js-0.2.8.tgz",
+      "integrity": "sha512-KgiSsbJzKcPLx0Zaca5PEdGOwm8X4Np+aTukK6stMl2eAqSrHvncjteyeXi6v6O0ECLYeUWVbqcPJfpw1PjnZQ==",
       "requires": {
         "@types/form-data": "^2.2.1",
         "@types/is-stream": "^1.1.0",
@@ -2536,8 +2597,8 @@
       "dependencies": {
         "is-buffer": {
           "version": "2.0.3",
-          "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha1-Ts8/z3ScvR5HJonhCaxmJhol5yU="
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
         }
       }
     },
@@ -2623,7 +2684,7 @@
     },
     "oauth-sign": {
       "version": "0.8.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "object-copy": {
@@ -2747,7 +2808,7 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
@@ -2791,8 +2852,8 @@
     },
     "psl": {
       "version": "1.1.29",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha1-YPWA02AXC7cip5fMcEQR5tqFDGc="
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
     },
     "pstree.remy": {
       "version": "1.1.0",
@@ -2805,18 +2866,18 @@
     },
     "punycode": {
       "version": "1.4.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/punycode/-/punycode-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
       "version": "6.5.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "querystringify": {
       "version": "2.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/querystringify/-/querystringify-2.0.0.tgz",
-      "integrity": "sha1-+j7W5o6xUVlFfImze8ZHKDMZV1U="
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+      "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
     },
     "rc": {
       "version": "1.2.8",
@@ -2919,8 +2980,8 @@
     },
     "request": {
       "version": "2.83.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/request/-/request-2.83.0.tgz",
-      "integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.6.0",
@@ -2948,7 +3009,7 @@
     },
     "requires-port": {
       "version": "1.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/requires-port/-/requires-port-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
@@ -2974,15 +3035,15 @@
     },
     "rimraf": {
       "version": "2.6.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "^7.0.5"
       }
     },
     "rsa-pem-from-mod-exp": {
       "version": "0.8.4",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
       "integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
     },
     "safe-buffer": {
@@ -3001,8 +3062,8 @@
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "5.5.1",
@@ -3193,8 +3254,8 @@
     },
     "sntp": {
       "version": "2.1.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
         "hoek": "4.x.x"
       }
@@ -3250,7 +3311,7 @@
     },
     "sshpk": {
       "version": "1.14.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/sshpk/-/sshpk-1.14.2.tgz",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
         "asn1": "~0.2.3",
@@ -3316,8 +3377,8 @@
     },
     "stringstream": {
       "version": "0.0.6",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha1-eIAiWw1K0Q4wkn0Weh1vL9OzOnI="
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
     },
     "strip-ansi": {
       "version": "4.0.0",
@@ -3342,8 +3403,8 @@
     },
     "strip-outer": {
       "version": "1.0.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/strip-outer/-/strip-outer-1.0.1.tgz",
-      "integrity": "sha1-sv0qv2YEudHmATBXGV34Nrip1jE=",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
@@ -3430,15 +3491,15 @@
     },
     "tough-cookie": {
       "version": "2.3.4",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
         "punycode": "^1.4.1"
       }
     },
     "trim-repeated": {
       "version": "1.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "requires": {
         "escape-string-regexp": "^1.0.2"
@@ -3501,12 +3562,12 @@
     },
     "tunnel": {
       "version": "0.0.5",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/tunnel/-/tunnel-0.0.5.tgz",
-      "integrity": "sha1-0VMiVHSe02Yg/NEBCGVJWh+p0K4="
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.5.tgz",
+      "integrity": "sha512-gj5sdqherx4VZKMcBA4vewER7zdK25Td+z1npBqpbDys4eJrLx+SlYjJvq1bDXs2irkuJM5pf8ktaEQVipkrbA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -3514,7 +3575,7 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
@@ -3546,8 +3607,8 @@
     },
     "underscore": {
       "version": "1.9.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha1-BtzjSg5op7q8KbNluOdLiSUgOWE="
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
     },
     "union-value": {
       "version": "1.0.0",
@@ -3671,8 +3732,8 @@
     },
     "url-parse": {
       "version": "1.4.3",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/url-parse/-/url-parse-1.4.3.tgz",
-      "integrity": "sha1-v67kVciJAjIZ11fgRfpqaE7DbBU=",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+      "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
       "requires": {
         "querystringify": "^2.0.0",
         "requires-port": "^1.0.0"
@@ -3695,7 +3756,7 @@
     },
     "util": {
       "version": "0.10.3",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/util/-/util-0.10.3.tgz",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "requires": {
         "inherits": "2.0.1"
@@ -3709,12 +3770,12 @@
     },
     "uuid": {
       "version": "3.3.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE="
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -3764,17 +3825,17 @@
     },
     "xmldom": {
       "version": "0.1.27",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/xmldom/-/xmldom-0.1.27.tgz",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
     },
     "xpath.js": {
       "version": "1.1.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/xpath.js/-/xpath.js-1.1.0.tgz",
-      "integrity": "sha1-OBakTtS7NSCRCD0AKjg91RBKX/E="
+      "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
+      "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
     },
     "xtend": {
       "version": "4.0.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/xtend/-/xtend-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yallist": {

--- a/samples/javascript_typescript/01.console-echo/package.json
+++ b/samples/javascript_typescript/01.console-echo/package.json
@@ -12,7 +12,7 @@
   "author": "Microsoft",
   "license": "MIT",
   "dependencies": {
-    "botbuilder": "^4.0.0-preview1.1163",
+    "botbuilder": "^4.0.6",
     "readline": "^1.3.0"
   },
   "devDependencies": {

--- a/samples/javascript_typescript/02.echobot-with-counter/package-lock.json
+++ b/samples/javascript_typescript/02.echobot-with-counter/package-lock.json
@@ -6,73 +6,73 @@
   "dependencies": {
     "@types/caseless": {
       "version": "0.12.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/caseless/-/@types/caseless-0.12.1.tgz",
-      "integrity": "sha1-l5TGnIOF0BkqzEcaVA0fjg0WIYo="
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
+      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A=="
     },
     "@types/filenamify": {
       "version": "2.0.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/filenamify/-/@types/filenamify-2.0.1.tgz",
-      "integrity": "sha1-KnWtJm9PuC4RPvf9xS4DVcJ8Kz0="
+      "resolved": "https://registry.npmjs.org/@types/filenamify/-/filenamify-2.0.1.tgz",
+      "integrity": "sha512-QpmNRLMBSQtvd1eV8dodwiUCtSJRhg0EhV+9Xwpch1DhiXPh75qx6aRxVfHvzhQdPzrFJx9v+hpiC0FIVyPQOA=="
     },
     "@types/form-data": {
       "version": "2.2.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/form-data/-/@types/form-data-2.2.1.tgz",
-      "integrity": "sha1-7is7jqoRwJOCiZU2BrdFtzjFSx4=",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
+      "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "requires": {
-        "@types/node": "9.6.31"
+        "@types/node": "*"
       }
     },
     "@types/is-stream": {
       "version": "1.1.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/is-stream/-/@types/is-stream-1.1.0.tgz",
-      "integrity": "sha1-uE17sgeiEPKvm+1DHcD76cQUO+E=",
+      "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
       "requires": {
-        "@types/node": "9.6.31"
+        "@types/node": "*"
       }
     },
     "@types/jsonwebtoken": {
       "version": "7.2.5",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/jsonwebtoken/-/@types/jsonwebtoken-7.2.5.tgz",
-      "integrity": "sha1-QTFZ1XDsRfw+fafqP3vKb7kwDnI=",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.5.tgz",
+      "integrity": "sha512-8CIcK1Vzq4w5TJyJYkLVhqASmCo1FSO1XIPQM1qv+Xo2nnb9RoRHxx8pkIzSZ4Tm9r3V4ZyFbF/fBewNPdclwA==",
       "requires": {
-        "@types/node": "9.6.31"
+        "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "9.6.31",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/node/-/@types/node-9.6.31.tgz",
-      "integrity": "sha1-TRcimH+NgItMGU3OuMITvZLwKOU="
+      "version": "9.6.32",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.32.tgz",
+      "integrity": "sha512-5+L3wQ+FHoQ589EaH6rYICleuj8gnunq+1CJkM9fxklirErIOv+kxm3s/vecYnpJOYnFowE5uUizcb3hgjHUug=="
     },
     "@types/node-fetch": {
       "version": "1.6.9",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/node-fetch/-/@types/node-fetch-1.6.9.tgz",
-      "integrity": "sha1-p1D7D0zylgv3K0YuTIaQgCLdacU=",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-1.6.9.tgz",
+      "integrity": "sha512-n2r6WLoY7+uuPT7pnEtKJCmPUGyJ+cbyBR8Avnu4+m1nzz7DwBVuyIvvlBzCZ/nrpC7rIgb3D6pNavL7rFEa9g==",
       "requires": {
-        "@types/node": "9.6.31"
+        "@types/node": "*"
       }
     },
     "@types/request": {
       "version": "2.47.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/request/-/@types/request-2.47.1.tgz",
-      "integrity": "sha1-JUENOvvawEyRqUrZ78mCQQBzWCQ=",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.1.tgz",
+      "integrity": "sha512-TV3XLvDjQbIeVxJ1Z3oCTDk/KuYwwcNKVwz2YaT0F5u86Prgc4syDAp6P96rkTQQ4bIdh+VswQIC9zS6NjY7/g==",
       "requires": {
-        "@types/caseless": "0.12.1",
-        "@types/form-data": "2.2.1",
-        "@types/node": "9.6.31",
-        "@types/tough-cookie": "2.3.3"
+        "@types/caseless": "*",
+        "@types/form-data": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*"
       }
     },
     "@types/tough-cookie": {
       "version": "2.3.3",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/tough-cookie/-/@types/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-fyJtZ9ZU7JBw51X0ba6/AUYo6dk="
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ=="
     },
     "@types/uuid": {
       "version": "3.4.4",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/uuid/-/@types/uuid-3.4.4.tgz",
-      "integrity": "sha1-evaTYPpl7w3stB/RUL9MpcDO/fU=",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.4.tgz",
+      "integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
       "requires": {
-        "@types/node": "9.6.31"
+        "@types/node": "*"
       }
     },
     "abbrev": {
@@ -83,36 +83,36 @@
     },
     "adal-node": {
       "version": "0.1.28",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/adal-node/-/adal-node-0.1.28.tgz",
+      "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.1.28.tgz",
       "integrity": "sha1-RoxLs+u9lrEnBmn0ucuk4AZepIU=",
       "requires": {
-        "@types/node": "8.10.29",
-        "async": "2.6.0",
-        "date-utils": "1.2.21",
-        "jws": "3.1.5",
-        "request": "2.83.0",
-        "underscore": "1.9.1",
-        "uuid": "3.3.2",
-        "xmldom": "0.1.27",
-        "xpath.js": "1.1.0"
+        "@types/node": "^8.0.47",
+        "async": ">=0.6.0",
+        "date-utils": "*",
+        "jws": "3.x.x",
+        "request": ">= 2.52.0",
+        "underscore": ">= 1.3.1",
+        "uuid": "^3.1.0",
+        "xmldom": ">= 0.1.x",
+        "xpath.js": "~1.1.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.10.29",
-          "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/node/-/@types/node-8.10.29.tgz",
-          "integrity": "sha1-s6E7WN17BoK/G0ICK+9KWpcY9oc="
+          "version": "8.10.30",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.30.tgz",
+          "integrity": "sha512-Le8HGMI5gjFSBqcCuKP/wfHC19oURzkU2D+ERIescUoJd+CmNEMYBib9LQ4zj1HHEZOJQWhw2ZTnbD8weASh/Q=="
         }
       }
     },
     "ajv": {
       "version": "5.5.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ajv/-/ajv-5.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ansi-align": {
@@ -121,7 +121,7 @@
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^2.0.0"
       }
     },
     "ansi-regex": {
@@ -136,7 +136,7 @@
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "anymatch": {
@@ -145,8 +145,8 @@
       "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
       "dev": true,
       "requires": {
-        "micromatch": "3.1.10",
-        "normalize-path": "2.1.1"
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
       }
     },
     "arr-diff": {
@@ -178,12 +178,12 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "~2.1.0"
       }
     },
     "assert": {
       "version": "1.4.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/assert/-/assert-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
       "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
       "requires": {
         "util": "0.10.3"
@@ -202,10 +202,10 @@
     },
     "async": {
       "version": "2.6.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/async/-/async-2.6.0.tgz",
-      "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.14.0"
       }
     },
     "async-each": {
@@ -216,15 +216,15 @@
     },
     "async-file": {
       "version": "2.0.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/async-file/-/async-file-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/async-file/-/async-file-2.0.2.tgz",
       "integrity": "sha1-Aq0HhWrDcX6DayCuxaTP4AxG3yM=",
       "requires": {
-        "rimraf": "2.6.2"
+        "rimraf": "^2.5.2"
       }
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
@@ -235,13 +235,13 @@
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.8.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8="
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -254,13 +254,13 @@
       "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "dev": true,
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -269,7 +269,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -278,7 +278,7 @@
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -287,7 +287,7 @@
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -296,16 +296,16 @@
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
     },
     "base64url": {
       "version": "2.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/base64url/-/base64url-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
       "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
     },
     "bcrypt-pbkdf": {
@@ -314,7 +314,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "binary-extensions": {
@@ -325,70 +325,70 @@
     },
     "boom": {
       "version": "4.3.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/boom/-/boom-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "botbuilder": {
-      "version": "4.0.5",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/botbuilder/-/botbuilder-4.0.5.tgz",
-      "integrity": "sha1-R4Urtlix69SwcALihOtdj8OAn+4=",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.0.6.tgz",
+      "integrity": "sha512-QvtaoCCfUUsWkWtbVBOSdmblPy7g/SjSRBpkcR9i2us7dgJvhlM0alhta3OvnUSGyMPrpV7k5aBCErtubxzdng==",
       "requires": {
-        "@types/filenamify": "2.0.1",
-        "@types/node": "9.6.31",
-        "async-file": "2.0.2",
-        "botbuilder-core": "4.0.5",
-        "botframework-connector": "4.0.5",
-        "filenamify": "2.1.0",
-        "rimraf": "2.6.2"
+        "@types/filenamify": "^2.0.1",
+        "@types/node": "^9.3.0",
+        "async-file": "^2.0.2",
+        "botbuilder-core": "^4.0.6",
+        "botframework-connector": "^4.0.6",
+        "filenamify": "^2.0.0",
+        "rimraf": "^2.6.2"
       }
     },
     "botbuilder-core": {
-      "version": "4.0.5",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/botbuilder-core/-/botbuilder-core-4.0.5.tgz",
-      "integrity": "sha1-hJtUEAP8CzvqJg9ImyK60udpuXA=",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.0.6.tgz",
+      "integrity": "sha512-23OE1MOQStQDIL2379O9gMgq/t4LcgXzr9+odFTK8WYpl9FSTelwntb8PIeW4fToqV/palQbmCDLNrFtQ/X7ug==",
       "requires": {
-        "assert": "1.4.1",
-        "botframework-schema": "4.0.5"
+        "assert": "^1.4.1",
+        "botframework-schema": "^4.0.6"
       }
     },
     "botframework-config": {
-      "version": "4.0.5",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/botframework-config/-/botframework-config-4.0.5.tgz",
-      "integrity": "sha1-SCg4pHV8nwf5BoPhh0/fDnk4J/Q=",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/botframework-config/-/botframework-config-4.0.6.tgz",
+      "integrity": "sha512-0yHnVWIb1xXBC+6gwAEggp8T30xtjJ4al1i2axNyOr6/Tov6LbCVbeO/Ysdrp27F7iu6hSrO7OwvDyHzwxN+7g==",
       "requires": {
-        "fs-extra": "7.0.0",
-        "process": "0.11.10",
-        "read-text-file": "1.1.0",
-        "url": "0.11.0",
-        "uuid": "3.3.2"
+        "fs-extra": "^7.0.0",
+        "process": "^0.11.10",
+        "read-text-file": "^1.1.0",
+        "url": "^0.11.0",
+        "uuid": "^3.3.2"
       }
     },
     "botframework-connector": {
-      "version": "4.0.5",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/botframework-connector/-/botframework-connector-4.0.5.tgz",
-      "integrity": "sha1-AyG6qIoaTt0tSV6z+HABySiUd3s=",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.0.6.tgz",
+      "integrity": "sha512-0AOJ91u9+9yJo68VNeeplM+ivWoQgfMswc5EE0h1+r2GYlqMNMDoWaLxKnD1ZG4jUdCVpUXwzpYvaWFSBFa9AQ==",
       "requires": {
         "@types/jsonwebtoken": "7.2.5",
-        "@types/node": "9.6.31",
-        "@types/request": "2.47.1",
-        "base64url": "2.0.0",
-        "botframework-schema": "4.0.5",
+        "@types/node": "^9.3.0",
+        "@types/request": "^2.47.0",
+        "base64url": "^2.0.0",
+        "botframework-schema": "^4.0.6",
         "jsonwebtoken": "8.0.1",
-        "ms-rest-azure": "2.5.7",
+        "ms-rest-azure": "^2.5.0",
         "ms-rest-js": "0.2.8",
         "request": "2.83.0",
-        "rsa-pem-from-mod-exp": "0.8.4"
+        "rsa-pem-from-mod-exp": "^0.8.4"
       }
     },
     "botframework-schema": {
-      "version": "4.0.5",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/botframework-schema/-/botframework-schema-4.0.5.tgz",
-      "integrity": "sha1-080u8EfqM7PLHlfFMPP9E+JbGQ4=",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.0.6.tgz",
+      "integrity": "sha512-FoOSWio0ZkpE3nCGsv5Yz5GbmT29uuFBwTsK9t0+MTv7pAmM+MDrqG3A1Ed99N0oQXr59yacEvx5Zdaeb6Xw5Q==",
       "requires": {
-        "@types/node": "9.6.31"
+        "@types/node": "^9.3.0"
       }
     },
     "boxen": {
@@ -397,13 +397,13 @@
       "integrity": "sha1-VcbDmouljZxhrSLNh3Uy3rZlogs=",
       "dev": true,
       "requires": {
-        "ansi-align": "2.0.0",
-        "camelcase": "4.1.0",
-        "chalk": "2.4.1",
-        "cli-boxes": "1.0.0",
-        "string-width": "2.1.1",
-        "term-size": "1.2.0",
-        "widest-line": "2.0.0"
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
       }
     },
     "brace-expansion": {
@@ -411,7 +411,7 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -421,16 +421,16 @@
       "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.3.2",
-        "extend-shallow": "2.0.1",
-        "fill-range": "4.0.0",
-        "isobject": "3.0.1",
-        "repeat-element": "1.1.3",
-        "snapdragon": "0.8.2",
-        "snapdragon-node": "2.1.1",
-        "split-string": "3.1.0",
-        "to-regex": "3.0.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -439,14 +439,14 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "bunyan": {
@@ -454,10 +454,10 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/bunyan/-/bunyan-1.8.12.tgz",
       "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
       "requires": {
-        "dtrace-provider": "0.8.7",
-        "moment": "2.22.2",
-        "mv": "2.1.1",
-        "safe-json-stringify": "1.2.0"
+        "dtrace-provider": "~0.8",
+        "moment": "^2.10.6",
+        "mv": "~2",
+        "safe-json-stringify": "~1"
       }
     },
     "cache-base": {
@@ -466,15 +466,15 @@
       "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "dev": true,
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "camelcase": {
@@ -491,7 +491,7 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
@@ -500,9 +500,9 @@
       "integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "chokidar": {
@@ -511,19 +511,19 @@
       "integrity": "sha1-NW/04rDo5D4yLRijckYLvPOszSY=",
       "dev": true,
       "requires": {
-        "anymatch": "2.0.0",
-        "async-each": "1.0.1",
-        "braces": "2.3.2",
-        "fsevents": "1.2.4",
-        "glob-parent": "3.1.0",
-        "inherits": "2.0.1",
-        "is-binary-path": "1.0.1",
-        "is-glob": "4.0.0",
-        "lodash.debounce": "4.0.8",
-        "normalize-path": "2.1.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0",
-        "upath": "1.1.0"
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.0",
+        "braces": "^2.3.0",
+        "fsevents": "^1.2.2",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "lodash.debounce": "^4.0.8",
+        "normalize-path": "^2.1.1",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0",
+        "upath": "^1.0.5"
       }
     },
     "ci-info": {
@@ -538,10 +538,10 @@
       "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -550,7 +550,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -566,13 +566,13 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/clone-regexp/-/clone-regexp-1.0.1.tgz",
       "integrity": "sha1-BRgFzTMXM3XYIRj8CRhgbaOf1g8=",
       "requires": {
-        "is-regexp": "1.0.0",
-        "is-supported-regexp-flag": "1.0.1"
+        "is-regexp": "^1.0.0",
+        "is-supported-regexp-flag": "^1.0.0"
       }
     },
     "co": {
       "version": "4.6.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/co/-/co-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "collection-visit": {
@@ -581,8 +581,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color-convert": {
@@ -602,10 +602,10 @@
     },
     "combined-stream": {
       "version": "1.0.7",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha1-LR0kMXr7ir6V1tLAsHtXgTU52Cg=",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "component-emitter": {
@@ -625,12 +625,12 @@
       "integrity": "sha1-xvJd767vJt8S3TNBSwAf6BpUP48=",
       "dev": true,
       "requires": {
-        "dot-prop": "4.2.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.3.0",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.3.0",
-        "xdg-basedir": "3.0.0"
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "copy-descriptor": {
@@ -650,7 +650,7 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "1.0.0"
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "cross-spawn": {
@@ -659,25 +659,25 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.3",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cryptiles": {
       "version": "3.1.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/cryptiles/-/cryptiles-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
           "version": "5.2.0",
-          "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.2.1"
+            "hoek": "4.x.x"
           }
         }
       }
@@ -693,10 +693,10 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/csv/-/csv-1.2.1.tgz",
       "integrity": "sha1-UjHt/BxxUlEuxFeBB2p6l/9SXAw=",
       "requires": {
-        "csv-generate": "1.1.2",
-        "csv-parse": "1.3.3",
-        "csv-stringify": "1.1.2",
-        "stream-transform": "0.2.2"
+        "csv-generate": "^1.1.2",
+        "csv-parse": "^1.3.3",
+        "csv-stringify": "^1.1.2",
+        "stream-transform": "^0.2.2"
       }
     },
     "csv-generate": {
@@ -714,7 +714,7 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/csv-stringify/-/csv-stringify-1.1.2.tgz",
       "integrity": "sha1-d6QVJlgbzjOA8SsA18W7rHDIK1g=",
       "requires": {
-        "lodash.get": "4.4.2"
+        "lodash.get": "~4.4.2"
       }
     },
     "dashdash": {
@@ -722,12 +722,12 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "date-utils": {
       "version": "1.2.21",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/date-utils/-/date-utils-1.2.21.tgz",
+      "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
       "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
     },
     "debug": {
@@ -763,8 +763,8 @@
       "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "dev": true,
       "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -773,7 +773,7 @@
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -782,7 +782,7 @@
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -791,16 +791,16 @@
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "detect-node": {
@@ -814,7 +814,7 @@
       "integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
       "dev": true,
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "dotenv": {
@@ -828,7 +828,7 @@
       "integrity": "sha1-3JObTT4GIM/gwc2APQ0tftBP/QQ=",
       "optional": true,
       "requires": {
-        "nan": "2.11.0"
+        "nan": "^2.10.0"
       }
     },
     "duplexer": {
@@ -848,29 +848,29 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.10",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
       "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "encoding": {
       "version": "0.1.12",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/encoding/-/encoding-0.1.12.tgz",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.24"
+        "iconv-lite": "~0.4.13"
       }
     },
     "es6-denodeify": {
       "version": "0.1.5",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/es6-denodeify/-/es6-denodeify-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/es6-denodeify/-/es6-denodeify-0.1.5.tgz",
       "integrity": "sha1-MdTV/pxVA+ElRgQ5MQ4WoqPznB8="
     },
     "escape-regexp-component": {
@@ -889,13 +889,13 @@
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1",
-        "from": "0.1.7",
-        "map-stream": "0.1.0",
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
         "pause-stream": "0.0.11",
-        "split": "0.3.3",
-        "stream-combiner": "0.0.4",
-        "through": "2.3.8"
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
       }
     },
     "ewma": {
@@ -903,7 +903,7 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ewma/-/ewma-2.0.1.tgz",
       "integrity": "sha1-mHbBxJGsVzPIZmABo5YaBMl88eg=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "execa": {
@@ -912,13 +912,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "expand-brackets": {
@@ -927,13 +927,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "posix-character-classes": "0.1.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -942,7 +942,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -951,15 +951,15 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -967,8 +967,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -977,7 +977,7 @@
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -988,14 +988,14 @@
       "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
       "dev": true,
       "requires": {
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "expand-brackets": "2.1.4",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -1004,7 +1004,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "extend-shallow": {
@@ -1013,7 +1013,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -1022,7 +1022,7 @@
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -1031,7 +1031,7 @@
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -1040,9 +1040,9 @@
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -1054,54 +1054,55 @@
     },
     "fast-deep-equal": {
       "version": "1.1.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fetch-cookie": {
       "version": "0.7.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/fetch-cookie/-/fetch-cookie-0.7.2.tgz",
-      "integrity": "sha1-W+US9xIbC80uNENQrXF3J6w7Gl0=",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-0.7.2.tgz",
+      "integrity": "sha512-Udm6ls1tV/pR9+EOjTYW2aGBadN03zOgVwu6grybxOg9ufACq7wE1HY/jh06DOykXH9FLYJC2RbUD3kJZcJBRg==",
       "requires": {
-        "es6-denodeify": "0.1.5",
-        "tough-cookie": "2.3.4"
+        "es6-denodeify": "^0.1.1",
+        "tough-cookie": "^2.3.1"
       }
     },
     "fetch-ponyfill": {
       "version": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
+      "from": "github:amarzavery/fetch-ponyfill#master",
       "requires": {
-        "fetch-cookie": "0.6.0",
-        "node-fetch": "1.7.3"
+        "fetch-cookie": "~0.6.0",
+        "node-fetch": "~1.7.1"
       },
       "dependencies": {
         "fetch-cookie": {
           "version": "0.6.0",
-          "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/fetch-cookie/-/fetch-cookie-0.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-0.6.0.tgz",
           "integrity": "sha1-T+xOQIzAAH9sBOVTYYr0s97jf2k=",
           "requires": {
-            "es6-denodeify": "0.1.5",
-            "tough-cookie": "2.3.4"
+            "es6-denodeify": "^0.1.1",
+            "tough-cookie": "^2.3.1"
           }
         }
       }
     },
     "filename-reserved-regex": {
       "version": "2.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
       "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
     },
     "filenamify": {
       "version": "2.1.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/filenamify/-/filenamify-2.1.0.tgz",
-      "integrity": "sha1-iPr0lfsbR6v9YSMAACoWIoxnfuk=",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
+      "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
       "requires": {
-        "filename-reserved-regex": "2.0.0",
-        "strip-outer": "1.0.1",
-        "trim-repeated": "1.0.0"
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.0",
+        "trim-repeated": "^1.0.0"
       }
     },
     "fill-range": {
@@ -1110,10 +1111,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1",
-        "to-regex-range": "2.1.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -1122,7 +1123,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -1135,25 +1136,25 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/form-data/-/form-data-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.20"
+        "mime-types": "^2.1.12"
       },
       "dependencies": {
         "combined-stream": {
           "version": "1.0.6",
-          "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/combined-stream/-/combined-stream-1.0.6.tgz",
+          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         }
       }
@@ -1169,7 +1170,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "from": {
@@ -1180,17 +1181,17 @@
     },
     "fs-extra": {
       "version": "7.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/fs-extra/-/fs-extra-7.0.0.tgz",
-      "integrity": "sha1-jMP0fOB+97NZOhG5+yRffjTAQdY=",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
+      "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.2"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
@@ -1200,8 +1201,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.11.0",
-        "node-pre-gyp": "0.10.0"
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -1227,8 +1228,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "balanced-match": {
@@ -1241,7 +1242,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -1305,7 +1306,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
@@ -1320,14 +1321,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
@@ -1336,12 +1337,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -1356,7 +1357,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "^2.1.0"
           }
         },
         "ignore-walk": {
@@ -1365,7 +1366,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -1374,8 +1375,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -1394,7 +1395,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -1408,7 +1409,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -1421,8 +1422,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
           }
         },
         "minizlib": {
@@ -1431,7 +1432,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
@@ -1454,9 +1455,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
-            "sax": "1.2.4"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -1465,16 +1466,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.7",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.1"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -1483,8 +1484,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
@@ -1499,8 +1500,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
@@ -1509,10 +1510,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -1531,7 +1532,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -1552,8 +1553,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -1574,10 +1575,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.5.1",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -1594,13 +1595,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
@@ -1609,7 +1610,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -1652,9 +1653,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -1663,7 +1664,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -1671,7 +1672,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -1686,13 +1687,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
           }
         },
         "util-deprecate": {
@@ -1707,7 +1708,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -1739,20 +1740,20 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
       "version": "7.1.3",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.1",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-parent": {
@@ -1761,8 +1762,8 @@
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "3.1.0",
-        "path-dirname": "1.0.2"
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
       },
       "dependencies": {
         "is-glob": {
@@ -1771,7 +1772,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         }
       }
@@ -1782,7 +1783,7 @@
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
-        "ini": "1.3.5"
+        "ini": "^1.3.4"
       }
     },
     "got": {
@@ -1791,17 +1792,17 @@
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.1",
-        "safe-buffer": "5.1.2",
-        "timed-out": "4.0.1",
-        "unzip-response": "2.0.1",
-        "url-parse-lax": "1.0.0"
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -1816,16 +1817,16 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.0.3",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/har-validator/-/har-validator-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has-flag": {
@@ -1840,9 +1841,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "has-values": {
@@ -1851,8 +1852,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -1861,36 +1862,36 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
     },
     "hawk": {
       "version": "6.0.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       }
     },
     "hoek": {
       "version": "4.2.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs="
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "hpack.js": {
       "version": "2.1.6",
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "requires": {
-        "inherits": "2.0.1",
-        "obuf": "1.1.2",
-        "readable-stream": "2.3.6",
-        "wbuf": "1.7.3"
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
       }
     },
     "http-deceiver": {
@@ -1903,17 +1904,17 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.2"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ignore-by-default": {
@@ -1939,8 +1940,8 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1960,7 +1961,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -1969,7 +1970,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -1980,7 +1981,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -1994,7 +1995,7 @@
       "integrity": "sha1-P0oI1jA6CYgs7z8PuXQ5xfXOLVM=",
       "dev": true,
       "requires": {
-        "ci-info": "1.4.0"
+        "ci-info": "^1.3.0"
       }
     },
     "is-data-descriptor": {
@@ -2003,7 +2004,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -2012,7 +2013,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -2023,9 +2024,9 @@
       "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -2060,7 +2061,7 @@
       "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
       "dev": true,
       "requires": {
-        "is-extglob": "2.1.1"
+        "is-extglob": "^2.1.1"
       }
     },
     "is-installed-globally": {
@@ -2069,8 +2070,8 @@
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
-        "global-dirs": "0.1.1",
-        "is-path-inside": "1.0.1"
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-npm": {
@@ -2085,7 +2086,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -2094,7 +2095,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -2111,7 +2112,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-object": {
@@ -2120,7 +2121,7 @@
       "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-redirect": {
@@ -2152,7 +2153,7 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-windows": {
@@ -2180,7 +2181,7 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jsbn": {
@@ -2191,8 +2192,8 @@
     },
     "jschardet": {
       "version": "1.6.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jschardet/-/jschardet-1.6.0.tgz",
-      "integrity": "sha1-x9GnHtz/KDnbL57DD8XV69PBpng="
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
+      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ=="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -2201,37 +2202,37 @@
     },
     "json-schema-traverse": {
       "version": "0.3.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jsonfile/-/jsonfile-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonwebtoken": {
       "version": "8.0.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jsonwebtoken/-/jsonwebtoken-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.0.1.tgz",
       "integrity": "sha1-UNrvjQqMfeLNBrwQE7dbBMzz8M8=",
       "requires": {
-        "jws": "3.1.5",
-        "lodash.includes": "4.3.0",
-        "lodash.isboolean": "3.0.3",
-        "lodash.isinteger": "4.0.4",
-        "lodash.isnumber": "3.0.3",
-        "lodash.isplainobject": "4.0.6",
-        "lodash.isstring": "4.0.1",
-        "lodash.once": "4.1.1",
-        "ms": "2.1.1",
-        "xtend": "4.0.1"
+        "jws": "^3.1.4",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "jsprim": {
@@ -2247,21 +2248,21 @@
     },
     "jwa": {
       "version": "1.1.6",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jwa/-/jwa-1.1.6.tgz",
-      "integrity": "sha1-hyQOdsmAjb3hh4PPImTvSSnuUOY=",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
+      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.10",
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "jws": {
       "version": "3.1.5",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jws/-/jws-3.1.5.tgz",
-      "integrity": "sha1-gNEtBbKT0ehB58uLTmnlYa3Pg08=",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
       "requires": {
-        "jwa": "1.1.6",
-        "safe-buffer": "5.1.2"
+        "jwa": "^1.1.5",
+        "safe-buffer": "^5.0.1"
       }
     },
     "kind-of": {
@@ -2276,7 +2277,7 @@
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "requires": {
-        "package-json": "4.0.1"
+        "package-json": "^4.0.0"
       }
     },
     "lodash": {
@@ -2297,37 +2298,37 @@
     },
     "lodash.includes": {
       "version": "4.3.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
     },
     "lodash.isboolean": {
       "version": "3.0.3",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
     },
     "lodash.isinteger": {
       "version": "4.0.4",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
     },
     "lodash.isnumber": {
       "version": "3.0.3",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.isstring": {
       "version": "4.0.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.once": {
       "version": "4.1.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.once/-/lodash.once-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lowercase-keys": {
@@ -2341,8 +2342,8 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lru-cache/-/lru-cache-4.1.3.tgz",
       "integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "make-dir": {
@@ -2351,7 +2352,7 @@
       "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       }
     },
     "map-cache": {
@@ -2372,7 +2373,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "micromatch": {
@@ -2381,19 +2382,19 @@
       "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "braces": "2.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "extglob": "2.0.4",
-        "fragment-cache": "0.2.1",
-        "kind-of": "6.0.2",
-        "nanomatch": "1.2.13",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       }
     },
     "mime": {
@@ -2403,15 +2404,15 @@
     },
     "mime-db": {
       "version": "1.36.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/mime-db/-/mime-db-1.36.0.tgz",
-      "integrity": "sha1-UCBHjbPH/pOq17vMTc+GnEM2M5c="
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
     },
     "mime-types": {
       "version": "2.1.20",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/mime-types/-/mime-types-2.1.20.tgz",
-      "integrity": "sha1-kwy3GdVx6QNzhSD4RwkRVIyizBk=",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "requires": {
-        "mime-db": "1.36.0"
+        "mime-db": "~1.36.0"
       }
     },
     "minimalistic-assert": {
@@ -2424,7 +2425,7 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -2439,8 +2440,8 @@
       "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -2449,7 +2450,7 @@
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -2470,112 +2471,165 @@
     },
     "ms": {
       "version": "2.1.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "ms-rest": {
-      "version": "2.3.6",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ms-rest/-/ms-rest-2.3.6.tgz",
-      "integrity": "sha1-mYT+kyjNB+MXK1INtd/wrLaPH3o=",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/ms-rest/-/ms-rest-2.3.7.tgz",
+      "integrity": "sha512-zZwuckC/Uv8F1Jr1bW+U1tsDTErWhtH6W4mpxvRrta4YrKwkFeLMt53RsaDOWTqMFsVpjNuCfznV1uxeGUF3/g==",
       "requires": {
-        "duplexer": "0.1.1",
-        "is-buffer": "1.1.6",
-        "is-stream": "1.1.0",
-        "moment": "2.22.2",
-        "request": "2.88.0",
-        "through": "2.3.8",
+        "duplexer": "^0.1.1",
+        "is-buffer": "^1.1.6",
+        "is-stream": "^1.1.0",
+        "moment": "^2.21.0",
+        "request": "^2.88.0",
+        "through": "^2.3.8",
         "tunnel": "0.0.5",
-        "uuid": "3.3.2"
+        "uuid": "^3.2.1"
       },
       "dependencies": {
         "har-validator": {
           "version": "5.1.0",
-          "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/har-validator/-/har-validator-5.1.0.tgz",
-          "integrity": "sha1-RGV/VoiiLP1LckhugbOj+xF0LCk=",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+          "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
           "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
+            "ajv": "^5.3.0",
+            "har-schema": "^2.0.0"
           }
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
-          "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
         },
         "request": {
           "version": "2.88.0",
-          "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/request/-/request-2.88.0.tgz",
-          "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.8.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.7",
-            "extend": "3.0.2",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.2",
-            "har-validator": "5.1.0",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.20",
-            "oauth-sign": "0.9.0",
-            "performance-now": "2.1.0",
-            "qs": "6.5.2",
-            "safe-buffer": "5.1.2",
-            "tough-cookie": "2.4.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.3.2"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
           }
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "requires": {
-            "psl": "1.1.29",
-            "punycode": "1.4.1"
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
           }
         }
       }
     },
     "ms-rest-azure": {
-      "version": "2.5.7",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ms-rest-azure/-/ms-rest-azure-2.5.7.tgz",
-      "integrity": "sha1-jUpo7ZONIUiLpuZrRSX+Loy9+y0=",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/ms-rest-azure/-/ms-rest-azure-2.5.9.tgz",
+      "integrity": "sha512-qonobzWLS7Jl6qwgTuA/SfyCtnv7olvCRKrcF8nzXSj68ds4Oj3K64ntzgQajroKa0hKVMcPUFbTk1IYMGvu8w==",
       "requires": {
-        "adal-node": "0.1.28",
+        "adal-node": "^0.1.28",
         "async": "2.6.0",
-        "moment": "2.22.2",
-        "ms-rest": "2.3.6",
-        "uuid": "3.3.2"
+        "moment": "^2.22.2",
+        "ms-rest": "^2.3.2",
+        "request": "^2.88.0",
+        "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "har-validator": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+          "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+          "requires": {
+            "ajv": "^5.3.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "request": {
+          "version": "2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        }
       }
     },
     "ms-rest-js": {
       "version": "0.2.8",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ms-rest-js/-/ms-rest-js-0.2.8.tgz",
-      "integrity": "sha1-mk4QQyexPtf2puUFri4WrVTD2DQ=",
+      "resolved": "http://registry.npmjs.org/ms-rest-js/-/ms-rest-js-0.2.8.tgz",
+      "integrity": "sha512-KgiSsbJzKcPLx0Zaca5PEdGOwm8X4Np+aTukK6stMl2eAqSrHvncjteyeXi6v6O0ECLYeUWVbqcPJfpw1PjnZQ==",
       "requires": {
-        "@types/form-data": "2.2.1",
-        "@types/is-stream": "1.1.0",
-        "@types/node": "9.6.31",
-        "@types/node-fetch": "1.6.9",
-        "@types/uuid": "3.4.4",
-        "fetch-cookie": "0.7.2",
+        "@types/form-data": "^2.2.1",
+        "@types/is-stream": "^1.1.0",
+        "@types/node": "^9.4.6",
+        "@types/node-fetch": "^1.6.7",
+        "@types/uuid": "^3.4.3",
+        "fetch-cookie": "^0.7.0",
         "fetch-ponyfill": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
-        "form-data": "2.3.2",
-        "is-buffer": "2.0.3",
-        "is-stream": "1.1.0",
-        "moment": "2.22.2",
-        "url-parse": "1.4.3",
-        "uuid": "3.3.2"
+        "form-data": "^2.3.2",
+        "is-buffer": "^2.0.0",
+        "is-stream": "^1.1.0",
+        "moment": "^2.21.0",
+        "url-parse": "^1.2.0",
+        "uuid": "^3.2.1"
       },
       "dependencies": {
         "is-buffer": {
           "version": "2.0.3",
-          "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha1-Ts8/z3ScvR5HJonhCaxmJhol5yU="
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
         }
       }
     },
@@ -2585,9 +2639,9 @@
       "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
       "optional": true,
       "requires": {
-        "mkdirp": "0.5.1",
-        "ncp": "2.0.0",
-        "rimraf": "2.4.5"
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
       },
       "dependencies": {
         "glob": {
@@ -2596,11 +2650,11 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "optional": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "rimraf": {
@@ -2609,7 +2663,7 @@
           "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
           "optional": true,
           "requires": {
-            "glob": "6.0.4"
+            "glob": "^6.0.1"
           }
         }
       }
@@ -2626,17 +2680,17 @@
       "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.2",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       }
     },
     "ncp": {
@@ -2652,11 +2706,11 @@
     },
     "node-fetch": {
       "version": "1.7.3",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "nodemon": {
@@ -2665,16 +2719,16 @@
       "integrity": "sha1-hz9l/bUyIOsWYYDPEGsTVKxdcU0=",
       "dev": true,
       "requires": {
-        "chokidar": "2.0.4",
-        "debug": "3.1.0",
-        "ignore-by-default": "1.0.1",
-        "minimatch": "3.0.4",
-        "pstree.remy": "1.1.0",
-        "semver": "5.5.1",
-        "supports-color": "5.5.0",
-        "touch": "3.1.0",
-        "undefsafe": "2.0.2",
-        "update-notifier": "2.5.0"
+        "chokidar": "^2.0.2",
+        "debug": "^3.1.0",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.0.4",
+        "pstree.remy": "^1.1.0",
+        "semver": "^5.5.0",
+        "supports-color": "^5.2.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.2",
+        "update-notifier": "^2.3.0"
       },
       "dependencies": {
         "debug": {
@@ -2700,7 +2754,7 @@
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.1"
+        "abbrev": "1"
       }
     },
     "normalize-path": {
@@ -2709,7 +2763,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "npm-run-path": {
@@ -2718,12 +2772,12 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "oauth-sign": {
       "version": "0.8.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "object-copy": {
@@ -2732,9 +2786,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -2743,7 +2797,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "kind-of": {
@@ -2752,7 +2806,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -2763,7 +2817,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "object.pick": {
@@ -2772,7 +2826,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "obuf": {
@@ -2785,7 +2839,7 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "p-finally": {
@@ -2800,10 +2854,10 @@
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
-        "got": "6.7.1",
-        "registry-auth-token": "3.3.2",
-        "registry-url": "3.1.0",
-        "semver": "5.5.1"
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
       }
     },
     "pascalcase": {
@@ -2841,12 +2895,12 @@
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3"
       }
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pidusage": {
@@ -2874,7 +2928,7 @@
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/process/-/process-0.11.10.tgz",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
@@ -2888,7 +2942,7 @@
       "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
       "dev": true,
       "requires": {
-        "event-stream": "3.3.4"
+        "event-stream": "~3.3.0"
       }
     },
     "pseudomap": {
@@ -2898,8 +2952,8 @@
     },
     "psl": {
       "version": "1.1.29",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha1-YPWA02AXC7cip5fMcEQR5tqFDGc="
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
     },
     "pstree.remy": {
       "version": "1.1.0",
@@ -2907,12 +2961,12 @@
       "integrity": "sha1-8q8nJlvT5bMrv8wQ6AusVbp4aIs=",
       "dev": true,
       "requires": {
-        "ps-tree": "1.1.0"
+        "ps-tree": "^1.1.0"
       }
     },
     "punycode": {
       "version": "1.4.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/punycode/-/punycode-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
@@ -2922,13 +2976,13 @@
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystringify": {
       "version": "2.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/querystringify/-/querystringify-2.0.0.tgz",
-      "integrity": "sha1-+j7W5o6xUVlFfImze8ZHKDMZV1U="
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+      "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
     },
     "rc": {
       "version": "1.2.8",
@@ -2936,10 +2990,10 @@
       "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
       "dev": true,
       "requires": {
-        "deep-extend": "0.6.0",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -2952,11 +3006,11 @@
     },
     "read-text-file": {
       "version": "1.1.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/read-text-file/-/read-text-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-text-file/-/read-text-file-1.1.0.tgz",
       "integrity": "sha1-0MPxh2iCj5EH1huws2jue5D3GJM=",
       "requires": {
-        "iconv-lite": "0.4.24",
-        "jschardet": "1.6.0"
+        "iconv-lite": "^0.4.17",
+        "jschardet": "^1.4.2"
       }
     },
     "readable-stream": {
@@ -2964,13 +3018,13 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       },
       "dependencies": {
         "inherits": {
@@ -2986,10 +3040,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.6",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "regex-not": {
@@ -2998,8 +3052,8 @@
       "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "registry-auth-token": {
@@ -3008,8 +3062,8 @@
       "integrity": "sha1-hR/UkDjuy1hpERFa+EUmDuyYPyA=",
       "dev": true,
       "requires": {
-        "rc": "1.2.8",
-        "safe-buffer": "5.1.2"
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
       }
     },
     "registry-url": {
@@ -3018,7 +3072,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.8"
+        "rc": "^1.0.1"
       }
     },
     "remove-trailing-separator": {
@@ -3041,36 +3095,36 @@
     },
     "request": {
       "version": "2.83.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/request/-/request-2.83.0.tgz",
-      "integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.8.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.7",
-        "extend": "3.0.2",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.20",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "stringstream": "0.0.6",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.3.2"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "requires-port": {
       "version": "1.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/requires-port/-/requires-port-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve-url": {
@@ -3084,28 +3138,28 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/restify/-/restify-6.4.0.tgz",
       "integrity": "sha1-PwyaTHgzmGnQF/7YWg5SVavz2kQ=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "bunyan": "1.8.12",
-        "clone-regexp": "1.0.1",
-        "csv": "1.2.1",
-        "dtrace-provider": "0.8.7",
-        "escape-regexp-component": "1.0.2",
-        "ewma": "2.0.1",
-        "formidable": "1.2.1",
-        "http-signature": "1.2.0",
-        "lodash": "4.17.10",
-        "lru-cache": "4.1.3",
-        "mime": "1.6.0",
-        "negotiator": "0.6.1",
-        "once": "1.4.0",
-        "pidusage": "1.2.0",
-        "qs": "6.5.2",
-        "restify-errors": "5.0.0",
-        "semver": "5.5.1",
-        "spdy": "3.4.7",
-        "uuid": "3.3.2",
-        "vasync": "1.6.4",
-        "verror": "1.10.0"
+        "assert-plus": "^1.0.0",
+        "bunyan": "^1.8.12",
+        "clone-regexp": "^1.0.0",
+        "csv": "^1.1.1",
+        "dtrace-provider": "^0.8.1",
+        "escape-regexp-component": "^1.0.2",
+        "ewma": "^2.0.1",
+        "formidable": "^1.1.1",
+        "http-signature": "^1.2.0",
+        "lodash": "^4.17.4",
+        "lru-cache": "^4.1.1",
+        "mime": "^1.5.0",
+        "negotiator": "^0.6.1",
+        "once": "^1.4.0",
+        "pidusage": "^1.2.0",
+        "qs": "^6.5.1",
+        "restify-errors": "^5.0.0",
+        "semver": "^5.4.1",
+        "spdy": "^3.4.7",
+        "uuid": "^3.1.0",
+        "vasync": "^1.6.4",
+        "verror": "^1.10.0"
       }
     },
     "restify-errors": {
@@ -3113,10 +3167,10 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/restify-errors/-/restify-errors-5.0.0.tgz",
       "integrity": "sha1-ZocX4QBoPuxs4NUV+J/x2+wlSo0=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "lodash": "4.17.10",
-        "safe-json-stringify": "1.2.0",
-        "verror": "1.10.0"
+        "assert-plus": "^1.0.0",
+        "lodash": "^4.2.1",
+        "safe-json-stringify": "^1.0.3",
+        "verror": "^1.8.1"
       }
     },
     "ret": {
@@ -3127,15 +3181,15 @@
     },
     "rimraf": {
       "version": "2.6.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "7.1.3"
+        "glob": "^7.0.5"
       }
     },
     "rsa-pem-from-mod-exp": {
       "version": "0.8.4",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
       "integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
     },
     "safe-buffer": {
@@ -3155,7 +3209,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "safer-buffer": {
@@ -3179,7 +3233,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "5.5.1"
+        "semver": "^5.0.3"
       }
     },
     "set-immediate-shim": {
@@ -3194,10 +3248,10 @@
       "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -3206,7 +3260,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -3217,7 +3271,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -3238,14 +3292,14 @@
       "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "dev": true,
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.2",
-        "use": "3.1.1"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -3254,7 +3308,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -3263,7 +3317,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -3274,9 +3328,9 @@
       "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "dev": true,
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -3285,7 +3339,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -3294,7 +3348,7 @@
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -3303,7 +3357,7 @@
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -3312,9 +3366,9 @@
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -3325,7 +3379,7 @@
       "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       },
       "dependencies": {
         "kind-of": {
@@ -3334,17 +3388,17 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
     },
     "sntp": {
       "version": "2.1.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "source-map": {
@@ -3359,11 +3413,11 @@
       "integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
       "dev": true,
       "requires": {
-        "atob": "2.1.2",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-url": {
@@ -3377,12 +3431,12 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/spdy/-/spdy-3.4.7.tgz",
       "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
       "requires": {
-        "debug": "2.6.9",
-        "handle-thing": "1.2.5",
-        "http-deceiver": "1.2.7",
-        "safe-buffer": "5.1.2",
-        "select-hose": "2.0.0",
-        "spdy-transport": "2.1.0"
+        "debug": "^2.6.8",
+        "handle-thing": "^1.2.5",
+        "http-deceiver": "^1.2.7",
+        "safe-buffer": "^5.0.1",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.18"
       }
     },
     "spdy-transport": {
@@ -3390,13 +3444,13 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/spdy-transport/-/spdy-transport-2.1.0.tgz",
       "integrity": "sha1-S7sVqv/tC+791WrWHb3Iuj4st6E=",
       "requires": {
-        "debug": "2.6.9",
-        "detect-node": "2.0.3",
-        "hpack.js": "2.1.6",
-        "obuf": "1.1.2",
-        "readable-stream": "2.3.6",
-        "safe-buffer": "5.1.2",
-        "wbuf": "1.7.3"
+        "debug": "^2.6.8",
+        "detect-node": "^2.0.3",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.1",
+        "readable-stream": "^2.2.9",
+        "safe-buffer": "^5.0.1",
+        "wbuf": "^1.7.2"
       }
     },
     "split": {
@@ -3405,7 +3459,7 @@
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "split-string": {
@@ -3414,7 +3468,7 @@
       "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       }
     },
     "sshpk": {
@@ -3422,15 +3476,15 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
-        "asn1": "0.2.4",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.2",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "static-extend": {
@@ -3439,8 +3493,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -3449,7 +3503,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -3460,7 +3514,7 @@
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1"
+        "duplexer": "~0.1.1"
       }
     },
     "stream-transform": {
@@ -3474,8 +3528,8 @@
       "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
     "string_decoder": {
@@ -3483,13 +3537,13 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {
       "version": "0.0.6",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha1-eIAiWw1K0Q4wkn0Weh1vL9OzOnI="
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
     },
     "strip-ansi": {
       "version": "4.0.0",
@@ -3497,7 +3551,7 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0"
+        "ansi-regex": "^3.0.0"
       }
     },
     "strip-eof": {
@@ -3514,10 +3568,10 @@
     },
     "strip-outer": {
       "version": "1.0.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/strip-outer/-/strip-outer-1.0.1.tgz",
-      "integrity": "sha1-sv0qv2YEudHmATBXGV34Nrip1jE=",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.2"
       }
     },
     "supports-color": {
@@ -3526,7 +3580,7 @@
       "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
       "dev": true,
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "term-size": {
@@ -3535,7 +3589,7 @@
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "requires": {
-        "execa": "0.7.0"
+        "execa": "^0.7.0"
       }
     },
     "through": {
@@ -3555,7 +3609,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3564,7 +3618,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -3575,10 +3629,10 @@
       "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "dev": true,
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "to-regex-range": {
@@ -3587,8 +3641,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
     "touch": {
@@ -3597,36 +3651,36 @@
       "integrity": "sha1-/jZfX3XsntTlaCXgu3bSSrdK+Ds=",
       "dev": true,
       "requires": {
-        "nopt": "1.0.10"
+        "nopt": "~1.0.10"
       }
     },
     "tough-cookie": {
       "version": "2.3.4",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "trim-repeated": {
       "version": "1.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.2"
       }
     },
     "tunnel": {
       "version": "0.0.5",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/tunnel/-/tunnel-0.0.5.tgz",
-      "integrity": "sha1-0VMiVHSe02Yg/NEBCGVJWh+p0K4="
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.5.tgz",
+      "integrity": "sha512-gj5sdqherx4VZKMcBA4vewER7zdK25Td+z1npBqpbDys4eJrLx+SlYjJvq1bDXs2irkuJM5pf8ktaEQVipkrbA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -3641,13 +3695,13 @@
       "integrity": "sha1-Il9rngM3Zj4Njnz9aG/Cg2zKznY=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9"
+        "debug": "^2.2.0"
       }
     },
     "underscore": {
       "version": "1.9.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha1-BtzjSg5op7q8KbNluOdLiSUgOWE="
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
     },
     "union-value": {
       "version": "1.0.0",
@@ -3655,10 +3709,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -3667,7 +3721,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "set-value": {
@@ -3676,10 +3730,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
@@ -3690,13 +3744,13 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
-        "crypto-random-string": "1.0.0"
+        "crypto-random-string": "^1.0.0"
       }
     },
     "universalify": {
       "version": "0.1.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY="
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unset-value": {
       "version": "1.0.0",
@@ -3704,8 +3758,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -3714,9 +3768,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -3756,16 +3810,16 @@
       "integrity": "sha1-0HRFk+E/Fh5AassdlAi3LK0Ir/Y=",
       "dev": true,
       "requires": {
-        "boxen": "1.3.0",
-        "chalk": "2.4.1",
-        "configstore": "3.1.2",
-        "import-lazy": "2.1.0",
-        "is-ci": "1.2.0",
-        "is-installed-globally": "0.1.0",
-        "is-npm": "1.0.0",
-        "latest-version": "3.1.0",
-        "semver-diff": "2.1.0",
-        "xdg-basedir": "3.0.0"
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^1.0.10",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "urix": {
@@ -3776,7 +3830,7 @@
     },
     "url": {
       "version": "0.11.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/url/-/url-0.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "requires": {
         "punycode": "1.3.2",
@@ -3785,18 +3839,18 @@
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
-          "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/punycode/-/punycode-1.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
     },
     "url-parse": {
       "version": "1.4.3",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/url-parse/-/url-parse-1.4.3.tgz",
-      "integrity": "sha1-v67kVciJAjIZ11fgRfpqaE7DbBU=",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+      "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
       "requires": {
-        "querystringify": "2.0.0",
-        "requires-port": "1.0.0"
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
       }
     },
     "url-parse-lax": {
@@ -3805,7 +3859,7 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
       }
     },
     "use": {
@@ -3816,7 +3870,7 @@
     },
     "util": {
       "version": "0.10.3",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/util/-/util-0.10.3.tgz",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "requires": {
         "inherits": "2.0.1"
@@ -3860,9 +3914,9 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "wbuf": {
@@ -3870,7 +3924,7 @@
       "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/wbuf/-/wbuf-1.7.3.tgz",
       "integrity": "sha1-wdjRSTFtPqhShIiVy2oL/oh7h98=",
       "requires": {
-        "minimalistic-assert": "1.0.1"
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "which": {
@@ -3879,7 +3933,7 @@
       "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "widest-line": {
@@ -3888,7 +3942,7 @@
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       }
     },
     "wrappy": {
@@ -3902,9 +3956,9 @@
       "integrity": "sha1-H/YVdcLipOjlENb6TiQ8zhg5mas=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "xdg-basedir": {
@@ -3915,17 +3969,17 @@
     },
     "xmldom": {
       "version": "0.1.27",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/xmldom/-/xmldom-0.1.27.tgz",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
     },
     "xpath.js": {
       "version": "1.1.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/xpath.js/-/xpath.js-1.1.0.tgz",
-      "integrity": "sha1-OBakTtS7NSCRCD0AKjg91RBKX/E="
+      "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
+      "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
     },
     "xtend": {
       "version": "4.0.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/xtend/-/xtend-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yallist": {

--- a/samples/javascript_typescript/02.echobot-with-counter/package.json
+++ b/samples/javascript_typescript/02.echobot-with-counter/package.json
@@ -11,8 +11,8 @@
   "author": "Microsoft",
   "license": "MIT",
   "dependencies": {
-    "botbuilder": "^4.0.5",
-    "botframework-config": "^4.0.5",
+    "botbuilder": "^4.0.6",
+    "botframework-config": "^4.0.6",
     "dotenv": "^6.0.0",
     "restify": "^6.3.4"
   },

--- a/samples/javascript_typescript/11.qnamaker/package-lock.json
+++ b/samples/javascript_typescript/11.qnamaker/package-lock.json
@@ -1049,14 +1049,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
-    },
     "es6-denodeify": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-denodeify/-/es6-denodeify-0.1.5.tgz",
@@ -1304,25 +1296,6 @@
       "requires": {
         "es6-denodeify": "^0.1.1",
         "tough-cookie": "^2.3.1"
-      }
-    },
-    "fetch-ponyfill": {
-      "version": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
-      "from": "github:amarzavery/fetch-ponyfill#master",
-      "requires": {
-        "fetch-cookie": "~0.6.0",
-        "node-fetch": "~1.7.1"
-      },
-      "dependencies": {
-        "fetch-cookie": {
-          "version": "0.6.0",
-          "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/fetch-cookie/-/fetch-cookie-0.6.0.tgz",
-          "integrity": "sha1-T+xOQIzAAH9sBOVTYYr0s97jf2k=",
-          "requires": {
-            "es6-denodeify": "^0.1.1",
-            "tough-cookie": "^2.3.1"
-          }
-        }
       }
     },
     "filename-reserved-regex": {
@@ -2857,7 +2830,6 @@
         "@types/node-fetch": "^1.6.7",
         "@types/uuid": "^3.4.3",
         "fetch-cookie": "^0.7.0",
-        "fetch-ponyfill": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
         "form-data": "^2.3.2",
         "is-buffer": "^2.0.0",
         "is-stream": "^1.1.0",
@@ -2866,6 +2838,25 @@
         "uuid": "^3.2.1"
       },
       "dependencies": {
+        "fetch-ponyfill": {
+          "version": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
+          "from": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
+          "requires": {
+            "fetch-cookie": "~0.6.0",
+            "node-fetch": "~1.7.1"
+          },
+          "dependencies": {
+            "fetch-cookie": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-0.6.0.tgz",
+              "integrity": "sha1-T+xOQIzAAH9sBOVTYYr0s97jf2k=",
+              "requires": {
+                "es6-denodeify": "^0.1.1",
+                "tough-cookie": "^2.3.1"
+              }
+            }
+          }
+        },
         "is-buffer": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
@@ -2975,15 +2966,6 @@
         "propagate": "^1.0.0",
         "qs": "^6.5.1",
         "semver": "^5.5.0"
-      }
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
       }
     },
     "nodemon": {

--- a/samples/javascript_typescript/13.basic-bot/package-lock.json
+++ b/samples/javascript_typescript/13.basic-bot/package-lock.json
@@ -10,7 +10,7 @@
             "integrity": "sha1-BuKrGb21NThVWaq7W6WXKUgoAPg=",
             "dev": true,
             "requires": {
-                "@babel/highlight": "7.0.0"
+                "@babel/highlight": "^7.0.0"
             }
         },
         "@babel/highlight": {
@@ -19,166 +19,166 @@
             "integrity": "sha1-9xDDjI1Fjm3ZogGvtjf8t4HOmeQ=",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "esutils": "2.0.2",
-                "js-tokens": "4.0.0"
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
             }
         },
         "@microsoft/recognizers-text": {
             "version": "1.0.1",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text/-/@microsoft/recognizers-text-1.0.1.tgz",
-            "integrity": "sha1-RmCYcq7n3tZS3bnezonrZNKjsE0="
+            "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text/-/recognizers-text-1.0.1.tgz",
+            "integrity": "sha512-BZbI6YiLrWRd/jAYgSpLQ+Otl3WYMctefh7Myw6jqMdHhADaj5WpwOdf+yfJHZHOJWQh7lK2v50R6Y0g3TJ18w=="
         },
         "@microsoft/recognizers-text-choice": {
             "version": "1.0.1",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-choice/-/@microsoft/recognizers-text-choice-1.0.1.tgz",
-            "integrity": "sha1-FbNwqko6lIpP2GWTI48B+HJvAWU=",
+            "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-choice/-/recognizers-text-choice-1.0.1.tgz",
+            "integrity": "sha512-2Vy2b4YVysm+3DnZObTfco2KSbGzgPKKI4TxrcY0tEsLJDfLxj9Nyxm2CJ6kd2X1MFlc53UB5ZWRhO32V2FAmw==",
             "requires": {
-                "@microsoft/recognizers-text": "1.0.1",
-                "grapheme-splitter": "1.0.4"
+                "@microsoft/recognizers-text": "~1.0.1",
+                "grapheme-splitter": "^1.0.2"
             }
         },
         "@microsoft/recognizers-text-date-time": {
             "version": "1.0.1",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-date-time/-/@microsoft/recognizers-text-date-time-1.0.1.tgz",
-            "integrity": "sha1-OUF8iIlNF5Qc7EzwQ9EuUsko/ng=",
+            "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-date-time/-/recognizers-text-date-time-1.0.1.tgz",
+            "integrity": "sha512-Tb8j+nDYSMe65pQhXh7hlm8uibfqliwbsUx6MY3g6ZlZnTzhq9cnzHYY1LILkJqlY5QtaGlUXr4BvW+a4SD8ew==",
             "requires": {
-                "@microsoft/recognizers-text": "1.0.1",
-                "@microsoft/recognizers-text-number": "1.0.1",
-                "@microsoft/recognizers-text-number-with-unit": "1.0.1",
-                "lodash.isequal": "4.5.0",
-                "lodash.tonumber": "4.0.3"
+                "@microsoft/recognizers-text": "~1.0.1",
+                "@microsoft/recognizers-text-number": "~1.0.1",
+                "@microsoft/recognizers-text-number-with-unit": "~1.0.1",
+                "lodash.isequal": "^4.5.0",
+                "lodash.tonumber": "^4.0.3"
             }
         },
         "@microsoft/recognizers-text-number": {
             "version": "1.0.1",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-number/-/@microsoft/recognizers-text-number-1.0.1.tgz",
-            "integrity": "sha1-q8yWhZCBVOW7lcZAgzhufukVkvY=",
+            "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number/-/recognizers-text-number-1.0.1.tgz",
+            "integrity": "sha512-eMhzRfWmzGaGdeBi+1vTtJ6AtTqhHNetJ+Rdt6isiv+R3+i18bzR2YzIOzIdHRhnApf0mbJG3wMEbWdWQBhvyg==",
             "requires": {
-                "@microsoft/recognizers-text": "1.0.1",
-                "bignumber.js": "4.1.0",
-                "lodash.escaperegexp": "4.1.2",
-                "lodash.sortby": "4.7.0",
-                "lodash.trimend": "4.5.1",
-                "xregexp": "3.2.0"
+                "@microsoft/recognizers-text": "~1.0.1",
+                "bignumber.js": "^4.1.0",
+                "lodash.escaperegexp": "^4.1.2",
+                "lodash.sortby": "^4.7.0",
+                "lodash.trimend": "^4.5.1",
+                "xregexp": "^3.2.0"
             }
         },
         "@microsoft/recognizers-text-number-with-unit": {
             "version": "1.0.1",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-number-with-unit/-/@microsoft/recognizers-text-number-with-unit-1.0.1.tgz",
-            "integrity": "sha1-yLUCNE64dBsF2a5ijT5GBvu20eE=",
+            "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number-with-unit/-/recognizers-text-number-with-unit-1.0.1.tgz",
+            "integrity": "sha512-g4Tum3sxkbeI52eYQX+h8t97Ww1TJi6M+bIpjB4/go7trmq/w005oFxnARmrJQNMQUukEHeQ0GGqR/uMe75SzA==",
             "requires": {
-                "@microsoft/recognizers-text": "1.0.1",
-                "@microsoft/recognizers-text-number": "1.0.1",
-                "lodash.escaperegexp": "4.1.2",
-                "lodash.last": "3.0.0",
-                "lodash.max": "4.0.1"
+                "@microsoft/recognizers-text": "~1.0.1",
+                "@microsoft/recognizers-text-number": "~1.0.1",
+                "lodash.escaperegexp": "^4.1.2",
+                "lodash.last": "^3.0.0",
+                "lodash.max": "^4.0.1"
             }
         },
         "@microsoft/recognizers-text-sequence": {
             "version": "1.0.1",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-sequence/-/@microsoft/recognizers-text-sequence-1.0.1.tgz",
-            "integrity": "sha1-lJ1MypzTenD2XlAYfMbr2L0SBRY=",
+            "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-sequence/-/recognizers-text-sequence-1.0.1.tgz",
+            "integrity": "sha512-Dim6fpiW6xupx8aI4GLAqEunDkjxNZ5Ax9IjVVWhD9Qo9gG8EUQkt5l49zT2E5c5ZQAfU62XI7+KWll8Ymtf/g==",
             "requires": {
-                "@microsoft/recognizers-text": "1.0.1",
-                "grapheme-splitter": "1.0.4"
+                "@microsoft/recognizers-text": "~1.0.1",
+                "grapheme-splitter": "^1.0.2"
             }
         },
         "@microsoft/recognizers-text-suite": {
             "version": "1.0.1",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-suite/-/@microsoft/recognizers-text-suite-1.0.1.tgz",
-            "integrity": "sha1-DaE/arTvE/sbvv76ms72AR273cE=",
+            "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-suite/-/recognizers-text-suite-1.0.1.tgz",
+            "integrity": "sha512-7v1K1UjrLHSSKIcha8Dj0XyymkfyJ3BjXcWkC5YxN68XXzwM7gsJoHMBRkA8wPL0DRkRnu9dTTtMGTsBFvpWYw==",
             "requires": {
-                "@microsoft/recognizers-text": "1.0.1",
-                "@microsoft/recognizers-text-choice": "1.0.1",
-                "@microsoft/recognizers-text-date-time": "1.0.1",
-                "@microsoft/recognizers-text-number": "1.0.1",
-                "@microsoft/recognizers-text-number-with-unit": "1.0.1",
-                "@microsoft/recognizers-text-sequence": "1.0.1"
+                "@microsoft/recognizers-text": "~1.0.1",
+                "@microsoft/recognizers-text-choice": "~1.0.1",
+                "@microsoft/recognizers-text-date-time": "~1.0.1",
+                "@microsoft/recognizers-text-number": "~1.0.1",
+                "@microsoft/recognizers-text-number-with-unit": "~1.0.1",
+                "@microsoft/recognizers-text-sequence": "~1.0.1"
             }
         },
         "@types/caseless": {
             "version": "0.12.1",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/caseless/-/@types/caseless-0.12.1.tgz",
-            "integrity": "sha1-l5TGnIOF0BkqzEcaVA0fjg0WIYo="
+            "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
+            "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A=="
         },
         "@types/filenamify": {
             "version": "2.0.1",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/filenamify/-/@types/filenamify-2.0.1.tgz",
-            "integrity": "sha1-KnWtJm9PuC4RPvf9xS4DVcJ8Kz0="
+            "resolved": "https://registry.npmjs.org/@types/filenamify/-/filenamify-2.0.1.tgz",
+            "integrity": "sha512-QpmNRLMBSQtvd1eV8dodwiUCtSJRhg0EhV+9Xwpch1DhiXPh75qx6aRxVfHvzhQdPzrFJx9v+hpiC0FIVyPQOA=="
         },
         "@types/form-data": {
             "version": "2.2.1",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/form-data/-/@types/form-data-2.2.1.tgz",
-            "integrity": "sha1-7is7jqoRwJOCiZU2BrdFtzjFSx4=",
+            "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
+            "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
             "requires": {
-                "@types/node": "9.6.31"
+                "@types/node": "*"
             }
         },
         "@types/html-entities": {
             "version": "1.2.16",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/html-entities/-/@types/html-entities-1.2.16.tgz",
-            "integrity": "sha1-TR/iCMTDNyesRlfm9dkr/lJCcCM="
+            "resolved": "https://registry.npmjs.org/@types/html-entities/-/html-entities-1.2.16.tgz",
+            "integrity": "sha512-CI6fHfFvkTtX2Nlr4JBA6yIFTfA4p9E6w9ky64X6PrfXiTALhUh/SOa+Sxvv2p87m+y5AH71lAUrx0lSYx4hKQ=="
         },
         "@types/is-stream": {
             "version": "1.1.0",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/is-stream/-/@types/is-stream-1.1.0.tgz",
-            "integrity": "sha1-uE17sgeiEPKvm+1DHcD76cQUO+E=",
+            "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
             "requires": {
-                "@types/node": "9.6.31"
+                "@types/node": "*"
             }
         },
         "@types/jsonwebtoken": {
             "version": "7.2.5",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/jsonwebtoken/-/@types/jsonwebtoken-7.2.5.tgz",
-            "integrity": "sha1-QTFZ1XDsRfw+fafqP3vKb7kwDnI=",
+            "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.5.tgz",
+            "integrity": "sha512-8CIcK1Vzq4w5TJyJYkLVhqASmCo1FSO1XIPQM1qv+Xo2nnb9RoRHxx8pkIzSZ4Tm9r3V4ZyFbF/fBewNPdclwA==",
             "requires": {
-                "@types/node": "9.6.31"
+                "@types/node": "*"
             }
         },
         "@types/node": {
-            "version": "9.6.31",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/node/-/@types/node-9.6.31.tgz",
-            "integrity": "sha1-TRcimH+NgItMGU3OuMITvZLwKOU="
+            "version": "9.6.32",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.32.tgz",
+            "integrity": "sha512-5+L3wQ+FHoQ589EaH6rYICleuj8gnunq+1CJkM9fxklirErIOv+kxm3s/vecYnpJOYnFowE5uUizcb3hgjHUug=="
         },
         "@types/node-fetch": {
             "version": "1.6.9",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/node-fetch/-/@types/node-fetch-1.6.9.tgz",
-            "integrity": "sha1-p1D7D0zylgv3K0YuTIaQgCLdacU=",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-1.6.9.tgz",
+            "integrity": "sha512-n2r6WLoY7+uuPT7pnEtKJCmPUGyJ+cbyBR8Avnu4+m1nzz7DwBVuyIvvlBzCZ/nrpC7rIgb3D6pNavL7rFEa9g==",
             "requires": {
-                "@types/node": "9.6.31"
+                "@types/node": "*"
             }
         },
         "@types/request": {
             "version": "2.47.1",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/request/-/@types/request-2.47.1.tgz",
-            "integrity": "sha1-JUENOvvawEyRqUrZ78mCQQBzWCQ=",
+            "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.1.tgz",
+            "integrity": "sha512-TV3XLvDjQbIeVxJ1Z3oCTDk/KuYwwcNKVwz2YaT0F5u86Prgc4syDAp6P96rkTQQ4bIdh+VswQIC9zS6NjY7/g==",
             "requires": {
-                "@types/caseless": "0.12.1",
-                "@types/form-data": "2.2.1",
-                "@types/node": "9.6.31",
-                "@types/tough-cookie": "2.3.3"
+                "@types/caseless": "*",
+                "@types/form-data": "*",
+                "@types/node": "*",
+                "@types/tough-cookie": "*"
             }
         },
         "@types/request-promise-native": {
             "version": "1.0.15",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/request-promise-native/-/@types/request-promise-native-1.0.15.tgz",
-            "integrity": "sha1-WzNp/Gqvnn/ve2toiu9MV1liPhY=",
+            "resolved": "https://registry.npmjs.org/@types/request-promise-native/-/request-promise-native-1.0.15.tgz",
+            "integrity": "sha512-uYPjTChD9TpjlvbBjNpZfNc64TBejBS52u7pbxhQLnlxw+5Em7wLb6DU2wdJVhJ2Mou7v50N0qgL4Gia5mmRYg==",
             "requires": {
-                "@types/request": "2.47.1"
+                "@types/request": "*"
             }
         },
         "@types/tough-cookie": {
             "version": "2.3.3",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/tough-cookie/-/@types/tough-cookie-2.3.3.tgz",
-            "integrity": "sha1-fyJtZ9ZU7JBw51X0ba6/AUYo6dk="
+            "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.3.tgz",
+            "integrity": "sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ=="
         },
         "@types/uuid": {
             "version": "3.4.4",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/uuid/-/@types/uuid-3.4.4.tgz",
-            "integrity": "sha1-evaTYPpl7w3stB/RUL9MpcDO/fU=",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.4.tgz",
+            "integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
             "requires": {
-                "@types/node": "9.6.31"
+                "@types/node": "*"
             }
         },
         "abbrev": {
@@ -199,7 +199,7 @@
             "integrity": "sha1-6OQeSOov4MiWdAYQq2pP/YrdIl4=",
             "dev": true,
             "requires": {
-                "acorn": "5.7.3"
+                "acorn": "^5.0.3"
             }
         },
         "adal-node": {
@@ -207,21 +207,21 @@
             "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.1.28.tgz",
             "integrity": "sha1-RoxLs+u9lrEnBmn0ucuk4AZepIU=",
             "requires": {
-                "@types/node": "8.10.29",
-                "async": "2.6.0",
-                "date-utils": "1.2.21",
-                "jws": "3.1.5",
-                "request": "2.83.0",
-                "underscore": "1.9.1",
-                "uuid": "3.3.2",
-                "xmldom": "0.1.27",
-                "xpath.js": "1.1.0"
+                "@types/node": "^8.0.47",
+                "async": ">=0.6.0",
+                "date-utils": "*",
+                "jws": "3.x.x",
+                "request": ">= 2.52.0",
+                "underscore": ">= 1.3.1",
+                "uuid": "^3.1.0",
+                "xmldom": ">= 0.1.x",
+                "xpath.js": "~1.1.0"
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "8.10.29",
-                    "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/node/-/@types/node-8.10.29.tgz",
-                    "integrity": "sha1-s6E7WN17BoK/G0ICK+9KWpcY9oc="
+                    "version": "8.10.30",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.30.tgz",
+                    "integrity": "sha512-Le8HGMI5gjFSBqcCuKP/wfHC19oURzkU2D+ERIescUoJd+CmNEMYBib9LQ4zj1HHEZOJQWhw2ZTnbD8weASh/Q=="
                 }
             }
         },
@@ -230,10 +230,10 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
         "ajv-keywords": {
@@ -248,7 +248,7 @@
             "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
             "dev": true,
             "requires": {
-                "string-width": "2.1.1"
+                "string-width": "^2.0.0"
             }
         },
         "ansi-escapes": {
@@ -269,7 +269,7 @@
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dev": true,
             "requires": {
-                "color-convert": "1.9.2"
+                "color-convert": "^1.9.0"
             }
         },
         "anymatch": {
@@ -278,8 +278,8 @@
             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
             "dev": true,
             "requires": {
-                "micromatch": "3.1.10",
-                "normalize-path": "2.1.1"
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
             }
         },
         "argparse": {
@@ -288,7 +288,7 @@
             "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
         "arr-diff": {
@@ -315,7 +315,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -341,7 +341,7 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/asn1/-/asn1-0.2.4.tgz",
             "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": "~2.1.0"
             }
         },
         "assert": {
@@ -359,8 +359,8 @@
         },
         "assertion-error": {
             "version": "1.1.0",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/assertion-error/-/assertion-error-1.1.0.tgz",
-            "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs="
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
         },
         "assign-symbols": {
             "version": "1.0.0",
@@ -370,10 +370,10 @@
         },
         "async": {
             "version": "2.6.0",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/async/-/async-2.6.0.tgz",
-            "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+            "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
             "requires": {
-                "lodash": "4.17.10"
+                "lodash": "^4.14.0"
             }
         },
         "async-each": {
@@ -387,7 +387,7 @@
             "resolved": "https://registry.npmjs.org/async-file/-/async-file-2.0.2.tgz",
             "integrity": "sha1-Aq0HhWrDcX6DayCuxaTP4AxG3yM=",
             "requires": {
-                "rimraf": "2.6.2"
+                "rimraf": "^2.5.2"
             }
         },
         "asynckit": {
@@ -408,15 +408,15 @@
         },
         "aws4": {
             "version": "1.8.0",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/aws4/-/aws4-1.8.0.tgz",
-            "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8="
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
         },
         "azure-cognitiveservices-luis-runtime": {
             "version": "1.0.0",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/azure-cognitiveservices-luis-runtime/-/azure-cognitiveservices-luis-runtime-1.0.0.tgz",
-            "integrity": "sha1-MyZRn9Xw8Sy/0xPSTH9YIWxNbgg=",
+            "resolved": "https://registry.npmjs.org/azure-cognitiveservices-luis-runtime/-/azure-cognitiveservices-luis-runtime-1.0.0.tgz",
+            "integrity": "sha512-UYqHe4efmO0QhBuJ+T3PM/Vtt+zy+wWNZBDYyKzfqnQ6eSPXEPC0eDrw0exT7bzETyg/TqTeksT5bEsRy5Rg1w==",
             "requires": {
-                "ms-rest": "2.3.6"
+                "ms-rest": "^2.3.3"
             }
         },
         "balanced-match": {
@@ -430,13 +430,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "1.0.1",
-                "class-utils": "0.3.6",
-                "component-emitter": "1.2.1",
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "mixin-deep": "1.3.1",
-                "pascalcase": "0.1.1"
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
             }
         },
         "base64url": {
@@ -450,13 +450,13 @@
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "bignumber.js": {
             "version": "4.1.0",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/bignumber.js/-/bignumber.js-4.1.0.tgz",
-            "integrity": "sha1-228UBnwUC9RmJIFaeRbJLZtsJLE="
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
+            "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
         },
         "binary-extensions": {
             "version": "1.11.0",
@@ -469,100 +469,100 @@
             "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
             "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
             "requires": {
-                "hoek": "4.2.1"
+                "hoek": "4.x.x"
             }
         },
         "botbuilder": {
-            "version": "4.0.5",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/botbuilder/-/botbuilder-4.0.5.tgz",
-            "integrity": "sha1-R4Urtlix69SwcALihOtdj8OAn+4=",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.0.6.tgz",
+            "integrity": "sha512-QvtaoCCfUUsWkWtbVBOSdmblPy7g/SjSRBpkcR9i2us7dgJvhlM0alhta3OvnUSGyMPrpV7k5aBCErtubxzdng==",
             "requires": {
-                "@types/filenamify": "2.0.1",
-                "@types/node": "9.6.31",
-                "async-file": "2.0.2",
-                "botbuilder-core": "4.0.5",
-                "botframework-connector": "4.0.5",
-                "filenamify": "2.1.0",
-                "rimraf": "2.6.2"
+                "@types/filenamify": "^2.0.1",
+                "@types/node": "^9.3.0",
+                "async-file": "^2.0.2",
+                "botbuilder-core": "^4.0.6",
+                "botframework-connector": "^4.0.6",
+                "filenamify": "^2.0.0",
+                "rimraf": "^2.6.2"
             }
         },
         "botbuilder-ai": {
-            "version": "4.0.5",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/botbuilder-ai/-/botbuilder-ai-4.0.5.tgz",
-            "integrity": "sha1-1y2TzH2qU8KQDPsk8E+KwiyA3vs=",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/botbuilder-ai/-/botbuilder-ai-4.0.6.tgz",
+            "integrity": "sha512-jsb89YVhsLAI4FToXmJy8NgqxjEbuzCuf4Zha4V7QC9Fe4wSFUNNRMb1S66iBdNy1oF8RLEXvUmrMqQ+n5sXRA==",
             "requires": {
                 "@microsoft/recognizers-text-date-time": "1.0.1",
-                "@types/html-entities": "1.2.16",
-                "@types/node": "9.6.31",
-                "@types/request-promise-native": "1.0.15",
-                "azure-cognitiveservices-luis-runtime": "1.0.0",
-                "botbuilder": "4.0.5",
-                "html-entities": "1.2.1",
-                "moment": "2.22.2",
-                "ms-rest": "2.3.6",
-                "mstranslator": "3.0.0",
-                "nock": "9.6.1",
+                "@types/html-entities": "^1.2.16",
+                "@types/node": "^9.3.0",
+                "@types/request-promise-native": "^1.0.10",
+                "azure-cognitiveservices-luis-runtime": "^1.0.0",
+                "botbuilder": "^4.0.6",
+                "html-entities": "^1.2.1",
+                "moment": "^2.20.1",
+                "ms-rest": "^2.3.6",
+                "mstranslator": "^3.0.0",
+                "nock": "^9.6.1",
                 "request": "2.83.0",
                 "request-promise-native": "1.0.5"
             }
         },
         "botbuilder-core": {
-            "version": "4.0.5",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/botbuilder-core/-/botbuilder-core-4.0.5.tgz",
-            "integrity": "sha1-hJtUEAP8CzvqJg9ImyK60udpuXA=",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.0.6.tgz",
+            "integrity": "sha512-23OE1MOQStQDIL2379O9gMgq/t4LcgXzr9+odFTK8WYpl9FSTelwntb8PIeW4fToqV/palQbmCDLNrFtQ/X7ug==",
             "requires": {
-                "assert": "1.4.1",
-                "botframework-schema": "4.0.5"
+                "assert": "^1.4.1",
+                "botframework-schema": "^4.0.6"
             }
         },
         "botbuilder-dialogs": {
-            "version": "4.0.5",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/botbuilder-dialogs/-/botbuilder-dialogs-4.0.5.tgz",
-            "integrity": "sha1-fdywbtosGF6gQ2GigTZqw6A9/Us=",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/botbuilder-dialogs/-/botbuilder-dialogs-4.0.6.tgz",
+            "integrity": "sha512-eTK15Dw4jo4FBT1AACMkDfwUhKoWssLmYSfqMbMy1zJIOSFfrWKaoTr9JUpygho0naPZPXEZGo3ymAv/jQGw9g==",
             "requires": {
                 "@microsoft/recognizers-text-choice": "1.0.1",
                 "@microsoft/recognizers-text-date-time": "1.0.1",
                 "@microsoft/recognizers-text-number": "1.0.1",
                 "@microsoft/recognizers-text-suite": "1.0.1",
-                "@types/node": "9.6.31",
-                "botbuilder-core": "4.0.5"
+                "@types/node": "^9.3.0",
+                "botbuilder-core": "^4.0.6"
             }
         },
         "botframework-config": {
-            "version": "4.0.5",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/botframework-config/-/botframework-config-4.0.5.tgz",
-            "integrity": "sha1-SCg4pHV8nwf5BoPhh0/fDnk4J/Q=",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/botframework-config/-/botframework-config-4.0.6.tgz",
+            "integrity": "sha512-0yHnVWIb1xXBC+6gwAEggp8T30xtjJ4al1i2axNyOr6/Tov6LbCVbeO/Ysdrp27F7iu6hSrO7OwvDyHzwxN+7g==",
             "requires": {
-                "fs-extra": "7.0.0",
-                "process": "0.11.10",
-                "read-text-file": "1.1.0",
-                "url": "0.11.0",
-                "uuid": "3.3.2"
+                "fs-extra": "^7.0.0",
+                "process": "^0.11.10",
+                "read-text-file": "^1.1.0",
+                "url": "^0.11.0",
+                "uuid": "^3.3.2"
             }
         },
         "botframework-connector": {
-            "version": "4.0.5",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/botframework-connector/-/botframework-connector-4.0.5.tgz",
-            "integrity": "sha1-AyG6qIoaTt0tSV6z+HABySiUd3s=",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.0.6.tgz",
+            "integrity": "sha512-0AOJ91u9+9yJo68VNeeplM+ivWoQgfMswc5EE0h1+r2GYlqMNMDoWaLxKnD1ZG4jUdCVpUXwzpYvaWFSBFa9AQ==",
             "requires": {
                 "@types/jsonwebtoken": "7.2.5",
-                "@types/node": "9.6.31",
-                "@types/request": "2.47.1",
-                "base64url": "2.0.0",
-                "botframework-schema": "4.0.5",
+                "@types/node": "^9.3.0",
+                "@types/request": "^2.47.0",
+                "base64url": "^2.0.0",
+                "botframework-schema": "^4.0.6",
                 "jsonwebtoken": "8.0.1",
-                "ms-rest-azure": "2.5.7",
+                "ms-rest-azure": "^2.5.0",
                 "ms-rest-js": "0.2.8",
                 "request": "2.83.0",
-                "rsa-pem-from-mod-exp": "0.8.4"
+                "rsa-pem-from-mod-exp": "^0.8.4"
             }
         },
         "botframework-schema": {
-            "version": "4.0.5",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/botframework-schema/-/botframework-schema-4.0.5.tgz",
-            "integrity": "sha1-080u8EfqM7PLHlfFMPP9E+JbGQ4=",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.0.6.tgz",
+            "integrity": "sha512-FoOSWio0ZkpE3nCGsv5Yz5GbmT29uuFBwTsK9t0+MTv7pAmM+MDrqG3A1Ed99N0oQXr59yacEvx5Zdaeb6Xw5Q==",
             "requires": {
-                "@types/node": "9.6.31"
+                "@types/node": "^9.3.0"
             }
         },
         "boxen": {
@@ -571,13 +571,13 @@
             "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
             "dev": true,
             "requires": {
-                "ansi-align": "2.0.0",
-                "camelcase": "4.1.0",
-                "chalk": "2.4.1",
-                "cli-boxes": "1.0.0",
-                "string-width": "2.1.1",
-                "term-size": "1.2.0",
-                "widest-line": "2.0.0"
+                "ansi-align": "^2.0.0",
+                "camelcase": "^4.0.0",
+                "chalk": "^2.0.1",
+                "cli-boxes": "^1.0.0",
+                "string-width": "^2.0.0",
+                "term-size": "^1.2.0",
+                "widest-line": "^2.0.0"
             }
         },
         "brace-expansion": {
@@ -585,7 +585,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -595,16 +595,16 @@
             "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "array-unique": "0.3.2",
-                "extend-shallow": "2.0.1",
-                "fill-range": "4.0.0",
-                "isobject": "3.0.1",
-                "repeat-element": "1.1.3",
-                "snapdragon": "0.8.2",
-                "snapdragon-node": "2.1.1",
-                "split-string": "3.1.0",
-                "to-regex": "3.0.2"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -613,7 +613,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -634,10 +634,10 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/bunyan/-/bunyan-1.8.12.tgz",
             "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
             "requires": {
-                "dtrace-provider": "0.8.7",
-                "moment": "2.22.2",
-                "mv": "2.1.1",
-                "safe-json-stringify": "1.2.0"
+                "dtrace-provider": "~0.8",
+                "moment": "^2.10.6",
+                "mv": "~2",
+                "safe-json-stringify": "~1"
             }
         },
         "cache-base": {
@@ -646,15 +646,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "1.0.0",
-                "component-emitter": "1.2.1",
-                "get-value": "2.0.6",
-                "has-value": "1.0.0",
-                "isobject": "3.0.1",
-                "set-value": "2.0.0",
-                "to-object-path": "0.3.0",
-                "union-value": "1.0.0",
-                "unset-value": "1.0.0"
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
             }
         },
         "caller-path": {
@@ -663,7 +663,7 @@
             "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
             "dev": true,
             "requires": {
-                "callsites": "0.2.0"
+                "callsites": "^0.2.0"
             }
         },
         "callsites": {
@@ -690,16 +690,16 @@
             "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "chai": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
-            "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+            "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
             "requires": {
-                "assertion-error": "1.1.0",
-                "check-error": "1.0.2",
-                "deep-eql": "3.0.1",
-                "get-func-name": "2.0.0",
-                "pathval": "1.1.0",
-                "type-detect": "4.0.8"
+                "assertion-error": "^1.1.0",
+                "check-error": "^1.0.2",
+                "deep-eql": "^3.0.1",
+                "get-func-name": "^2.0.0",
+                "pathval": "^1.1.0",
+                "type-detect": "^4.0.5"
             }
         },
         "chalk": {
@@ -708,9 +708,9 @@
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.5.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
             }
         },
         "chardet": {
@@ -730,19 +730,19 @@
             "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
             "dev": true,
             "requires": {
-                "anymatch": "2.0.0",
-                "async-each": "1.0.1",
-                "braces": "2.3.2",
-                "fsevents": "1.2.4",
-                "glob-parent": "3.1.0",
-                "inherits": "2.0.1",
-                "is-binary-path": "1.0.1",
-                "is-glob": "4.0.0",
-                "lodash.debounce": "4.0.8",
-                "normalize-path": "2.1.1",
-                "path-is-absolute": "1.0.1",
-                "readdirp": "2.1.0",
-                "upath": "1.1.0"
+                "anymatch": "^2.0.0",
+                "async-each": "^1.0.0",
+                "braces": "^2.3.0",
+                "fsevents": "^1.2.2",
+                "glob-parent": "^3.1.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^4.0.0",
+                "lodash.debounce": "^4.0.8",
+                "normalize-path": "^2.1.1",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0",
+                "upath": "^1.0.5"
             }
         },
         "ci-info": {
@@ -763,10 +763,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "static-extend": "0.1.2"
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -775,7 +775,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -784,7 +784,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -793,7 +793,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -804,7 +804,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -813,7 +813,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -824,9 +824,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -849,7 +849,7 @@
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "dev": true,
             "requires": {
-                "restore-cursor": "2.0.0"
+                "restore-cursor": "^2.0.0"
             }
         },
         "cli-width": {
@@ -863,8 +863,8 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/clone-regexp/-/clone-regexp-1.0.1.tgz",
             "integrity": "sha1-BRgFzTMXM3XYIRj8CRhgbaOf1g8=",
             "requires": {
-                "is-regexp": "1.0.0",
-                "is-supported-regexp-flag": "1.0.1"
+                "is-regexp": "^1.0.0",
+                "is-supported-regexp-flag": "^1.0.0"
             }
         },
         "co": {
@@ -878,8 +878,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "1.0.0",
-                "object-visit": "1.0.1"
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
             }
         },
         "color-convert": {
@@ -899,10 +899,10 @@
         },
         "combined-stream": {
             "version": "1.0.7",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/combined-stream/-/combined-stream-1.0.7.tgz",
-            "integrity": "sha1-LR0kMXr7ir6V1tLAsHtXgTU52Cg=",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+            "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "component-emitter": {
@@ -922,12 +922,12 @@
             "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
             "dev": true,
             "requires": {
-                "dot-prop": "4.2.0",
-                "graceful-fs": "4.1.11",
-                "make-dir": "1.3.0",
-                "unique-string": "1.0.0",
-                "write-file-atomic": "2.3.0",
-                "xdg-basedir": "3.0.0"
+                "dot-prop": "^4.1.0",
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^1.0.0",
+                "unique-string": "^1.0.0",
+                "write-file-atomic": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
             }
         },
         "contains-path": {
@@ -953,7 +953,7 @@
             "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
             "dev": true,
             "requires": {
-                "capture-stack-trace": "1.0.0"
+                "capture-stack-trace": "^1.0.0"
             }
         },
         "cross-spawn": {
@@ -962,9 +962,9 @@
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "dev": true,
             "requires": {
-                "lru-cache": "4.1.3",
-                "shebang-command": "1.2.0",
-                "which": "1.3.1"
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
             }
         },
         "cryptiles": {
@@ -972,15 +972,15 @@
             "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
             "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
             "requires": {
-                "boom": "5.2.0"
+                "boom": "5.x.x"
             },
             "dependencies": {
                 "boom": {
                     "version": "5.2.0",
-                    "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/boom/-/boom-5.2.0.tgz",
-                    "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
+                    "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+                    "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                     "requires": {
-                        "hoek": "4.2.1"
+                        "hoek": "4.x.x"
                     }
                 }
             }
@@ -996,10 +996,10 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/csv/-/csv-1.2.1.tgz",
             "integrity": "sha1-UjHt/BxxUlEuxFeBB2p6l/9SXAw=",
             "requires": {
-                "csv-generate": "1.1.2",
-                "csv-parse": "1.3.3",
-                "csv-stringify": "1.1.2",
-                "stream-transform": "0.2.2"
+                "csv-generate": "^1.1.2",
+                "csv-parse": "^1.3.3",
+                "csv-stringify": "^1.1.2",
+                "stream-transform": "^0.2.2"
             }
         },
         "csv-generate": {
@@ -1017,7 +1017,7 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/csv-stringify/-/csv-stringify-1.1.2.tgz",
             "integrity": "sha1-d6QVJlgbzjOA8SsA18W7rHDIK1g=",
             "requires": {
-                "lodash.get": "4.4.2"
+                "lodash.get": "~4.4.2"
             }
         },
         "dashdash": {
@@ -1025,7 +1025,7 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "date-utils": {
@@ -1049,10 +1049,10 @@
         },
         "deep-eql": {
             "version": "3.0.1",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/deep-eql/-/deep-eql-3.0.1.tgz",
-            "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+            "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
             "requires": {
-                "type-detect": "4.0.8"
+                "type-detect": "^4.0.0"
             }
         },
         "deep-equal": {
@@ -1078,7 +1078,7 @@
             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
             "dev": true,
             "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
             }
         },
         "del": {
@@ -1087,13 +1087,13 @@
             "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
             "dev": true,
             "requires": {
-                "globby": "5.0.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.1",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "rimraf": "2.6.2"
+                "globby": "^5.0.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "rimraf": "^2.2.8"
             },
             "dependencies": {
                 "pify": {
@@ -1120,7 +1120,7 @@
             "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
             "dev": true,
             "requires": {
-                "esutils": "2.0.2"
+                "esutils": "^2.0.2"
             }
         },
         "dot-prop": {
@@ -1129,7 +1129,7 @@
             "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "dotenv": {
@@ -1143,7 +1143,7 @@
             "integrity": "sha1-3JObTT4GIM/gwc2APQ0tftBP/QQ=",
             "optional": true,
             "requires": {
-                "nan": "2.11.0"
+                "nan": "^2.10.0"
             }
         },
         "duplexer": {
@@ -1163,8 +1163,8 @@
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2"
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "ecdsa-sig-formatter": {
@@ -1172,15 +1172,15 @@
             "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
             "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
             }
         },
         "encoding": {
             "version": "0.1.12",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/encoding/-/encoding-0.1.12.tgz",
+            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
             "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
             "requires": {
-                "iconv-lite": "0.4.24"
+                "iconv-lite": "~0.4.13"
             }
         },
         "error-ex": {
@@ -1189,7 +1189,7 @@
             "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
             "dev": true,
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             }
         },
         "es6-denodeify": {
@@ -1213,44 +1213,44 @@
             "integrity": "sha1-tveAYEGvAfcbPxiVy7IJcepLYiM=",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0",
-                "ajv": "6.5.3",
-                "chalk": "2.4.1",
-                "cross-spawn": "6.0.5",
-                "debug": "3.1.0",
-                "doctrine": "2.1.0",
-                "eslint-scope": "4.0.0",
-                "eslint-utils": "1.3.1",
-                "eslint-visitor-keys": "1.0.0",
-                "espree": "4.0.0",
-                "esquery": "1.0.1",
-                "esutils": "2.0.2",
-                "file-entry-cache": "2.0.0",
-                "functional-red-black-tree": "1.0.1",
-                "glob": "7.1.3",
-                "globals": "11.7.0",
-                "ignore": "4.0.6",
-                "imurmurhash": "0.1.4",
-                "inquirer": "6.2.0",
-                "is-resolvable": "1.1.0",
-                "js-yaml": "3.12.0",
-                "json-stable-stringify-without-jsonify": "1.0.1",
-                "levn": "0.3.0",
-                "lodash": "4.17.10",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "natural-compare": "1.4.0",
-                "optionator": "0.8.2",
-                "path-is-inside": "1.0.2",
-                "pluralize": "7.0.0",
-                "progress": "2.0.0",
-                "regexpp": "2.0.0",
-                "require-uncached": "1.0.3",
-                "semver": "5.5.1",
-                "strip-ansi": "4.0.0",
-                "strip-json-comments": "2.0.1",
-                "table": "4.0.3",
-                "text-table": "0.2.0"
+                "@babel/code-frame": "^7.0.0",
+                "ajv": "^6.5.3",
+                "chalk": "^2.1.0",
+                "cross-spawn": "^6.0.5",
+                "debug": "^3.1.0",
+                "doctrine": "^2.1.0",
+                "eslint-scope": "^4.0.0",
+                "eslint-utils": "^1.3.1",
+                "eslint-visitor-keys": "^1.0.0",
+                "espree": "^4.0.0",
+                "esquery": "^1.0.1",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^2.0.0",
+                "functional-red-black-tree": "^1.0.1",
+                "glob": "^7.1.2",
+                "globals": "^11.7.0",
+                "ignore": "^4.0.6",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^6.1.0",
+                "is-resolvable": "^1.1.0",
+                "js-yaml": "^3.12.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.5",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "path-is-inside": "^1.0.2",
+                "pluralize": "^7.0.0",
+                "progress": "^2.0.0",
+                "regexpp": "^2.0.0",
+                "require-uncached": "^1.0.3",
+                "semver": "^5.5.1",
+                "strip-ansi": "^4.0.0",
+                "strip-json-comments": "^2.0.1",
+                "table": "^4.0.3",
+                "text-table": "^0.2.0"
             },
             "dependencies": {
                 "ajv": {
@@ -1259,10 +1259,10 @@
                     "integrity": "sha1-caVp0Yns9PTzISJP7LFm8HHdkPk=",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "2.0.1",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.4.1",
-                        "uri-js": "4.2.2"
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
                     }
                 },
                 "cross-spawn": {
@@ -1271,11 +1271,11 @@
                     "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
                     "dev": true,
                     "requires": {
-                        "nice-try": "1.0.5",
-                        "path-key": "2.0.1",
-                        "semver": "5.5.1",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.1"
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
                 "fast-deep-equal": {
@@ -1304,8 +1304,8 @@
             "integrity": "sha1-WPFfuDm40FdsqYBBNHaqskcttmo=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "resolve": "1.8.1"
+                "debug": "^2.6.9",
+                "resolve": "^1.5.0"
             },
             "dependencies": {
                 "debug": {
@@ -1325,8 +1325,8 @@
             "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "pkg-dir": "1.0.0"
+                "debug": "^2.6.8",
+                "pkg-dir": "^1.0.0"
             },
             "dependencies": {
                 "debug": {
@@ -1346,8 +1346,8 @@
             "integrity": "sha1-WsslZdtENIA9HUaptMvJSzRb0Cg=",
             "dev": true,
             "requires": {
-                "eslint-utils": "1.3.1",
-                "regexpp": "2.0.0"
+                "eslint-utils": "^1.3.0",
+                "regexpp": "^2.0.0"
             }
         },
         "eslint-plugin-import": {
@@ -1356,16 +1356,16 @@
             "integrity": "sha1-axdibS4+atUs/OiAeoRdFeIhEag=",
             "dev": true,
             "requires": {
-                "contains-path": "0.1.0",
-                "debug": "2.6.9",
+                "contains-path": "^0.1.0",
+                "debug": "^2.6.8",
                 "doctrine": "1.5.0",
-                "eslint-import-resolver-node": "0.3.2",
-                "eslint-module-utils": "2.2.0",
-                "has": "1.0.3",
-                "lodash": "4.17.10",
-                "minimatch": "3.0.4",
-                "read-pkg-up": "2.0.0",
-                "resolve": "1.8.1"
+                "eslint-import-resolver-node": "^0.3.1",
+                "eslint-module-utils": "^2.2.0",
+                "has": "^1.0.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.3",
+                "read-pkg-up": "^2.0.0",
+                "resolve": "^1.6.0"
             },
             "dependencies": {
                 "debug": {
@@ -1383,8 +1383,8 @@
                     "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
                     "dev": true,
                     "requires": {
-                        "esutils": "2.0.2",
-                        "isarray": "1.0.0"
+                        "esutils": "^2.0.2",
+                        "isarray": "^1.0.0"
                     }
                 }
             }
@@ -1395,12 +1395,12 @@
             "integrity": "sha1-puBU5QGZsu3YVRi4m057MjyfNts=",
             "dev": true,
             "requires": {
-                "eslint-plugin-es": "1.3.1",
-                "eslint-utils": "1.3.1",
-                "ignore": "4.0.6",
-                "minimatch": "3.0.4",
-                "resolve": "1.8.1",
-                "semver": "5.5.1"
+                "eslint-plugin-es": "^1.3.1",
+                "eslint-utils": "^1.3.1",
+                "ignore": "^4.0.2",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.8.1",
+                "semver": "^5.5.0"
             }
         },
         "eslint-plugin-promise": {
@@ -1421,8 +1421,8 @@
             "integrity": "sha1-UL8wcekzi83EMzF5Sgy1M/ATYXI=",
             "dev": true,
             "requires": {
-                "esrecurse": "4.2.1",
-                "estraverse": "4.2.0"
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
             }
         },
         "eslint-utils": {
@@ -1443,8 +1443,8 @@
             "integrity": "sha1-JTmY8goPgttdhmOFeZ2RKoOjZjQ=",
             "dev": true,
             "requires": {
-                "acorn": "5.7.3",
-                "acorn-jsx": "4.1.1"
+                "acorn": "^5.6.0",
+                "acorn-jsx": "^4.1.1"
             }
         },
         "esprima": {
@@ -1459,7 +1459,7 @@
             "integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
             "dev": true,
             "requires": {
-                "estraverse": "4.2.0"
+                "estraverse": "^4.0.0"
             }
         },
         "esrecurse": {
@@ -1468,7 +1468,7 @@
             "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
             "dev": true,
             "requires": {
-                "estraverse": "4.2.0"
+                "estraverse": "^4.1.0"
             }
         },
         "estraverse": {
@@ -1489,13 +1489,13 @@
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "ewma": {
@@ -1503,7 +1503,7 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/ewma/-/ewma-2.0.1.tgz",
             "integrity": "sha1-mHbBxJGsVzPIZmABo5YaBMl88eg=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "execa": {
@@ -1512,13 +1512,13 @@
             "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
             "dev": true,
             "requires": {
-                "cross-spawn": "5.1.0",
-                "get-stream": "3.0.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
             }
         },
         "expand-brackets": {
@@ -1527,13 +1527,13 @@
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "posix-character-classes": "0.1.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "debug": {
@@ -1551,7 +1551,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -1560,7 +1560,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -1569,7 +1569,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -1578,7 +1578,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -1589,7 +1589,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -1598,7 +1598,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -1609,9 +1609,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -1624,8 +1624,8 @@
         },
         "extend": {
             "version": "3.0.2",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "extend-shallow": {
             "version": "3.0.2",
@@ -1633,8 +1633,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "1.0.0",
-                "is-extendable": "1.0.1"
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -1643,7 +1643,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -1654,9 +1654,9 @@
             "integrity": "sha1-WGbbKal4Jtvkvzr9JAcOrZ6kOic=",
             "dev": true,
             "requires": {
-                "chardet": "0.7.0",
-                "iconv-lite": "0.4.24",
-                "tmp": "0.0.33"
+                "chardet": "^0.7.0",
+                "iconv-lite": "^0.4.24",
+                "tmp": "^0.0.33"
             }
         },
         "extglob": {
@@ -1665,14 +1665,14 @@
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "dev": true,
             "requires": {
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "expand-brackets": "2.1.4",
-                "extend-shallow": "2.0.1",
-                "fragment-cache": "0.2.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -1681,7 +1681,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -1709,27 +1709,28 @@
         },
         "fetch-cookie": {
             "version": "0.7.2",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/fetch-cookie/-/fetch-cookie-0.7.2.tgz",
-            "integrity": "sha1-W+US9xIbC80uNENQrXF3J6w7Gl0=",
+            "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-0.7.2.tgz",
+            "integrity": "sha512-Udm6ls1tV/pR9+EOjTYW2aGBadN03zOgVwu6grybxOg9ufACq7wE1HY/jh06DOykXH9FLYJC2RbUD3kJZcJBRg==",
             "requires": {
-                "es6-denodeify": "0.1.5",
-                "tough-cookie": "2.3.4"
+                "es6-denodeify": "^0.1.1",
+                "tough-cookie": "^2.3.1"
             }
         },
         "fetch-ponyfill": {
             "version": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
+            "from": "github:amarzavery/fetch-ponyfill#master",
             "requires": {
-                "fetch-cookie": "0.6.0",
-                "node-fetch": "1.7.3"
+                "fetch-cookie": "~0.6.0",
+                "node-fetch": "~1.7.1"
             },
             "dependencies": {
                 "fetch-cookie": {
                     "version": "0.6.0",
-                    "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/fetch-cookie/-/fetch-cookie-0.6.0.tgz",
+                    "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-0.6.0.tgz",
                     "integrity": "sha1-T+xOQIzAAH9sBOVTYYr0s97jf2k=",
                     "requires": {
-                        "es6-denodeify": "0.1.5",
-                        "tough-cookie": "2.3.4"
+                        "es6-denodeify": "^0.1.1",
+                        "tough-cookie": "^2.3.1"
                     }
                 }
             }
@@ -1740,7 +1741,7 @@
             "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "1.0.5"
+                "escape-string-regexp": "^1.0.5"
             }
         },
         "file-entry-cache": {
@@ -1749,8 +1750,8 @@
             "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
             "dev": true,
             "requires": {
-                "flat-cache": "1.3.0",
-                "object-assign": "4.1.1"
+                "flat-cache": "^1.2.1",
+                "object-assign": "^4.0.1"
             }
         },
         "filename-reserved-regex": {
@@ -1760,12 +1761,12 @@
         },
         "filenamify": {
             "version": "2.1.0",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/filenamify/-/filenamify-2.1.0.tgz",
-            "integrity": "sha1-iPr0lfsbR6v9YSMAACoWIoxnfuk=",
+            "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
+            "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
             "requires": {
-                "filename-reserved-regex": "2.0.0",
-                "strip-outer": "1.0.1",
-                "trim-repeated": "1.0.0"
+                "filename-reserved-regex": "^2.0.0",
+                "strip-outer": "^1.0.0",
+                "trim-repeated": "^1.0.0"
             }
         },
         "fill-range": {
@@ -1774,10 +1775,10 @@
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1",
-                "to-regex-range": "2.1.1"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -1786,7 +1787,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -1797,8 +1798,8 @@
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
             "dev": true,
             "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "flat-cache": {
@@ -1807,10 +1808,10 @@
             "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
             "dev": true,
             "requires": {
-                "circular-json": "0.3.3",
-                "del": "2.2.2",
-                "graceful-fs": "4.1.11",
-                "write": "0.2.1"
+                "circular-json": "^0.3.1",
+                "del": "^2.0.2",
+                "graceful-fs": "^4.1.2",
+                "write": "^0.2.1"
             }
         },
         "for-in": {
@@ -1829,17 +1830,17 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
             "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "requires": {
-                "asynckit": "0.4.0",
+                "asynckit": "^0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "2.1.20"
+                "mime-types": "^2.1.12"
             },
             "dependencies": {
                 "combined-stream": {
                     "version": "1.0.6",
-                    "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/combined-stream/-/combined-stream-1.0.6.tgz",
+                    "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
                     "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
                     "requires": {
-                        "delayed-stream": "1.0.0"
+                        "delayed-stream": "~1.0.0"
                     }
                 }
             }
@@ -1855,7 +1856,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "0.2.2"
+                "map-cache": "^0.2.2"
             }
         },
         "from": {
@@ -1866,12 +1867,12 @@
         },
         "fs-extra": {
             "version": "7.0.0",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/fs-extra/-/fs-extra-7.0.0.tgz",
-            "integrity": "sha1-jMP0fOB+97NZOhG5+yRffjTAQdY=",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
+            "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "4.0.0",
-                "universalify": "0.1.2"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs.realpath": {
@@ -1886,8 +1887,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "2.11.0",
-                "node-pre-gyp": "0.10.0"
+                "nan": "^2.9.2",
+                "node-pre-gyp": "^0.10.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -1913,8 +1914,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.3.6"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
                     }
                 },
                 "balanced-match": {
@@ -1927,7 +1928,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -1991,7 +1992,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "2.2.4"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "fs.realpath": {
@@ -2006,14 +2007,14 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
                     }
                 },
                 "glob": {
@@ -2022,12 +2023,12 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "has-unicode": {
@@ -2042,7 +2043,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safer-buffer": "2.1.2"
+                        "safer-buffer": "^2.1.0"
                     }
                 },
                 "ignore-walk": {
@@ -2051,7 +2052,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minimatch": "3.0.4"
+                        "minimatch": "^3.0.4"
                     }
                 },
                 "inflight": {
@@ -2060,8 +2061,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -2080,7 +2081,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "isarray": {
@@ -2094,7 +2095,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.11"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
@@ -2107,8 +2108,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1",
-                        "yallist": "3.0.2"
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.0"
                     }
                 },
                 "minizlib": {
@@ -2117,7 +2118,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "2.2.4"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "mkdirp": {
@@ -2140,9 +2141,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "iconv-lite": "0.4.21",
-                        "sax": "1.2.4"
+                        "debug": "^2.1.2",
+                        "iconv-lite": "^0.4.4",
+                        "sax": "^1.2.4"
                     }
                 },
                 "node-pre-gyp": {
@@ -2151,16 +2152,16 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "1.0.3",
-                        "mkdirp": "0.5.1",
-                        "needle": "2.2.0",
-                        "nopt": "4.0.1",
-                        "npm-packlist": "1.1.10",
-                        "npmlog": "4.1.2",
-                        "rc": "1.2.7",
-                        "rimraf": "2.6.2",
-                        "semver": "5.5.0",
-                        "tar": "4.4.1"
+                        "detect-libc": "^1.0.2",
+                        "mkdirp": "^0.5.1",
+                        "needle": "^2.2.0",
+                        "nopt": "^4.0.1",
+                        "npm-packlist": "^1.1.6",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.1.7",
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^4"
                     }
                 },
                 "nopt": {
@@ -2169,8 +2170,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1.1.1",
-                        "osenv": "0.1.5"
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
                     }
                 },
                 "npm-bundled": {
@@ -2185,8 +2186,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ignore-walk": "3.0.1",
-                        "npm-bundled": "1.0.3"
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
                     }
                 },
                 "npmlog": {
@@ -2195,10 +2196,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -2217,7 +2218,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "os-homedir": {
@@ -2238,8 +2239,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
                     }
                 },
                 "path-is-absolute": {
@@ -2260,10 +2261,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "0.5.1",
-                        "ini": "1.3.5",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
+                        "deep-extend": "^0.5.1",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -2280,13 +2281,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "rimraf": {
@@ -2295,7 +2296,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.0.5"
                     }
                 },
                 "safe-buffer": {
@@ -2338,9 +2339,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "string_decoder": {
@@ -2349,7 +2350,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 },
                 "strip-ansi": {
@@ -2357,7 +2358,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-json-comments": {
@@ -2372,13 +2373,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "chownr": "1.0.1",
-                        "fs-minipass": "1.2.5",
-                        "minipass": "2.2.4",
-                        "minizlib": "1.1.0",
-                        "mkdirp": "0.5.1",
-                        "safe-buffer": "5.1.1",
-                        "yallist": "3.0.2"
+                        "chownr": "^1.0.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.2.4",
+                        "minizlib": "^1.1.0",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.2"
                     }
                 },
                 "util-deprecate": {
@@ -2393,7 +2394,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.2"
                     }
                 },
                 "wrappy": {
@@ -2442,7 +2443,7 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "glob": {
@@ -2450,12 +2451,12 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/glob/-/glob-7.1.3.tgz",
             "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.1",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-parent": {
@@ -2464,8 +2465,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             },
             "dependencies": {
                 "is-glob": {
@@ -2474,7 +2475,7 @@
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.0"
                     }
                 }
             }
@@ -2485,7 +2486,7 @@
             "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
             "dev": true,
             "requires": {
-                "ini": "1.3.5"
+                "ini": "^1.3.4"
             }
         },
         "globals": {
@@ -2500,12 +2501,12 @@
             "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
             "dev": true,
             "requires": {
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "glob": "7.1.3",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -2522,17 +2523,17 @@
             "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
             "dev": true,
             "requires": {
-                "create-error-class": "3.0.2",
-                "duplexer3": "0.1.4",
-                "get-stream": "3.0.0",
-                "is-redirect": "1.0.0",
-                "is-retry-allowed": "1.1.0",
-                "is-stream": "1.1.0",
-                "lowercase-keys": "1.0.1",
-                "safe-buffer": "5.1.2",
-                "timed-out": "4.0.1",
-                "unzip-response": "2.0.1",
-                "url-parse-lax": "1.0.0"
+                "create-error-class": "^3.0.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-redirect": "^1.0.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "lowercase-keys": "^1.0.0",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "unzip-response": "^2.0.1",
+                "url-parse-lax": "^1.0.0"
             }
         },
         "graceful-fs": {
@@ -2542,8 +2543,8 @@
         },
         "grapheme-splitter": {
             "version": "1.0.4",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-            "integrity": "sha1-nPOmZcYkdHmJaDSvNc8du0QAdn4="
+            "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+            "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
         },
         "handle-thing": {
             "version": "1.2.5",
@@ -2560,8 +2561,8 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
             "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
             "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
+                "ajv": "^5.1.0",
+                "har-schema": "^2.0.0"
             }
         },
         "has": {
@@ -2570,7 +2571,7 @@
             "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
             "dev": true,
             "requires": {
-                "function-bind": "1.1.1"
+                "function-bind": "^1.1.1"
             }
         },
         "has-flag": {
@@ -2585,9 +2586,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "2.0.6",
-                "has-values": "1.0.0",
-                "isobject": "3.0.1"
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
             }
         },
         "has-values": {
@@ -2596,8 +2597,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -2606,26 +2607,26 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
         },
         "hawk": {
             "version": "6.0.2",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/hawk/-/hawk-6.0.2.tgz",
-            "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
+            "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+            "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
             "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.1",
-                "sntp": "2.1.0"
+                "boom": "4.x.x",
+                "cryptiles": "3.x.x",
+                "hoek": "4.x.x",
+                "sntp": "2.x.x"
             }
         },
         "hoek": {
             "version": "4.2.1",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/hoek/-/hoek-4.2.1.tgz",
-            "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs="
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+            "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
         },
         "hosted-git-info": {
             "version": "2.7.1",
@@ -2638,10 +2639,10 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/hpack.js/-/hpack.js-2.1.6.tgz",
             "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
             "requires": {
-                "inherits": "2.0.1",
-                "obuf": "1.1.2",
-                "readable-stream": "2.3.6",
-                "wbuf": "1.7.3"
+                "inherits": "^2.0.1",
+                "obuf": "^1.0.0",
+                "readable-stream": "^2.0.1",
+                "wbuf": "^1.1.0"
             }
         },
         "html-entities": {
@@ -2659,9 +2660,9 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.2"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "iconv-lite": {
@@ -2669,7 +2670,7 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
             }
         },
         "ignore": {
@@ -2701,8 +2702,8 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -2722,19 +2723,19 @@
             "integrity": "sha1-Ua3Nd29mE2ncHolIWcJWCiJKvdg=",
             "dev": true,
             "requires": {
-                "ansi-escapes": "3.1.0",
-                "chalk": "2.4.1",
-                "cli-cursor": "2.1.0",
-                "cli-width": "2.2.0",
-                "external-editor": "3.0.3",
-                "figures": "2.0.0",
-                "lodash": "4.17.10",
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^3.0.0",
+                "figures": "^2.0.0",
+                "lodash": "^4.17.10",
                 "mute-stream": "0.0.7",
-                "run-async": "2.3.0",
-                "rxjs": "6.3.2",
-                "string-width": "2.1.1",
-                "strip-ansi": "4.0.0",
-                "through": "2.3.8"
+                "run-async": "^2.2.0",
+                "rxjs": "^6.1.0",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
             }
         },
         "is-accessor-descriptor": {
@@ -2743,7 +2744,7 @@
             "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
             }
         },
         "is-arrayish": {
@@ -2758,7 +2759,7 @@
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
             "requires": {
-                "binary-extensions": "1.11.0"
+                "binary-extensions": "^1.0.0"
             }
         },
         "is-buffer": {
@@ -2772,7 +2773,7 @@
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
             }
         },
         "is-ci": {
@@ -2781,7 +2782,7 @@
             "integrity": "sha512-plgvKjQtalH2P3Gytb7L61Lmz95g2DlpzFiQyRSFew8WoJKxtKRzrZMeyRN2supblm3Psc8OQGy7Xjb6XG11jw==",
             "dev": true,
             "requires": {
-                "ci-info": "1.4.0"
+                "ci-info": "^1.3.0"
             }
         },
         "is-data-descriptor": {
@@ -2790,7 +2791,7 @@
             "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
             }
         },
         "is-descriptor": {
@@ -2799,9 +2800,9 @@
             "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
             }
         },
         "is-extendable": {
@@ -2828,7 +2829,7 @@
             "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.1"
             }
         },
         "is-installed-globally": {
@@ -2837,8 +2838,8 @@
             "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
             "dev": true,
             "requires": {
-                "global-dirs": "0.1.1",
-                "is-path-inside": "1.0.1"
+                "global-dirs": "^0.1.0",
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-npm": {
@@ -2853,7 +2854,7 @@
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -2862,7 +2863,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -2885,7 +2886,7 @@
             "integrity": "sha1-WsSLNF72dTOb1sekipEhELJBz1I=",
             "dev": true,
             "requires": {
-                "is-path-inside": "1.0.1"
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-path-inside": {
@@ -2894,7 +2895,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
         "is-plain-object": {
@@ -2903,7 +2904,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "is-promise": {
@@ -2990,8 +2991,8 @@
             "integrity": "sha1-6u1lbsg0TxD1J8a/obbiJE3hZ9E=",
             "dev": true,
             "requires": {
-                "argparse": "1.0.10",
-                "esprima": "4.0.1"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             }
         },
         "jsbn": {
@@ -3002,8 +3003,8 @@
         },
         "jschardet": {
             "version": "1.6.0",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jschardet/-/jschardet-1.6.0.tgz",
-            "integrity": "sha1-x9GnHtz/KDnbL57DD8XV69PBpng="
+            "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
+            "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ=="
         },
         "json-schema": {
             "version": "0.2.3",
@@ -3031,7 +3032,7 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.6"
             }
         },
         "jsonwebtoken": {
@@ -3039,16 +3040,16 @@
             "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.0.1.tgz",
             "integrity": "sha1-UNrvjQqMfeLNBrwQE7dbBMzz8M8=",
             "requires": {
-                "jws": "3.1.5",
-                "lodash.includes": "4.3.0",
-                "lodash.isboolean": "3.0.3",
-                "lodash.isinteger": "4.0.4",
-                "lodash.isnumber": "3.0.3",
-                "lodash.isplainobject": "4.0.6",
-                "lodash.isstring": "4.0.1",
-                "lodash.once": "4.1.1",
-                "ms": "2.0.0",
-                "xtend": "4.0.1"
+                "jws": "^3.1.4",
+                "lodash.includes": "^4.3.0",
+                "lodash.isboolean": "^3.0.3",
+                "lodash.isinteger": "^4.0.4",
+                "lodash.isnumber": "^3.0.3",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.once": "^4.0.0",
+                "ms": "^2.0.0",
+                "xtend": "^4.0.1"
             }
         },
         "jsprim": {
@@ -3064,21 +3065,21 @@
         },
         "jwa": {
             "version": "1.1.6",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jwa/-/jwa-1.1.6.tgz",
-            "integrity": "sha1-hyQOdsmAjb3hh4PPImTvSSnuUOY=",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
+            "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
             "requires": {
                 "buffer-equal-constant-time": "1.0.1",
                 "ecdsa-sig-formatter": "1.0.10",
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
             }
         },
         "jws": {
             "version": "3.1.5",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jws/-/jws-3.1.5.tgz",
-            "integrity": "sha1-gNEtBbKT0ehB58uLTmnlYa3Pg08=",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+            "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
             "requires": {
-                "jwa": "1.1.6",
-                "safe-buffer": "5.1.2"
+                "jwa": "^1.1.5",
+                "safe-buffer": "^5.0.1"
             }
         },
         "kind-of": {
@@ -3093,7 +3094,7 @@
             "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
             "dev": true,
             "requires": {
-                "package-json": "4.0.1"
+                "package-json": "^4.0.0"
             }
         },
         "levn": {
@@ -3102,8 +3103,8 @@
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
             }
         },
         "load-json-file": {
@@ -3112,10 +3113,10 @@
             "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "strip-bom": "3.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "strip-bom": "^3.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -3132,8 +3133,8 @@
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "dev": true,
             "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
             },
             "dependencies": {
                 "path-exists": {
@@ -3241,8 +3242,8 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
             "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
             "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "make-dir": {
@@ -3251,7 +3252,7 @@
             "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "dev": true,
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             }
         },
         "map-cache": {
@@ -3272,7 +3273,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "1.0.1"
+                "object-visit": "^1.0.0"
             }
         },
         "micromatch": {
@@ -3281,19 +3282,19 @@
             "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "braces": "2.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "extglob": "2.0.4",
-                "fragment-cache": "0.2.1",
-                "kind-of": "6.0.2",
-                "nanomatch": "1.2.13",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
             },
             "dependencies": {
                 "define-property": {
@@ -3302,8 +3303,8 @@
                     "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2",
-                        "isobject": "3.0.1"
+                        "is-descriptor": "^1.0.2",
+                        "isobject": "^3.0.1"
                     }
                 }
             }
@@ -3315,15 +3316,15 @@
         },
         "mime-db": {
             "version": "1.36.0",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/mime-db/-/mime-db-1.36.0.tgz",
-            "integrity": "sha1-UCBHjbPH/pOq17vMTc+GnEM2M5c="
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+            "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
         },
         "mime-types": {
             "version": "2.1.20",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/mime-types/-/mime-types-2.1.20.tgz",
-            "integrity": "sha1-kwy3GdVx6QNzhSD4RwkRVIyizBk=",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+            "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
             "requires": {
-                "mime-db": "1.36.0"
+                "mime-db": "~1.36.0"
             }
         },
         "mimic-fn": {
@@ -3342,7 +3343,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -3357,8 +3358,8 @@
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2",
-                "is-extendable": "1.0.1"
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -3367,7 +3368,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -3398,108 +3399,161 @@
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "ms-rest": {
-            "version": "2.3.6",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ms-rest/-/ms-rest-2.3.6.tgz",
-            "integrity": "sha1-mYT+kyjNB+MXK1INtd/wrLaPH3o=",
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/ms-rest/-/ms-rest-2.3.7.tgz",
+            "integrity": "sha512-zZwuckC/Uv8F1Jr1bW+U1tsDTErWhtH6W4mpxvRrta4YrKwkFeLMt53RsaDOWTqMFsVpjNuCfznV1uxeGUF3/g==",
             "requires": {
-                "duplexer": "0.1.1",
-                "is-buffer": "1.1.6",
-                "is-stream": "1.1.0",
-                "moment": "2.22.2",
-                "request": "2.88.0",
-                "through": "2.3.8",
+                "duplexer": "^0.1.1",
+                "is-buffer": "^1.1.6",
+                "is-stream": "^1.1.0",
+                "moment": "^2.21.0",
+                "request": "^2.88.0",
+                "through": "^2.3.8",
                 "tunnel": "0.0.5",
-                "uuid": "3.3.2"
+                "uuid": "^3.2.1"
             },
             "dependencies": {
                 "har-validator": {
                     "version": "5.1.0",
-                    "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/har-validator/-/har-validator-5.1.0.tgz",
-                    "integrity": "sha1-RGV/VoiiLP1LckhugbOj+xF0LCk=",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+                    "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
                     "requires": {
-                        "ajv": "5.5.2",
-                        "har-schema": "2.0.0"
+                        "ajv": "^5.3.0",
+                        "har-schema": "^2.0.0"
                     }
                 },
                 "oauth-sign": {
                     "version": "0.9.0",
-                    "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
-                    "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+                    "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
                 },
                 "request": {
                     "version": "2.88.0",
-                    "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/request/-/request-2.88.0.tgz",
-                    "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+                    "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
                     "requires": {
-                        "aws-sign2": "0.7.0",
-                        "aws4": "1.8.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.7",
-                        "extend": "3.0.2",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.3.2",
-                        "har-validator": "5.1.0",
-                        "http-signature": "1.2.0",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.20",
-                        "oauth-sign": "0.9.0",
-                        "performance-now": "2.1.0",
-                        "qs": "6.5.2",
-                        "safe-buffer": "5.1.2",
-                        "tough-cookie": "2.4.3",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.3.2"
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.8.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.6",
+                        "extend": "~3.0.2",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.2",
+                        "har-validator": "~5.1.0",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.19",
+                        "oauth-sign": "~0.9.0",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.2",
+                        "safe-buffer": "^5.1.2",
+                        "tough-cookie": "~2.4.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.3.2"
                     }
                 },
                 "tough-cookie": {
                     "version": "2.4.3",
-                    "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
-                    "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+                    "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
                     "requires": {
-                        "psl": "1.1.29",
-                        "punycode": "1.4.1"
+                        "psl": "^1.1.24",
+                        "punycode": "^1.4.1"
                     }
                 }
             }
         },
         "ms-rest-azure": {
-            "version": "2.5.7",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ms-rest-azure/-/ms-rest-azure-2.5.7.tgz",
-            "integrity": "sha1-jUpo7ZONIUiLpuZrRSX+Loy9+y0=",
+            "version": "2.5.9",
+            "resolved": "https://registry.npmjs.org/ms-rest-azure/-/ms-rest-azure-2.5.9.tgz",
+            "integrity": "sha512-qonobzWLS7Jl6qwgTuA/SfyCtnv7olvCRKrcF8nzXSj68ds4Oj3K64ntzgQajroKa0hKVMcPUFbTk1IYMGvu8w==",
             "requires": {
-                "adal-node": "0.1.28",
+                "adal-node": "^0.1.28",
                 "async": "2.6.0",
-                "moment": "2.22.2",
-                "ms-rest": "2.3.6",
-                "uuid": "3.3.2"
+                "moment": "^2.22.2",
+                "ms-rest": "^2.3.2",
+                "request": "^2.88.0",
+                "uuid": "^3.2.1"
+            },
+            "dependencies": {
+                "har-validator": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+                    "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+                    "requires": {
+                        "ajv": "^5.3.0",
+                        "har-schema": "^2.0.0"
+                    }
+                },
+                "oauth-sign": {
+                    "version": "0.9.0",
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+                    "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+                },
+                "request": {
+                    "version": "2.88.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+                    "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+                    "requires": {
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.8.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.6",
+                        "extend": "~3.0.2",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.2",
+                        "har-validator": "~5.1.0",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.19",
+                        "oauth-sign": "~0.9.0",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.2",
+                        "safe-buffer": "^5.1.2",
+                        "tough-cookie": "~2.4.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.3.2"
+                    }
+                },
+                "tough-cookie": {
+                    "version": "2.4.3",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+                    "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+                    "requires": {
+                        "psl": "^1.1.24",
+                        "punycode": "^1.4.1"
+                    }
+                }
             }
         },
         "ms-rest-js": {
             "version": "0.2.8",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ms-rest-js/-/ms-rest-js-0.2.8.tgz",
-            "integrity": "sha1-mk4QQyexPtf2puUFri4WrVTD2DQ=",
+            "resolved": "http://registry.npmjs.org/ms-rest-js/-/ms-rest-js-0.2.8.tgz",
+            "integrity": "sha512-KgiSsbJzKcPLx0Zaca5PEdGOwm8X4Np+aTukK6stMl2eAqSrHvncjteyeXi6v6O0ECLYeUWVbqcPJfpw1PjnZQ==",
             "requires": {
-                "@types/form-data": "2.2.1",
-                "@types/is-stream": "1.1.0",
-                "@types/node": "9.6.31",
-                "@types/node-fetch": "1.6.9",
-                "@types/uuid": "3.4.4",
-                "fetch-cookie": "0.7.2",
+                "@types/form-data": "^2.2.1",
+                "@types/is-stream": "^1.1.0",
+                "@types/node": "^9.4.6",
+                "@types/node-fetch": "^1.6.7",
+                "@types/uuid": "^3.4.3",
+                "fetch-cookie": "^0.7.0",
                 "fetch-ponyfill": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
-                "form-data": "2.3.2",
-                "is-buffer": "2.0.3",
-                "is-stream": "1.1.0",
-                "moment": "2.22.2",
-                "url-parse": "1.4.3",
-                "uuid": "3.3.2"
+                "form-data": "^2.3.2",
+                "is-buffer": "^2.0.0",
+                "is-stream": "^1.1.0",
+                "moment": "^2.21.0",
+                "url-parse": "^1.2.0",
+                "uuid": "^3.2.1"
             },
             "dependencies": {
                 "is-buffer": {
                     "version": "2.0.3",
-                    "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/is-buffer/-/is-buffer-2.0.3.tgz",
-                    "integrity": "sha1-Ts8/z3ScvR5HJonhCaxmJhol5yU="
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+                    "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
                 }
             }
         },
@@ -3520,9 +3574,9 @@
             "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
             "optional": true,
             "requires": {
-                "mkdirp": "0.5.1",
-                "ncp": "2.0.0",
-                "rimraf": "2.4.5"
+                "mkdirp": "~0.5.1",
+                "ncp": "~2.0.0",
+                "rimraf": "~2.4.0"
             },
             "dependencies": {
                 "glob": {
@@ -3531,11 +3585,11 @@
                     "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                     "optional": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.1",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "rimraf": {
@@ -3544,7 +3598,7 @@
                     "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
                     "optional": true,
                     "requires": {
-                        "glob": "6.0.4"
+                        "glob": "^6.0.1"
                     }
                 }
             }
@@ -3561,17 +3615,17 @@
             "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "fragment-cache": "0.2.1",
-                "is-windows": "1.0.2",
-                "kind-of": "6.0.2",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -3580,8 +3634,8 @@
                     "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2",
-                        "isobject": "3.0.1"
+                        "is-descriptor": "^1.0.2",
+                        "isobject": "^3.0.1"
                     }
                 }
             }
@@ -3611,27 +3665,27 @@
         },
         "nock": {
             "version": "9.6.1",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/nock/-/nock-9.6.1.tgz",
-            "integrity": "sha1-2W4Jm+m8HQGJp39EkLu7Jlw4G0k=",
+            "resolved": "https://registry.npmjs.org/nock/-/nock-9.6.1.tgz",
+            "integrity": "sha512-EDgl/WgNQ0C1BZZlASOQkQdE6tAWXJi8QQlugqzN64JJkvZ7ILijZuG24r4vCC7yOfnm6HKpne5AGExLGCeBWg==",
             "requires": {
-                "chai": "4.1.2",
-                "debug": "3.1.0",
-                "deep-equal": "1.0.1",
-                "json-stringify-safe": "5.0.1",
-                "lodash": "4.17.10",
-                "mkdirp": "0.5.1",
-                "propagate": "1.0.0",
-                "qs": "6.5.2",
-                "semver": "5.5.1"
+                "chai": "^4.1.2",
+                "debug": "^3.1.0",
+                "deep-equal": "^1.0.0",
+                "json-stringify-safe": "^5.0.1",
+                "lodash": "^4.17.5",
+                "mkdirp": "^0.5.0",
+                "propagate": "^1.0.0",
+                "qs": "^6.5.1",
+                "semver": "^5.5.0"
             }
         },
         "node-fetch": {
             "version": "1.7.3",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/node-fetch/-/node-fetch-1.7.3.tgz",
-            "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+            "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
             "requires": {
-                "encoding": "0.1.12",
-                "is-stream": "1.1.0"
+                "encoding": "^0.1.11",
+                "is-stream": "^1.0.1"
             }
         },
         "nodemon": {
@@ -3640,16 +3694,16 @@
             "integrity": "sha512-XdVfAjGlDKU2nqoGgycxTndkJ5fdwvWJ/tlMGk2vHxMZBrSPVh86OM6z7viAv8BBJWjMgeuYQBofzr6LUoi+7g==",
             "dev": true,
             "requires": {
-                "chokidar": "2.0.4",
-                "debug": "3.1.0",
-                "ignore-by-default": "1.0.1",
-                "minimatch": "3.0.4",
-                "pstree.remy": "1.1.0",
-                "semver": "5.5.1",
-                "supports-color": "5.5.0",
-                "touch": "3.1.0",
-                "undefsafe": "2.0.2",
-                "update-notifier": "2.5.0"
+                "chokidar": "^2.0.2",
+                "debug": "^3.1.0",
+                "ignore-by-default": "^1.0.1",
+                "minimatch": "^3.0.4",
+                "pstree.remy": "^1.1.0",
+                "semver": "^5.5.0",
+                "supports-color": "^5.2.0",
+                "touch": "^3.1.0",
+                "undefsafe": "^2.0.2",
+                "update-notifier": "^2.3.0"
             }
         },
         "nopt": {
@@ -3658,7 +3712,7 @@
             "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
             "dev": true,
             "requires": {
-                "abbrev": "1.1.1"
+                "abbrev": "1"
             }
         },
         "normalize-package-data": {
@@ -3667,10 +3721,10 @@
             "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
             "dev": true,
             "requires": {
-                "hosted-git-info": "2.7.1",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.5.1",
-                "validate-npm-package-license": "3.0.4"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-path": {
@@ -3679,7 +3733,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "npm-run-path": {
@@ -3688,7 +3742,7 @@
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "dev": true,
             "requires": {
-                "path-key": "2.0.1"
+                "path-key": "^2.0.0"
             }
         },
         "oauth-sign": {
@@ -3708,9 +3762,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "0.1.1",
-                "define-property": "0.2.5",
-                "kind-of": "3.2.2"
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
             },
             "dependencies": {
                 "define-property": {
@@ -3719,7 +3773,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -3728,7 +3782,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -3737,7 +3791,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -3746,9 +3800,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -3765,7 +3819,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -3776,7 +3830,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.0"
             }
         },
         "object.pick": {
@@ -3785,7 +3839,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "obuf": {
@@ -3798,7 +3852,7 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "onetime": {
@@ -3807,7 +3861,7 @@
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "dev": true,
             "requires": {
-                "mimic-fn": "1.2.0"
+                "mimic-fn": "^1.0.0"
             }
         },
         "optionator": {
@@ -3816,12 +3870,12 @@
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
             "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
             }
         },
         "os-tmpdir": {
@@ -3842,7 +3896,7 @@
             "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
             "dev": true,
             "requires": {
-                "p-try": "1.0.0"
+                "p-try": "^1.0.0"
             }
         },
         "p-locate": {
@@ -3851,7 +3905,7 @@
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "dev": true,
             "requires": {
-                "p-limit": "1.3.0"
+                "p-limit": "^1.1.0"
             }
         },
         "p-try": {
@@ -3866,10 +3920,10 @@
             "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
             "dev": true,
             "requires": {
-                "got": "6.7.1",
-                "registry-auth-token": "3.3.2",
-                "registry-url": "3.1.0",
-                "semver": "5.5.1"
+                "got": "^6.7.1",
+                "registry-auth-token": "^3.0.1",
+                "registry-url": "^3.0.3",
+                "semver": "^5.1.0"
             }
         },
         "parse-json": {
@@ -3878,7 +3932,7 @@
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "dev": true,
             "requires": {
-                "error-ex": "1.3.2"
+                "error-ex": "^1.2.0"
             }
         },
         "pascalcase": {
@@ -3899,7 +3953,7 @@
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
             "dev": true,
             "requires": {
-                "pinkie-promise": "2.0.1"
+                "pinkie-promise": "^2.0.0"
             }
         },
         "path-is-absolute": {
@@ -3931,7 +3985,7 @@
             "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
             "dev": true,
             "requires": {
-                "pify": "2.3.0"
+                "pify": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -3953,7 +4007,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "performance-now": {
@@ -3984,7 +4038,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "pkg-dir": {
@@ -3993,7 +4047,7 @@
             "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
             "dev": true,
             "requires": {
-                "find-up": "1.1.2"
+                "find-up": "^1.0.0"
             }
         },
         "pluralize": {
@@ -4047,7 +4101,7 @@
             "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4"
+                "event-stream": "~3.3.0"
             }
         },
         "pseudomap": {
@@ -4057,8 +4111,8 @@
         },
         "psl": {
             "version": "1.1.29",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/psl/-/psl-1.1.29.tgz",
-            "integrity": "sha1-YPWA02AXC7cip5fMcEQR5tqFDGc="
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+            "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
         },
         "pstree.remy": {
             "version": "1.1.0",
@@ -4066,7 +4120,7 @@
             "integrity": "sha512-q5I5vLRMVtdWa8n/3UEzZX7Lfghzrg9eG2IKk2ENLSofKRCXVqMvMUHxCKgXNaqH/8ebhBxrqftHWnyTFweJ5Q==",
             "dev": true,
             "requires": {
-                "ps-tree": "1.1.0"
+                "ps-tree": "^1.1.0"
             }
         },
         "punycode": {
@@ -4086,8 +4140,8 @@
         },
         "querystringify": {
             "version": "2.0.0",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/querystringify/-/querystringify-2.0.0.tgz",
-            "integrity": "sha1-+j7W5o6xUVlFfImze8ZHKDMZV1U="
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+            "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
         },
         "rc": {
             "version": "1.2.8",
@@ -4095,10 +4149,10 @@
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
             "dev": true,
             "requires": {
-                "deep-extend": "0.6.0",
-                "ini": "1.3.5",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
             }
         },
         "read-pkg": {
@@ -4107,9 +4161,9 @@
             "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
             "dev": true,
             "requires": {
-                "load-json-file": "2.0.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "2.0.0"
+                "load-json-file": "^2.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^2.0.0"
             }
         },
         "read-pkg-up": {
@@ -4118,8 +4172,8 @@
             "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
             "dev": true,
             "requires": {
-                "find-up": "2.1.0",
-                "read-pkg": "2.0.0"
+                "find-up": "^2.0.0",
+                "read-pkg": "^2.0.0"
             },
             "dependencies": {
                 "find-up": {
@@ -4128,7 +4182,7 @@
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "dev": true,
                     "requires": {
-                        "locate-path": "2.0.0"
+                        "locate-path": "^2.0.0"
                     }
                 }
             }
@@ -4138,8 +4192,8 @@
             "resolved": "https://registry.npmjs.org/read-text-file/-/read-text-file-1.1.0.tgz",
             "integrity": "sha1-0MPxh2iCj5EH1huws2jue5D3GJM=",
             "requires": {
-                "iconv-lite": "0.4.24",
-                "jschardet": "1.6.0"
+                "iconv-lite": "^0.4.17",
+                "jschardet": "^1.4.2"
             }
         },
         "readable-stream": {
@@ -4147,13 +4201,13 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             },
             "dependencies": {
                 "inherits": {
@@ -4169,10 +4223,10 @@
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "readable-stream": "2.3.6",
-                "set-immediate-shim": "1.0.1"
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "readable-stream": "^2.0.2",
+                "set-immediate-shim": "^1.0.1"
             }
         },
         "regex-not": {
@@ -4181,8 +4235,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "regexpp": {
@@ -4197,8 +4251,8 @@
             "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
             "dev": true,
             "requires": {
-                "rc": "1.2.8",
-                "safe-buffer": "5.1.2"
+                "rc": "^1.1.6",
+                "safe-buffer": "^5.0.1"
             }
         },
         "registry-url": {
@@ -4207,7 +4261,7 @@
             "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
             "dev": true,
             "requires": {
-                "rc": "1.2.8"
+                "rc": "^1.0.1"
             }
         },
         "remove-trailing-separator": {
@@ -4230,31 +4284,31 @@
         },
         "request": {
             "version": "2.83.0",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/request/-/request-2.83.0.tgz",
-            "integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+            "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.8.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.7",
-                "extend": "3.0.2",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.20",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.2",
-                "safe-buffer": "5.1.2",
-                "stringstream": "0.0.6",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.3.2"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.6.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.1",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.1",
+                "har-validator": "~5.0.3",
+                "hawk": "~6.0.2",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.17",
+                "oauth-sign": "~0.8.2",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.1",
+                "safe-buffer": "^5.1.1",
+                "stringstream": "~0.0.5",
+                "tough-cookie": "~2.3.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.1.0"
             }
         },
         "request-promise-core": {
@@ -4262,7 +4316,7 @@
             "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
             "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
             "requires": {
-                "lodash": "4.17.10"
+                "lodash": "^4.13.1"
             }
         },
         "request-promise-native": {
@@ -4271,8 +4325,8 @@
             "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
             "requires": {
                 "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.4"
+                "stealthy-require": "^1.1.0",
+                "tough-cookie": ">=2.3.3"
             }
         },
         "require-uncached": {
@@ -4281,8 +4335,8 @@
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
             "dev": true,
             "requires": {
-                "caller-path": "0.1.0",
-                "resolve-from": "1.0.1"
+                "caller-path": "^0.1.0",
+                "resolve-from": "^1.0.0"
             }
         },
         "requires-port": {
@@ -4296,7 +4350,7 @@
             "integrity": "sha1-gvHsGaQjrB+9CAsLqwa6NuhKeiY=",
             "dev": true,
             "requires": {
-                "path-parse": "1.0.6"
+                "path-parse": "^1.0.5"
             }
         },
         "resolve-from": {
@@ -4316,28 +4370,28 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/restify/-/restify-6.4.0.tgz",
             "integrity": "sha1-PwyaTHgzmGnQF/7YWg5SVavz2kQ=",
             "requires": {
-                "assert-plus": "1.0.0",
-                "bunyan": "1.8.12",
-                "clone-regexp": "1.0.1",
-                "csv": "1.2.1",
-                "dtrace-provider": "0.8.7",
-                "escape-regexp-component": "1.0.2",
-                "ewma": "2.0.1",
-                "formidable": "1.2.1",
-                "http-signature": "1.2.0",
-                "lodash": "4.17.10",
-                "lru-cache": "4.1.3",
-                "mime": "1.6.0",
-                "negotiator": "0.6.1",
-                "once": "1.4.0",
-                "pidusage": "1.2.0",
-                "qs": "6.5.2",
-                "restify-errors": "5.0.0",
-                "semver": "5.5.1",
-                "spdy": "3.4.7",
-                "uuid": "3.3.2",
-                "vasync": "1.6.4",
-                "verror": "1.10.0"
+                "assert-plus": "^1.0.0",
+                "bunyan": "^1.8.12",
+                "clone-regexp": "^1.0.0",
+                "csv": "^1.1.1",
+                "dtrace-provider": "^0.8.1",
+                "escape-regexp-component": "^1.0.2",
+                "ewma": "^2.0.1",
+                "formidable": "^1.1.1",
+                "http-signature": "^1.2.0",
+                "lodash": "^4.17.4",
+                "lru-cache": "^4.1.1",
+                "mime": "^1.5.0",
+                "negotiator": "^0.6.1",
+                "once": "^1.4.0",
+                "pidusage": "^1.2.0",
+                "qs": "^6.5.1",
+                "restify-errors": "^5.0.0",
+                "semver": "^5.4.1",
+                "spdy": "^3.4.7",
+                "uuid": "^3.1.0",
+                "vasync": "^1.6.4",
+                "verror": "^1.10.0"
             }
         },
         "restify-errors": {
@@ -4345,10 +4399,10 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/restify-errors/-/restify-errors-5.0.0.tgz",
             "integrity": "sha1-ZocX4QBoPuxs4NUV+J/x2+wlSo0=",
             "requires": {
-                "assert-plus": "1.0.0",
-                "lodash": "4.17.10",
-                "safe-json-stringify": "1.2.0",
-                "verror": "1.10.0"
+                "assert-plus": "^1.0.0",
+                "lodash": "^4.2.1",
+                "safe-json-stringify": "^1.0.3",
+                "verror": "^1.8.1"
             }
         },
         "restore-cursor": {
@@ -4357,8 +4411,8 @@
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
             "requires": {
-                "onetime": "2.0.1",
-                "signal-exit": "3.0.2"
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
             }
         },
         "ret": {
@@ -4372,7 +4426,7 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
             "requires": {
-                "glob": "7.1.3"
+                "glob": "^7.0.5"
             }
         },
         "rsa-pem-from-mod-exp": {
@@ -4386,7 +4440,7 @@
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "dev": true,
             "requires": {
-                "is-promise": "2.1.0"
+                "is-promise": "^2.1.0"
             }
         },
         "rxjs": {
@@ -4395,7 +4449,7 @@
             "integrity": "sha1-amiLFsTm6YDmLqgF7DBkjhxgkH8=",
             "dev": true,
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             }
         },
         "safe-buffer": {
@@ -4415,7 +4469,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
             }
         },
         "safer-buffer": {
@@ -4439,7 +4493,7 @@
             "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
             "dev": true,
             "requires": {
-                "semver": "5.5.1"
+                "semver": "^5.0.3"
             }
         },
         "set-immediate-shim": {
@@ -4454,10 +4508,10 @@
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "split-string": "3.1.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -4466,7 +4520,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -4477,7 +4531,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
@@ -4498,7 +4552,7 @@
             "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "2.0.0"
+                "is-fullwidth-code-point": "^2.0.0"
             }
         },
         "snapdragon": {
@@ -4507,14 +4561,14 @@
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "0.11.2",
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "map-cache": "0.2.2",
-                "source-map": "0.5.7",
-                "source-map-resolve": "0.5.2",
-                "use": "3.1.1"
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -4532,7 +4586,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -4541,7 +4595,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -4550,7 +4604,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -4559,7 +4613,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -4570,7 +4624,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -4579,7 +4633,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -4590,9 +4644,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -4609,9 +4663,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "snapdragon-util": "3.0.1"
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
             }
         },
         "snapdragon-util": {
@@ -4620,7 +4674,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.2.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -4629,17 +4683,17 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
         },
         "sntp": {
             "version": "2.1.0",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/sntp/-/sntp-2.1.0.tgz",
-            "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
+            "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+            "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
             "requires": {
-                "hoek": "4.2.1"
+                "hoek": "4.x.x"
             }
         },
         "source-map": {
@@ -4654,11 +4708,11 @@
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "dev": true,
             "requires": {
-                "atob": "2.1.2",
-                "decode-uri-component": "0.2.0",
-                "resolve-url": "0.2.1",
-                "source-map-url": "0.4.0",
-                "urix": "0.1.0"
+                "atob": "^2.1.1",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
             }
         },
         "source-map-url": {
@@ -4673,8 +4727,8 @@
             "integrity": "sha1-BaW01xU6GVvJLDxCW2nzsqlSTII=",
             "dev": true,
             "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.1"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-exceptions": {
@@ -4689,8 +4743,8 @@
             "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
             "dev": true,
             "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.1"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-license-ids": {
@@ -4704,12 +4758,12 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/spdy/-/spdy-3.4.7.tgz",
             "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
             "requires": {
-                "debug": "2.6.9",
-                "handle-thing": "1.2.5",
-                "http-deceiver": "1.2.7",
-                "safe-buffer": "5.1.2",
-                "select-hose": "2.0.0",
-                "spdy-transport": "2.1.0"
+                "debug": "^2.6.8",
+                "handle-thing": "^1.2.5",
+                "http-deceiver": "^1.2.7",
+                "safe-buffer": "^5.0.1",
+                "select-hose": "^2.0.0",
+                "spdy-transport": "^2.0.18"
             },
             "dependencies": {
                 "debug": {
@@ -4727,13 +4781,13 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/spdy-transport/-/spdy-transport-2.1.0.tgz",
             "integrity": "sha1-S7sVqv/tC+791WrWHb3Iuj4st6E=",
             "requires": {
-                "debug": "2.6.9",
-                "detect-node": "2.0.4",
-                "hpack.js": "2.1.6",
-                "obuf": "1.1.2",
-                "readable-stream": "2.3.6",
-                "safe-buffer": "5.1.2",
-                "wbuf": "1.7.3"
+                "debug": "^2.6.8",
+                "detect-node": "^2.0.3",
+                "hpack.js": "^2.1.6",
+                "obuf": "^1.1.1",
+                "readable-stream": "^2.2.9",
+                "safe-buffer": "^5.0.1",
+                "wbuf": "^1.7.2"
             },
             "dependencies": {
                 "debug": {
@@ -4752,7 +4806,7 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "split-string": {
@@ -4761,7 +4815,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2"
+                "extend-shallow": "^3.0.0"
             }
         },
         "sprintf-js": {
@@ -4775,15 +4829,15 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/sshpk/-/sshpk-1.14.2.tgz",
             "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
             "requires": {
-                "asn1": "0.2.4",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.2",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.2",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
             }
         },
         "static-extend": {
@@ -4792,8 +4846,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "object-copy": "0.1.0"
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -4802,7 +4856,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -4811,7 +4865,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -4820,7 +4874,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -4831,7 +4885,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -4840,7 +4894,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -4851,9 +4905,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -4875,7 +4929,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-transform": {
@@ -4889,8 +4943,8 @@
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
             }
         },
         "string_decoder": {
@@ -4898,13 +4952,13 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
             }
         },
         "stringstream": {
             "version": "0.0.6",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/stringstream/-/stringstream-0.0.6.tgz",
-            "integrity": "sha1-eIAiWw1K0Q4wkn0Weh1vL9OzOnI="
+            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+            "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
         },
         "strip-ansi": {
             "version": "4.0.0",
@@ -4912,7 +4966,7 @@
             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
             }
         },
         "strip-bom": {
@@ -4935,10 +4989,10 @@
         },
         "strip-outer": {
             "version": "1.0.1",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/strip-outer/-/strip-outer-1.0.1.tgz",
-            "integrity": "sha1-sv0qv2YEudHmATBXGV34Nrip1jE=",
+            "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+            "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
             "requires": {
-                "escape-string-regexp": "1.0.5"
+                "escape-string-regexp": "^1.0.2"
             }
         },
         "supports-color": {
@@ -4947,7 +5001,7 @@
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "dev": true,
             "requires": {
-                "has-flag": "3.0.0"
+                "has-flag": "^3.0.0"
             }
         },
         "table": {
@@ -4956,12 +5010,12 @@
             "integrity": "sha1-ALXitgLxeUuayvnKkIp2OGp4E7w=",
             "dev": true,
             "requires": {
-                "ajv": "6.5.3",
-                "ajv-keywords": "3.2.0",
-                "chalk": "2.4.1",
-                "lodash": "4.17.10",
+                "ajv": "^6.0.1",
+                "ajv-keywords": "^3.0.0",
+                "chalk": "^2.1.0",
+                "lodash": "^4.17.4",
                 "slice-ansi": "1.0.0",
-                "string-width": "2.1.1"
+                "string-width": "^2.1.1"
             },
             "dependencies": {
                 "ajv": {
@@ -4970,10 +5024,10 @@
                     "integrity": "sha1-caVp0Yns9PTzISJP7LFm8HHdkPk=",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "2.0.1",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.4.1",
-                        "uri-js": "4.2.2"
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
                     }
                 },
                 "fast-deep-equal": {
@@ -4996,7 +5050,7 @@
             "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
             "dev": true,
             "requires": {
-                "execa": "0.7.0"
+                "execa": "^0.7.0"
             }
         },
         "text-table": {
@@ -5022,7 +5076,7 @@
             "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
             "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.2"
             }
         },
         "to-object-path": {
@@ -5031,7 +5085,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -5040,7 +5094,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -5051,10 +5105,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "regex-not": "1.0.2",
-                "safe-regex": "1.1.0"
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -5063,8 +5117,8 @@
                     "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2",
-                        "isobject": "3.0.1"
+                        "is-descriptor": "^1.0.2",
+                        "isobject": "^3.0.1"
                     }
                 }
             }
@@ -5075,8 +5129,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
             }
         },
         "touch": {
@@ -5085,15 +5139,15 @@
             "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
             "dev": true,
             "requires": {
-                "nopt": "1.0.10"
+                "nopt": "~1.0.10"
             }
         },
         "tough-cookie": {
             "version": "2.3.4",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/tough-cookie/-/tough-cookie-2.3.4.tgz",
-            "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+            "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
             }
         },
         "trim-repeated": {
@@ -5101,7 +5155,7 @@
             "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
             "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
             "requires": {
-                "escape-string-regexp": "1.0.5"
+                "escape-string-regexp": "^1.0.2"
             }
         },
         "tslib": {
@@ -5112,15 +5166,15 @@
         },
         "tunnel": {
             "version": "0.0.5",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/tunnel/-/tunnel-0.0.5.tgz",
-            "integrity": "sha1-0VMiVHSe02Yg/NEBCGVJWh+p0K4="
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.5.tgz",
+            "integrity": "sha512-gj5sdqherx4VZKMcBA4vewER7zdK25Td+z1npBqpbDys4eJrLx+SlYjJvq1bDXs2irkuJM5pf8ktaEQVipkrbA=="
         },
         "tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
@@ -5135,13 +5189,13 @@
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2"
+                "prelude-ls": "~1.1.2"
             }
         },
         "type-detect": {
             "version": "4.0.8",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/type-detect/-/type-detect-4.0.8.tgz",
-            "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw="
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
         },
         "undefsafe": {
             "version": "2.0.2",
@@ -5149,7 +5203,7 @@
             "integrity": "sha1-Il9rngM3Zj4Njnz9aG/Cg2zKznY=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9"
+                "debug": "^2.2.0"
             },
             "dependencies": {
                 "debug": {
@@ -5165,8 +5219,8 @@
         },
         "underscore": {
             "version": "1.9.1",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/underscore/-/underscore-1.9.1.tgz",
-            "integrity": "sha1-BtzjSg5op7q8KbNluOdLiSUgOWE="
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+            "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
         },
         "union-value": {
             "version": "1.0.0",
@@ -5174,10 +5228,10 @@
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "get-value": "2.0.6",
-                "is-extendable": "0.1.1",
-                "set-value": "0.4.3"
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -5186,7 +5240,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "set-value": {
@@ -5195,10 +5249,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-extendable": "0.1.1",
-                        "is-plain-object": "2.0.4",
-                        "to-object-path": "0.3.0"
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
                     }
                 }
             }
@@ -5209,13 +5263,13 @@
             "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
             "dev": true,
             "requires": {
-                "crypto-random-string": "1.0.0"
+                "crypto-random-string": "^1.0.0"
             }
         },
         "universalify": {
             "version": "0.1.2",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY="
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         },
         "unset-value": {
             "version": "1.0.0",
@@ -5223,8 +5277,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "0.3.1",
-                "isobject": "3.0.1"
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "has-value": {
@@ -5233,9 +5287,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "0.1.4",
-                        "isobject": "2.1.0"
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -5275,16 +5329,16 @@
             "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
             "dev": true,
             "requires": {
-                "boxen": "1.3.0",
-                "chalk": "2.4.1",
-                "configstore": "3.1.2",
-                "import-lazy": "2.1.0",
-                "is-ci": "1.2.0",
-                "is-installed-globally": "0.1.0",
-                "is-npm": "1.0.0",
-                "latest-version": "3.1.0",
-                "semver-diff": "2.1.0",
-                "xdg-basedir": "3.0.0"
+                "boxen": "^1.2.1",
+                "chalk": "^2.0.1",
+                "configstore": "^3.0.0",
+                "import-lazy": "^2.1.0",
+                "is-ci": "^1.0.10",
+                "is-installed-globally": "^0.1.0",
+                "is-npm": "^1.0.0",
+                "latest-version": "^3.0.0",
+                "semver-diff": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
             }
         },
         "uri-js": {
@@ -5293,7 +5347,7 @@
             "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
             "dev": true,
             "requires": {
-                "punycode": "2.1.1"
+                "punycode": "^2.1.0"
             },
             "dependencies": {
                 "punycode": {
@@ -5328,11 +5382,11 @@
         },
         "url-parse": {
             "version": "1.4.3",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/url-parse/-/url-parse-1.4.3.tgz",
-            "integrity": "sha1-v67kVciJAjIZ11fgRfpqaE7DbBU=",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+            "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
             "requires": {
-                "querystringify": "2.0.0",
-                "requires-port": "1.0.0"
+                "querystringify": "^2.0.0",
+                "requires-port": "^1.0.0"
             }
         },
         "url-parse-lax": {
@@ -5341,7 +5395,7 @@
             "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
             "dev": true,
             "requires": {
-                "prepend-http": "1.0.4"
+                "prepend-http": "^1.0.1"
             }
         },
         "use": {
@@ -5374,8 +5428,8 @@
             "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
             "dev": true,
             "requires": {
-                "spdx-correct": "3.0.0",
-                "spdx-expression-parse": "3.0.0"
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
             }
         },
         "vasync": {
@@ -5406,9 +5460,9 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             }
         },
         "wbuf": {
@@ -5416,7 +5470,7 @@
             "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/wbuf/-/wbuf-1.7.3.tgz",
             "integrity": "sha1-wdjRSTFtPqhShIiVy2oL/oh7h98=",
             "requires": {
-                "minimalistic-assert": "1.0.1"
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "which": {
@@ -5425,7 +5479,7 @@
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "widest-line": {
@@ -5434,7 +5488,7 @@
             "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
             "dev": true,
             "requires": {
-                "string-width": "2.1.1"
+                "string-width": "^2.1.1"
             }
         },
         "wordwrap": {
@@ -5454,7 +5508,7 @@
             "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
             "dev": true,
             "requires": {
-                "mkdirp": "0.5.1"
+                "mkdirp": "^0.5.1"
             }
         },
         "write-file-atomic": {
@@ -5463,9 +5517,9 @@
             "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "imurmurhash": "0.1.4",
-                "signal-exit": "3.0.2"
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
             }
         },
         "xdg-basedir": {
@@ -5481,8 +5535,8 @@
         },
         "xpath.js": {
             "version": "1.1.0",
-            "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/xpath.js/-/xpath.js-1.1.0.tgz",
-            "integrity": "sha1-OBakTtS7NSCRCD0AKjg91RBKX/E="
+            "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
+            "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
         },
         "xregexp": {
             "version": "3.2.0",

--- a/samples/javascript_typescript/13.basic-bot/package.json
+++ b/samples/javascript_typescript/13.basic-bot/package.json
@@ -12,10 +12,10 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "botbuilder": "^4.0.5",
-        "botbuilder-ai": "^4.0.5",
-        "botbuilder-dialogs": "^4.0.5",
-        "botframework-config": "^4.0.5",
+        "botbuilder": "^4.0.6",
+        "botbuilder-ai": "^4.0.6",
+        "botbuilder-dialogs": "^4.0.6",
+        "botframework-config": "^4.0.6",
         "dotenv": "^6.0.0",
         "restify": "^6.3.4"
     },


### PR DESCRIPTION
Fixes 
typescript console-echo sample wasn't pulling botbuilder package from npm
update all typescript samples to pull latest sdk packages (4.0.6)

