### PR TITLE
Replace "\" with "/" in JS READMEs and cleanup es6 READMEs

### DIFF
--- a/samples/javascript_es6/01.a.browser-echo/README.md
+++ b/samples/javascript_es6/01.a.browser-echo/README.md
@@ -16,11 +16,6 @@ After running the bot, to see it in action, visit `http://localhost:8080`.
     ```
 - To see the bot in action, visit `http://localhost:8080` in a browser.
 
-- To reset registry, you can do
-    ```bash
-    npm config set registry https://registry.npmjs.org/
-    ```
-
 # Adapters
 Developers can use the [BotAdapter](https://docs.microsoft.com/en-us/javascript/api/botbuilder-core/botadapter) abstract base class to implement their own custom adapters.
 Implementing a custom adapter allows users to connect bots to channels not supported by the [Bot Framework](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-manage-channels?view=azure-bot-service-4.0).

--- a/samples/javascript_es6/70.styling-webchat/README.md
+++ b/samples/javascript_es6/70.styling-webchat/README.md
@@ -1,6 +1,6 @@
 This sample shows how to create a web page with customized [Web Chat](https://github.com/Microsoft/BotFramework-WebChat/) component.
 
-![Screenshot of styled Web Chat](https://raw.githubusercontent.com/Microsoft/BotBuilder-Samples/v4/samples/javascript_es6/25.styling-webchat/screenshot.png)
+![Screenshot of styled Web Chat](https://raw.githubusercontent.com/Microsoft/BotBuilder-Samples/v4/samples/javascript_es6/70.styling-webchat/screenshot.png)
 
 > You will need to obtain bot secret from a bot hosted on Azure Bot Services. You can follow this [article](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-channel-connect-webchat?view=azure-bot-service-3.0#step-1) to get the bot secret key.
 
@@ -12,7 +12,7 @@ This sample shows how to create a web page with customized [Web Chat](https://gi
    ```sh
    cd samples/javascript_es6/70.styling-webchat
    ```
-- In [`index.html`](https://github.com/Microsoft/BotBuilder-Samples/tree/v4/samples/javascript_es6/25.styling-webchat), put your bot secret key by replacing `YOUR_BOT_SECRET_FROM_AZURE` with the key
+- In [`index.html`](https://github.com/Microsoft/BotBuilder-Samples/tree/v4/samples/javascript_es6/70.styling-webchat), put your bot secret key by replacing `YOUR_BOT_SECRET_FROM_AZURE` with the key
 - Host it using [`serve`](https://npmjs.com/package/serve)
    ```sh
    npx serve

--- a/samples/javascript_nodejs/02.echobot-with-counter/README.MD
+++ b/samples/javascript_nodejs/02.echobot-with-counter/README.MD
@@ -7,9 +7,9 @@ This sample shows how to create a simple echo bot with state. The bot maintains 
     ```
 - In a terminal, 
     ```bash
-    cd samples\javascript_nodejs\02.echobot-with-counter
+    cd samples/javascript_nodejs/02.echobot-with-counter
     ```
-- [Optional] Update the .env file under samples\javascript_nodejs\02.echobot-with-counter with your botFileSecret
+- [Optional] Update the .env file under samples/javascript_nodejs/02.echobot-with-counter with your botFileSecret
     For Azure Bot Service bots, you can find the botFileSecret under application settings.
 - Install modules and start the bot
     ```bash
@@ -27,7 +27,7 @@ This sample shows how to create a simple echo bot with state. The bot maintains 
 
 ## Connect to bot using Bot Framework Emulator **V4**
 - Launch Bot Framework Emulator
-- File -> Open Bot Configuration and navigate to samples\javascript_nodejs\02.echobot-with-state folder
+- File -> Open Bot Configuration and navigate to samples/javascript_nodejs/02.echobot-with-state folder
 - Select echobot-with-counter.bot file
 
 # Bot state

--- a/samples/javascript_nodejs/04.simple-prompt/README.md
+++ b/samples/javascript_nodejs/04.simple-prompt/README.md
@@ -21,7 +21,7 @@ This sample shows how to use the prompts classes included in `botbuilder-dialogs
 
 ## Connect to bot using Bot Framework Emulator V4
 - Launch Bot Framework Emulator
-- File -> Open Bot Configuration and navigate to samples\javascript_nodejs\04.simple-prompt-bot
+- File -> Open Bot Configuration and navigate to samples/javascript_nodejs/04.simple-prompt-bot
 - Select simple-prompt-bot.bot file
 
 # Deploy this bot to Azure

--- a/samples/javascript_nodejs/06.using-cards/README.md
+++ b/samples/javascript_nodejs/06.using-cards/README.md
@@ -7,9 +7,9 @@ This sample shows how to create a bot that uses Rich Cards. This bot example use
     ```
 - In a terminal, 
     ```bash
-    cd samples\javascript_nodejs\06.using-cards
+    cd samples/javascript_nodejs/06.using-cards
     ```
-- [Optional] Update the .env file under samples\javascript_nodejs\06.using-cards with your botFileSecret
+- [Optional] Update the .env file under samples/javascript_nodejs/06.using-cards with your botFileSecret
     For Azure Bot Service bots, you can find the botFileSecret under application settings.
 - Install modules and start the bot
     ```bash
@@ -27,7 +27,7 @@ This sample shows how to create a bot that uses Rich Cards. This bot example use
 
 ## Connect to bot using Bot Framework Emulator V4
 - Launch Bot Framework Emulator
-- File -> Open Bot Configuration and navigate to samples\javascript_nodejs\06.using-cards folder
+- File -> Open Bot Configuration and navigate to samples/javascript_nodejs/06.using-cards folder
 - Select using-cards.bot file
 
 # Rich Cards

--- a/samples/javascript_nodejs/12.nlp-with-luis/README.MD
+++ b/samples/javascript_nodejs/12.nlp-with-luis/README.MD
@@ -41,7 +41,7 @@ In this sample, we demonstrate how to call LUIS to extract the intents from a us
 - Click the `Sign in` button.
 - Click on `My Apps`.
 - Click on the `Import new app` button.
-- Click on the `Choose File` and select [Reminders.json](cognitiveModels/Reminders.json) from the `BotBuilder-Samples\javascript_nodejs\12.nlp-with-luis\cognitiveModels` folder.
+- Click on the `Choose File` and select [Reminders.json](cognitiveModels/Reminders.json) from the `BotBuilder-Samples/javascript_nodejs/12.nlp-with-luis/cognitiveModels` folder.
 - Update [nlp-with-luis.bot](nlp-with-luis.bot) file with your AppId, SubscriptionKey, Region and Version. 
     You can find this information under "Publish" tab for your LUIS application at [LUIS portal](https://www.luis.ai).  For example, for
 	https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/XXXXXXXXXXXXX?subscription-key=YYYYYYYYYYYY&verbose=true&timezoneOffset=0&q= 

--- a/samples/javascript_nodejs/23.facebook-events/README.MD
+++ b/samples/javascript_nodejs/23.facebook-events/README.MD
@@ -30,7 +30,7 @@ Install the Bot Framework Emulator from [here](https://aka.ms/botframework-emula
 
 ## Connect to bot using Bot Framework Emulator V4
 - Launch Bot Framework Emulator
-- File -> Open Bot Configuration and navigate to javascript_nodejs\81.facebook-events folder
+- File -> Open Bot Configuration and navigate to samples/javascript_nodejs/23.facebook-events folder
 - Select facebook-events.bot file
 
 # Deploy this bot to Azure

--- a/samples/javascript_typescript/02.echobot-with-counter/README.MD
+++ b/samples/javascript_typescript/02.echobot-with-counter/README.MD
@@ -34,7 +34,7 @@ In order to run this sample, you must have TypeScript installed.  To install Typ
 
 ## Connect to bot using Bot Framework Emulator **V4**
 - Launch Bot Framework Emulator
-- File -> Open Bot Configuration and navigate to samples\javascript_typescript\02.echobot-with-state folder
+- File -> Open Bot Configuration and navigate to samples/javascript_typescript/02.echobot-with-state folder
 - Select echobot-with-counter.bot file
 
 # Bot state


### PR DESCRIPTION
Partial fix for #578 (JS-samples only)

## Proposed Changes
  - Update paths in READMEs to be UNIX-compatible
  - Also cleanup js_es6 READMEs