### PR TITLE
change '\' to '/' clean up paths and other errors in .netcore READMEs

### DIFF
--- a/samples/csharp_dotnetcore/01.console-echo/README.md
+++ b/samples/csharp_dotnetcore/01.console-echo/README.md
@@ -19,12 +19,12 @@ git clone https://github.com/microsoft/botbuilder-samples.git
 ```
 # Prerequisites
 ## Visual studio
-- Navigate to the samples folder (`BotBuilder-Samples\samples\csharp_dotnetcore\01.Console-EchoBot`) and open Console-EchoBot.csproj in Visual studio 
+- Navigate to the samples folder (`BotBuilder-Samples/samples/csharp_dotnetcore/01.Console-EchoBot`) and open Console-EchoBot.csproj in Visual studio 
 - Hit F5
 
 ## Visual studio code
-- Open `botbuilder-samples\samples\csharp_dotnetcore\1.Console-EchoBot` folder
-- Bring up a terminal, navigate to `botbuilder-samples\samples\csharp_dotnetcore\01.Console-EchoBot` folder
+- Open `botbuilder-samples/samples/csharp_dotnetcore/1.Console-EchoBot` folder
+- Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/01.Console-EchoBot` folder
 - Type 'dotnet run'.
 
 ## Update packages

--- a/samples/csharp_dotnetcore/01.console-echo/README.md
+++ b/samples/csharp_dotnetcore/01.console-echo/README.md
@@ -19,12 +19,12 @@ git clone https://github.com/microsoft/botbuilder-samples.git
 ```
 # Prerequisites
 ## Visual studio
-- Navigate to the samples folder (`BotBuilder-Samples/samples/csharp_dotnetcore/01.Console-EchoBot`) and open Console-EchoBot.csproj in Visual studio 
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/01.console-echo`) and open Console-EchoBot.csproj in Visual studio 
 - Hit F5
 
 ## Visual studio code
-- Open `botbuilder-samples/samples/csharp_dotnetcore/1.Console-EchoBot` folder
-- Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/01.Console-EchoBot` folder
+- Open `botbuilder-samples/samples/csharp_dotnetcore/01.console-echo` folder
+- Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/01.console-echo` folder
 - Type 'dotnet run'.
 
 ## Update packages

--- a/samples/csharp_dotnetcore/02.echo-with-counter/README.md
+++ b/samples/csharp_dotnetcore/02.echo-with-counter/README.md
@@ -5,15 +5,15 @@
 ```bash
 git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `botbuilder-samples\samples\csharp_dotnetcore\02.echo-with-counter` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/02.echo-with-counter` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 # Prerequisites
 ## Visual Studio
-- Navigate to the samples folder (`botbuilder-samples\samples\csharp_dotnetcore\02.echo-with-counter`) and open EchoBotWithCounter.csproj in Visual Studio.
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/02.echo-with-counter`) and open EchoBotWithCounter.csproj in Visual Studio.
 - Hit F5.
 
 ## Visual Studio Code
-- Open `botbuilder-samples\samples\csharp_dotnetcore\02.echo-with-counter` sample folder.
-- Bring up a terminal, navigate to `botbuilder-samples\samples\csharp_dotnetcore\02.echo-with-counter` folder.
+- Open `botbuilder-samples/samples/csharp_dotnetcore/02.echo-with-counter` sample folder.
+- Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/02.echo-with-counter` folder.
 - Type 'dotnet run'.
 
 ## Testing the bot using Bot Framework Emulator
@@ -23,7 +23,7 @@ developers to test and debug their bots on localhost or running remotely through
 
 ## Connect to bot using Bot Framework Emulator **V4**
 - Launch the Bot Framework Emulator.
-- File -> Open bot and navigate to `botbuilder-samples\samples\csharp_dotnetcore\02.echo-with-counter` folder.
+- File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/02.echo-with-counter` folder.
 - Select `BotConfiguration.bot` file.
 # Bot state
 A key to good bot design is to track the context of a conversation, so that your bot remembers things like the answers to previous questions. Depending on what your bot is used for, you may even need to keep track of conversation state or store user related information for longer than the lifetime of one given conversation.

--- a/samples/csharp_dotnetcore/03.welcome-user/readme.md
+++ b/samples/csharp_dotnetcore/03.welcome-user/readme.md
@@ -9,11 +9,11 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 
 # Prerequisites
 ## Visual Studio
-- Navigate to the samples folder (`BotBuilder-Samples/samples/csharp_dotnetcore/03.welcome-user`) and open WelcomeUser.csproj in Visual Studio 
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/03.welcome-user`) and open WelcomeUser.csproj in Visual Studio 
 - Hit F5
 ## Visual Studio Code
-- Open `BotBuilder-Samples/samples/csharp_dotnetcore/03.welcome-user` folder
-- Bring up a terminal, navigate to BotBuilder-Samples/samples/csharp_dotnetcore/03.welcome-user
+- Open `botbuilder-samples/samples/csharp_dotnetcore/03.welcome-user` folder
+- Bring up a terminal, navigate to botbuilder-samples/samples/csharp_dotnetcore/03.welcome-user
 - Type 'dotnet run'.
 
 # Testing the bot using Bot Framework Emulator V4
@@ -23,7 +23,7 @@ Microsoft Bot Framework Emulator is a desktop application that allows bot develo
 
 ## Connect to bot using Bot Framework Emulator V4
 Launch Bot Framework Emulator
-File -> Open Bot Configuration and navigate to BotBuilder-Samples/samples/03.welcome-user folder
+File -> Open Bot Configuration and navigate to botbuilder-samples/samples/csharp_dotnetcore/03.welcome-user folder
 Select BotConfiguration.bot file
 
 # ConversationUpdate Activity Type

--- a/samples/csharp_dotnetcore/03.welcome-user/readme.md
+++ b/samples/csharp_dotnetcore/03.welcome-user/readme.md
@@ -5,15 +5,15 @@
 ```bash
 git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `botbuilder-samples\samples\csharp_dotnetcore\WelcomeUser.csproj` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/WelcomeUser.csproj` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 
 # Prerequisites
 ## Visual Studio
-- Navigate to the samples folder (`BotBuilder-Samples\samples\csharp_dotnetcore\03.welcome-user`) and open WelcomeUser.csproj in Visual Studio 
+- Navigate to the samples folder (`BotBuilder-Samples/samples/csharp_dotnetcore/03.welcome-user`) and open WelcomeUser.csproj in Visual Studio 
 - Hit F5
 ## Visual Studio Code
-- Open `BotBuilder-Samples\samples\csharp_dotnetcore\03.welcome-user` folder
-- Bring up a terminal, navigate to BotBuilder-Samples\samples\csharp_dotnetcore\03.welcome-user
+- Open `BotBuilder-Samples/samples/csharp_dotnetcore/03.welcome-user` folder
+- Bring up a terminal, navigate to BotBuilder-Samples/samples/csharp_dotnetcore/03.welcome-user
 - Type 'dotnet run'.
 
 # Testing the bot using Bot Framework Emulator V4
@@ -23,7 +23,7 @@ Microsoft Bot Framework Emulator is a desktop application that allows bot develo
 
 ## Connect to bot using Bot Framework Emulator V4
 Launch Bot Framework Emulator
-File -> Open Bot Configuration and navigate to samples\03.welcome-user folder
+File -> Open Bot Configuration and navigate to BotBuilder-Samples/samples/03.welcome-user folder
 Select BotConfiguration.bot file
 
 # ConversationUpdate Activity Type

--- a/samples/csharp_dotnetcore/04.simple-prompt/readme.md
+++ b/samples/csharp_dotnetcore/04.simple-prompt/readme.md
@@ -8,12 +8,12 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 - [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/04.simple-prompt` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 # Prerequisites
 ## Visual Studio
-- Navigate to the samples folder (`BotBuilder-Samples/samples/csharp_dotnetcore/04.simple-prompt`) and open SimplePromptBot.csproj in Visual Studio.
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/04.simple-prompt`) and open SimplePromptBot.csproj in Visual Studio.
 - Hit F5.
 
 ## Visual Studio Code
-- Open `BotBuilder-Samples/samples/csharp_dotnetcore/04.simple-prompt` sample folder.
-- Bring up a terminal, navigate to `BotBuilder-Samples/samples/csharp_dotnetcore/04.simple-prompt` folder.
+- Open `botbuilder-samples/samples/csharp_dotnetcore/04.simple-prompt` sample folder.
+- Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/04.simple-prompt` folder.
 - Type 'dotnet run'.
 
 ## Update packages
@@ -26,7 +26,7 @@ developers to test and debug their bots on localhost or running remotely through
 
 ## Connect to bot using Bot Framework Emulator **V4**
 - Launch the Bot Framework Emulator.
-- File -> Open bot and navigate to `BotBuilder-Samples/samples/csharp_dotnetcore/04.simple-prompt` folder.
+- File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/04.simple-prompt` folder.
 - Select `BotConfiguration.bot` file.
 # Deploy this bot to Azure
 You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. 

--- a/samples/csharp_dotnetcore/04.simple-prompt/readme.md
+++ b/samples/csharp_dotnetcore/04.simple-prompt/readme.md
@@ -5,15 +5,15 @@ This sample demonstrates a the use of prompts with ASP.Net Core 2.
 ```bash
 git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `botbuilder-samples\samples\csharp_dotnetcore\04.simple-prompt` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/04.simple-prompt` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 # Prerequisites
 ## Visual Studio
-- Navigate to the samples folder (`BotBuilder-Samples\samples\csharp_dotnetcore\04.simple-prompt`) and open SimplePromptBot.csproj in Visual Studio.
+- Navigate to the samples folder (`BotBuilder-Samples/samples/csharp_dotnetcore/04.simple-prompt`) and open SimplePromptBot.csproj in Visual Studio.
 - Hit F5.
 
 ## Visual Studio Code
-- Open `BotBuilder-Samples\samples\csharp_dotnetcore\04.simple-prompt` sample folder.
-- Bring up a terminal, navigate to `BotBuilder-Samples\samples\csharp_dotnetcore\04.simple-prompt` folder.
+- Open `BotBuilder-Samples/samples/csharp_dotnetcore/04.simple-prompt` sample folder.
+- Bring up a terminal, navigate to `BotBuilder-Samples/samples/csharp_dotnetcore/04.simple-prompt` folder.
 - Type 'dotnet run'.
 
 ## Update packages
@@ -26,7 +26,7 @@ developers to test and debug their bots on localhost or running remotely through
 
 ## Connect to bot using Bot Framework Emulator **V4**
 - Launch the Bot Framework Emulator.
-- File -> Open bot and navigate to `BotBuilder-Samples\samples\csharp_dotnetcore\04.simple-prompt` folder.
+- File -> Open bot and navigate to `BotBuilder-Samples/samples/csharp_dotnetcore/04.simple-prompt` folder.
 - Select `BotConfiguration.bot` file.
 # Deploy this bot to Azure
 You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. 

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/readme.md
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/readme.md
@@ -5,16 +5,16 @@ This sample demonstrates a the use of multiple prompts with ASP.Net Core 2.
 ```bash
 git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `botbuilder-samples\samples\csharp_dotnetcore\05.multi-turn-prompt` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/05.multi-turn-prompt` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 
 # Prerequisites
 ## Visual Studio
-- Navigate to the samples folder (`botbuilder-samples\samples\csharp_dotnetcore\05.multi-turn-prompt`) and open MultiTurnPromptsBot.csproj in Visual Studio.
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/05.multi-turn-prompt`) and open MultiTurnPromptsBot.csproj in Visual Studio.
 - Hit F5.
 
 ## Visual Studio Code
-- Open `botbuilder-samples\samples\csharp_dotnetcore\05.multi-turn-prompt` sample folder.
-- Bring up a terminal, navigate to `botbuilder-samples\samples\csharp_dotnetcore\05.multi-turn-prompt` folder.
+- Open `botbuilder-samples/samples/csharp_dotnetcore/05.multi-turn-prompt` sample folder.
+- Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/05.multi-turn-prompt` folder.
 - Type 'dotnet run'.
 
 ## Update packages
@@ -28,7 +28,7 @@ developers to test and debug their bots on localhost or running remotely through
 
 ## Connect to bot using Bot Framework Emulator **V4**
 - Launch the Bot Framework Emulator.
-- File -> Open bot and navigate to `botbuilder-samples\samples\csharp_dotnetcore\05.multi-turn-prompt` folder.
+- File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/05.multi-turn-prompt` folder.
 - Select `BotConfiguration.bot` file.
 # Deploy this bot to Azure
 You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. 

--- a/samples/csharp_dotnetcore/06.using-cards/readme.md
+++ b/samples/csharp_dotnetcore/06.using-cards/readme.md
@@ -11,14 +11,14 @@ Most channels support rich content.  In this sample we explore the different typ
 ```bash
 git clone https://github.com/microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `botbuilder-samples\samples\csharp_dotnetcore\06.using-cards` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/06.using-cards` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 # Prerequisites
 ## Visual Studio
-- Navigate to the samples folder (`BotBuilder-Samples\samples\csharp_dotnetcore\06.using-cards`) and open CardsBot.csproj in Visual Studio 
+- Navigate to the samples folder (`BotBuilder-Samples/samples/csharp_dotnetcore/06.using-cards`) and open CardsBot.csproj in Visual Studio 
 - Hit F5
 ## Visual Studio Code
-- Open `BotBuilder-Samples\samples\csharp_dotnetcore\06.using-cards` folder
-- Bring up a terminal, navigate to BotBuilder-Samples\samples\csharp_dotnetcore\06.using-cards
+- Open `BotBuilder-Samples/samples/csharp_dotnetcore/06.using-cards` folder
+- Bring up a terminal, navigate to BotBuilder-Samples/samples/csharp_dotnetcore/06.using-cards
 - Type 'dotnet run'.
 ## Update packages
 - In Visual Studio right click on the solution and select "Restore NuGet Packages".

--- a/samples/csharp_dotnetcore/06.using-cards/readme.md
+++ b/samples/csharp_dotnetcore/06.using-cards/readme.md
@@ -14,11 +14,11 @@ git clone https://github.com/microsoft/botbuilder-samples.git
 - [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/06.using-cards` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 # Prerequisites
 ## Visual Studio
-- Navigate to the samples folder (`BotBuilder-Samples/samples/csharp_dotnetcore/06.using-cards`) and open CardsBot.csproj in Visual Studio 
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/06.using-cards`) and open CardsBot.csproj in Visual Studio 
 - Hit F5
 ## Visual Studio Code
-- Open `BotBuilder-Samples/samples/csharp_dotnetcore/06.using-cards` folder
-- Bring up a terminal, navigate to BotBuilder-Samples/samples/csharp_dotnetcore/06.using-cards
+- Open `botbuilder-samples/samples/csharp_dotnetcore/06.using-cards` folder
+- Bring up a terminal, navigate to botbuilder-samples/samples/csharp_dotnetcore/06.using-cards
 - Type 'dotnet run'.
 ## Update packages
 - In Visual Studio right click on the solution and select "Restore NuGet Packages".

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/readme.md
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/readme.md
@@ -19,11 +19,11 @@ git clone https://github.com/microsoft/botbuilder-samples.git
 - [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/07.using-adaptive-cards` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 # Prerequisites
 ## Visual Studio
-- Navigate to the samples folder (`BotBuilder-Samples/samples/csharp_dotnetcore/07.using-adaptive-cards`) and open AdaptiveCardsBot.csproj in Visual Studio 
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/07.using-adaptive-cards`) and open AdaptiveCardsBot.csproj in Visual Studio 
 - Hit F5
 ## Visual Studio Code
-- Open `BotBuilder-Samples/samples/csharp_dotnetcore/07.using-adaptive-cards` folder
-- Bring up a terminal, navigate to BotBuilder-Samples/samples/csharp_dotnetcore/07.using-adaptive-cards
+- Open `botbuilder-samples/samples/csharp_dotnetcore/07.using-adaptive-cards` folder
+- Bring up a terminal, navigate to botbuilder-samples/samples/csharp_dotnetcore/07.using-adaptive-cards
 - Type 'dotnet run'.
 ## Update packages
 - In Visual Studio right click on the solution and select "Restore NuGet Packages".

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/readme.md
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/readme.md
@@ -16,14 +16,14 @@ control the user experience. Card authors win because their content gets broader
 ```bash
 git clone https://github.com/microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `botbuilder-samples\samples\csharp_dotnetcore\07.using-adaptive-cards` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/07.using-adaptive-cards` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 # Prerequisites
 ## Visual Studio
-- Navigate to the samples folder (`BotBuilder-Samples\samples\csharp_dotnetcore\07.using-adaptive-cards`) and open AdaptiveCardsBot.csproj in Visual Studio 
+- Navigate to the samples folder (`BotBuilder-Samples/samples/csharp_dotnetcore/07.using-adaptive-cards`) and open AdaptiveCardsBot.csproj in Visual Studio 
 - Hit F5
 ## Visual Studio Code
-- Open `BotBuilder-Samples\samples\csharp_dotnetcore\07.using-adaptive-cards` folder
-- Bring up a terminal, navigate to BotBuilder-Samples\samples\csharp_dotnetcore\07.using-adaptive-cards\
+- Open `BotBuilder-Samples/samples/csharp_dotnetcore/07.using-adaptive-cards` folder
+- Bring up a terminal, navigate to BotBuilder-Samples/samples/csharp_dotnetcore/07.using-adaptive-cards
 - Type 'dotnet run'.
 ## Update packages
 - In Visual Studio right click on the solution and select "Restore NuGet Packages".

--- a/samples/csharp_dotnetcore/08.suggested-actions/readme.md
+++ b/samples/csharp_dotnetcore/08.suggested-actions/readme.md
@@ -15,14 +15,14 @@ and simplifies bot development (since you will not need to account for that scen
 ```bash
 git clone https://github.com/microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `botbuilder-samples\samples\csharp_dotnetcore\08.suggested-actions` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/08.suggested-actions` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 # Prerequisites
 ## Visual studio
-- Navigate to the samples folder (`botbuilder-samples\samples\csharp_dotnetcore\08.suggested-actions`) and open Suggested_Actions.csproj in Visual Studio 
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/08.suggested-actions`) and open Suggested_Actions.csproj in Visual Studio 
 - Hit F5
 ## Visual studio code
-- Open `botbuilder-samples\samples\csharp_dotnetcore\08.suggested-actions` folder
-- Bring up a terminal, navigate to botbuilder-samples\samples\csharp_dotnetcore\08.suggested-actions
+- Open `botbuilder-samples/samples/csharp_dotnetcore/08.suggested-actions` folder
+- Bring up a terminal, navigate to botbuilder-samples/samples/csharp_dotnetcore/08.suggested-actions
 - Type 'dotnet run'.
 ## Update packages
 - In Visual Studio right click on the solution and select "Restore NuGet Packages".

--- a/samples/csharp_dotnetcore/09.message-routing/readme.md
+++ b/samples/csharp_dotnetcore/09.message-routing/readme.md
@@ -7,23 +7,23 @@ In this sample, we create a bot that collects user information after the user gr
 git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
 ## Install BotBuilder tools
-- In a command prompt, navigate to the samples folder (`BotBuilder-Samples/samples/csharp_dotnetcore/09.message-routing`) 
+- In a command prompt, navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/09.message-routing`) 
     ```bash
-    cd BotBuilder-Samples/samples/csharp_dotnetcore/09.message-routing
+    cd botbuilder-samples/samples/csharp_dotnetcore/09.message-routing
     ```
 ## Visual Studio
-- Navigate to the samples folder (`BotBuilder-Samples/samples/csharp_dotnetcore/09.message-routing`) and open MessageRoutingBot.csproj in Visual Studio 
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/09.message-routing`) and open MessageRoutingBot.csproj in Visual Studio 
 - Hit F5
 ## Visual Studio Code
-- Open `BotBuilder-Samples/samples/csharp_dotnetcore/09.message-routing` sample folder.
-- Bring up a terminal, navigate to BotBuilder-Samples/samples/csharp_dotnetcore/09.message-routing folder
+- Open `botbuilder-samples/samples/csharp_dotnetcore/09.message-routing` sample folder.
+- Bring up a terminal, navigate to botbuilder-samples/samples/csharp_dotnetcore/09.message-routing folder
 - type 'dotnet run'
 ## Testing the bot using Bot Framework Emulator
 [Microsoft Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
 - Install the Bot Framework Emulator from [here](https://aka.ms/botframeworkemulator).
 ### Connect to bot using Bot Framework Emulator
 - Launch Bot Framework Emulator
-- File -> Open bot and navigate to `BotBuilder-Samples/samples/csharp_dotnetcore/09.message-routing` folder
+- File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/09.message-routing` folder
 - Select BotConfiguration.bot file
 # Deploy this bot to Azure
 You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. 

--- a/samples/csharp_dotnetcore/09.message-routing/readme.md
+++ b/samples/csharp_dotnetcore/09.message-routing/readme.md
@@ -7,23 +7,23 @@ In this sample, we create a bot that collects user information after the user gr
 git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
 ## Install BotBuilder tools
-- In a command prompt, navigate to the samples folder (`BotBuilder-Samples\samples\csharp_dotnetcore\09.message-routing`) 
+- In a command prompt, navigate to the samples folder (`BotBuilder-Samples/samples/csharp_dotnetcore/09.message-routing`) 
     ```bash
-    cd BotBuilder-Samples\samples\csharp_dotnetcore\09.message-routing
+    cd BotBuilder-Samples/samples/csharp_dotnetcore/09.message-routing
     ```
 ## Visual Studio
-- Navigate to the samples folder (`BotBuilder-Samples\samples\csharp_dotnetcore\09.message-routing`) and open MessageRoutingBot.csproj in Visual Studio 
+- Navigate to the samples folder (`BotBuilder-Samples/samples/csharp_dotnetcore/09.message-routing`) and open MessageRoutingBot.csproj in Visual Studio 
 - Hit F5
 ## Visual Studio Code
-- Open `BotBuilder-Samples\samples\csharp_dotnetcore\09.message-routing` sample folder.
-- Bring up a terminal, navigate to BotBuilder-Samples\samples\09.message-routing folder
+- Open `BotBuilder-Samples/samples/csharp_dotnetcore/09.message-routing` sample folder.
+- Bring up a terminal, navigate to BotBuilder-Samples/samples/csharp_dotnetcore/09.message-routing folder
 - type 'dotnet run'
 ## Testing the bot using Bot Framework Emulator
 [Microsoft Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
 - Install the Bot Framework Emulator from [here](https://aka.ms/botframeworkemulator).
 ### Connect to bot using Bot Framework Emulator
 - Launch Bot Framework Emulator
-- File -> Open bot and navigate to `BotBuilder-Samples\samples\csharp_dotnetcore\09.message-routing` folder
+- File -> Open bot and navigate to `BotBuilder-Samples/samples/csharp_dotnetcore/09.message-routing` folder
 - Select BotConfiguration.bot file
 # Deploy this bot to Azure
 You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. 

--- a/samples/csharp_dotnetcore/10.prompt-validations/readme.md
+++ b/samples/csharp_dotnetcore/10.prompt-validations/readme.md
@@ -4,14 +4,14 @@
 ```bash
 git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `botbuilder-Samples\samples\csharp_dotnetcore\10.prompt-validations` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/10.prompt-validations` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 # Prerequisites
 ## Visual Studio
-- Navigate to the samples folder (`botbuilder-Samples\samples\csharp_dotnetcore\10.prompt-validations`) and open PromptValidationsBot.csproj in Visual Studio.
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/10.prompt-validations`) and open PromptValidationsBot.csproj in Visual Studio.
 - Hit F5.
 ## Visual Studio Code
-- Open `BotBuilder-Samples\samples\csharp_dotnetcore\04.simple-prompt` sample folder.
-- Bring up a terminal, navigate to `botbuilder-Samples\samples\csharp_dotnetcore\10.prompt-validations` folder.
+- Open `botbuilder-samples/samples/csharp_dotnetcore/04.simple-prompt` sample folder.
+- Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/10.prompt-validations` folder.
 - Type 'dotnet run'.
 ## Update packages
 - In Visual Studio right click on the solution and select "Restore NuGet Packages".
@@ -22,7 +22,7 @@ developers to test and debug their bots on localhost or running remotely through
 - Install the Bot Framework emulator from [here](https://aka.ms/botframeworkemulator).
 ## Connect to bot using Bot Framework Emulator V4
 - Launch the Bot Framework Emulator.
-- File -> Open bot and navigate to `BotBuilder-Samples\samples\csharp_dotnetcore\10.prompt-validations` folder.
+- File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/10.prompt-validations` folder.
 - Select `BotConfiguration.bot` file.
  # Further reading
 - [Azure Bot Service](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)

--- a/samples/csharp_dotnetcore/11.qnamaker/README.md
+++ b/samples/csharp_dotnetcore/11.qnamaker/README.md
@@ -12,7 +12,7 @@ In this sample, we demonstrate how to use the QnA Maker service to answer questi
 ```bash
 git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `botbuilder-samples\samples\csharp_dotnetcore\11.qnamaker` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/11.qnamaker` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 # Prerequisites
 - Follow instructions [here](https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/how-to/set-up-qnamaker-service-azure)
 to create a QnA Maker service.
@@ -24,12 +24,12 @@ information under "Settings" tab for your QnA Maker Knowledge Base at [QnAMaker.
 QnA Maker CLI to deploy the model.
 
 ## Visual Studio
-- Navigate to the samples folder (`botbuilder-samples\samples\csharp_dotnetcore\11.qnamaker`) and open QnABot.csproj in Visual Studio .
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/11.qnamaker`) and open QnABot.csproj in Visual Studio .
 - Hit F5
 
 ## Visual Studio Code
-- Open `botbuilder-samples\samples\csharp_dotnetcore\11.qnamaker` sample folder.
-- Bring up a terminal, navigate to `botbuilder-samples\samples\csharp_dotnetcore\11.qnamaker` folder.
+- Open `botbuilder-samples/samples/csharp_dotnetcore/11.qnamaker` sample folder.
+- Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/11.qnamaker` folder.
 - Type 'dotnet run'.
 
 ## Update packages
@@ -39,11 +39,11 @@ QnA Maker CLI to deploy the model.
 ## Testing the bot using Bot Framework Emulator
 [Microsoft Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
 
-- Install the Bot Framework Emulator from [here](https://aka.ms/botframeworkemulator).
+- Install the Bot Framework Emulator from [here](https://aka.ms/botframework-emulator).
 
 ### Connect to bot using Bot Framework Emulator **V4**
 - Launch the Bot Framework Emulator
-- File -> Open bot and navigate to `botbuilder-samples\samples\csharp_dotnetcore\11.qnamaker` folder.
+- File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/11.qnamaker` folder.
 - Select the BotConfiguration.bot file.
 
 # Further reading

--- a/samples/csharp_dotnetcore/12.nlp-with-luis/README.md
+++ b/samples/csharp_dotnetcore/12.nlp-with-luis/README.md
@@ -5,14 +5,14 @@
 ```bash
 git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `botbuilder-samples\samples\csharp_dotnetcore\12.nlp-with-luis` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/12.nlp-with-luis` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 ## Prerequisites
 ### Set up LUIS
 - Navigate to [LUIS portal](https://www.luis.ai).
 - Click the `Sign in` button.
 - Click on `My Apps`.
 - Click on the `Import new app` button.
-- Click on the `Choose File` and select [LUIS-Reminders.json](LUIS-Reminders.json) from the `botbuilder-samples\samples\csharp_dotnetcore\12.nlp-with-luis\CognitiveModels` folder.
+- Click on the `Choose File` and select [LUIS-Reminders.json](LUIS-Reminders.json) from the `botbuilder-samples/samples/csharp_dotnetcore/12.nlp-with-luis/CognitiveModels` folder.
 - Update [BotConfiguration.bot](BotConfiguration.bot) file with your AppId, SubscriptionKey, Region and Version. 
     You can find this information under "Publish" tab for your LUIS application at [LUIS portal](https://www.luis.ai).  For example, for
 	https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/XXXXXXXXXXXXX?subscription-key=YYYYYYYYYYYY&verbose=true&timezoneOffset=0&q= 
@@ -29,12 +29,12 @@ NOTE: Once you publish your app on LUIS portal for the first time, it takes some
 - (Optional) Install the LUDown [here](https://github.com/Microsoft/botbuilder-tools/tree/master/packages/LUDown) to help describe language understanding components for your bot.
 
 ## Visual Studio
-- Navigate to the samples folder (`botbuilder-samples\samples\csharp_dotnetcore\12.nlp-with-luis`) and open `LuisBot.csproj` in Visual Studio 
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/12.nlp-with-luis`) and open `LuisBot.csproj` in Visual Studio 
 - Hit F5
 
 ## Visual Studio Code
-- Open `botbuilder-samples\samples\csharp_dotnetcore\12.nlp-with-luis` sample folder
-- Bring up a terminal, navigate to `botbuilder-samples\samples\csharp_dotnetcore\12.nlp-with-luis` folder.
+- Open `botbuilder-samples/samples/csharp_dotnetcore/12.nlp-with-luis` sample folder
+- Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/12.nlp-with-luis` folder.
 - Type 'dotnet run'.
 
 ## Testing the bot using Bot Framework Emulator
@@ -44,7 +44,7 @@ their bots on localhost or running remotely through a tunnel.
 
 ## Connect to bot using Bot Framework Emulator **V4**
 - Launch the Bot Framework Emulator
-- File -> Open bot and navigate to `botbuilder-samples\samples\csharp_dotnetcore\12.nlp-with-luis` folder
+- File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/12.nlp-with-luis` folder
 - Select BotConfiguration.bot file
 # Deploy this bot to Azure
 You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. 

--- a/samples/csharp_dotnetcore/13.basic-bot/README.md
+++ b/samples/csharp_dotnetcore/13.basic-bot/README.md
@@ -9,7 +9,7 @@ This bot has been created using [Microsoft Bot Framework](https://dev.botframewo
 ```bash
 git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/13.Basic-Bot-Template` with your botFileSecret.  
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/13.basic-bot` with your botFileSecret.  
   - For Azure Bot Service bots, you can find the botFileSecret under application settings.
   - If you use [MSBot CLI](https://github.com/microsoft/botbuilder-tools) to encrypt your bot file, the botFileSecret will be written out to the console window.
   - If you used [Bot Framework Emulator **V4**](https://github.com/microsoft/botframework-emulator) to encrypt your bot file, the secret key will be available in bot settings. 
@@ -19,7 +19,7 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 ## [Alternate to CLI] Set up LUIS via Portal
 - Navigate to [LUIS portal](https://www.luis.ai).
 - Click the `Sign in` button.
-- Click on the `Choose File` and select [basic-bot.json](basic-bot.json) from the `botbuilder-samples/csharp_dotnetcore/13.Basic-Bot-Template/CognitiveModels` folder.
+- Click on the `Choose File` and select [basic-bot.json](basic-bot.json) from the `botbuilder-samples/csharp_dotnetcore/13.basic-bot/CognitiveModels` folder.
 - Update [BasicBot.bot](BasicBot.bot) file with your AppId, SubscriptionKey, Region and Version. 
     You can find this information under "Publish" tab for your LUIS application at [LUIS portal](https://www.luis.ai).  For example, for
 	https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/XXXXXXXXXXXXX?subscription-key=YYYYYYYYYYYY&verbose=true&timezoneOffset=0&q= 
@@ -32,11 +32,11 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 NOTE: Once you publish your app on LUIS portal for the first time, it takes some time for the endpoint to become available, about 5 minutes of wait should be sufficient.
 - Update [BotConfiguration.bot](BotConfiguration.bot) file to ensure the `Id` property on the `luis` service type is set to `basic-bot-LUIS`.
 ## Visual Studio
-- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/13.Basic-Bot-Template`) and open `BasicBot.csproj` in Visual Studio.
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/13.basic-bot`) and open `BasicBot.csproj` in Visual Studio.
 - Press F5.
 ## Visual Studio Code
-- Open `BotBuilder-Samples/samples/csharp_dotnetcore/13.Basic-Bot-Template` sample folder.
-- Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/13.Basic-Bot-Template` folder.
+- Open `botbuilder-samples/samples/csharp_dotnetcore/13.basic-bot` sample folder.
+- Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/13.basic-bot` folder.
 - Type 'dotnet run'.
 ## Testing the bot using Bot Framework Emulator
 [Microsoft Bot Framework Emulator](https://aka.ms/botframework-emulator) is a desktop application that allows bot developers to test and debug
@@ -44,7 +44,7 @@ their bots on localhost or running remotely through a tunnel.
 - Install the Bot Framework Emulator from [here](https://aka.ms/botframework-emulator).
 ### Connect to bot using Bot Framework Emulator
 - Launch the Bot Framework Emulator
-- File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/13.Basic-Bot-Template` folder
+- File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/13.basic-bot` folder
 - Select `BotConfiguration.bot` file
 
 # Deploy this bot to Azure

--- a/samples/csharp_dotnetcore/13.basic-bot/README.md
+++ b/samples/csharp_dotnetcore/13.basic-bot/README.md
@@ -9,7 +9,7 @@ This bot has been created using [Microsoft Bot Framework](https://dev.botframewo
 ```bash
 git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `BotBuilder-Samples\samples\csharp_dotnetcore\13.Basic-Bot-Template` with your botFileSecret.  
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/13.Basic-Bot-Template` with your botFileSecret.  
   - For Azure Bot Service bots, you can find the botFileSecret under application settings.
   - If you use [MSBot CLI](https://github.com/microsoft/botbuilder-tools) to encrypt your bot file, the botFileSecret will be written out to the console window.
   - If you used [Bot Framework Emulator **V4**](https://github.com/microsoft/botframework-emulator) to encrypt your bot file, the secret key will be available in bot settings. 
@@ -19,7 +19,7 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 ## [Alternate to CLI] Set up LUIS via Portal
 - Navigate to [LUIS portal](https://www.luis.ai).
 - Click the `Sign in` button.
-- Click on the `Choose File` and select [basic-bot.json](basic-bot.json) from the `BotBuilder-Samples\csharp_dotnetcore\13.Basic-Bot-Template\CognitiveModels` folder.
+- Click on the `Choose File` and select [basic-bot.json](basic-bot.json) from the `botbuilder-samples/csharp_dotnetcore/13.Basic-Bot-Template/CognitiveModels` folder.
 - Update [BasicBot.bot](BasicBot.bot) file with your AppId, SubscriptionKey, Region and Version. 
     You can find this information under "Publish" tab for your LUIS application at [LUIS portal](https://www.luis.ai).  For example, for
 	https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/XXXXXXXXXXXXX?subscription-key=YYYYYYYYYYYY&verbose=true&timezoneOffset=0&q= 
@@ -32,11 +32,11 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 NOTE: Once you publish your app on LUIS portal for the first time, it takes some time for the endpoint to become available, about 5 minutes of wait should be sufficient.
 - Update [BotConfiguration.bot](BotConfiguration.bot) file to ensure the `Id` property on the `luis` service type is set to `basic-bot-LUIS`.
 ## Visual Studio
-- Navigate to the samples folder (`BotBuilder-Samples\samples\csharp_dotnetcore\13.Basic-Bot-Template`) and open `BasicBot.csproj` in Visual Studio.
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/13.Basic-Bot-Template`) and open `BasicBot.csproj` in Visual Studio.
 - Press F5.
 ## Visual Studio Code
-- Open `BotBuilder-Samples\samples\csharp_dotnetcore\13.Basic-Bot-Template` sample folder.
-- Bring up a terminal, navigate to `BotBuilder-Samples\samples\csharp_dotnetcore\13.Basic-Bot-Template` folder.
+- Open `BotBuilder-Samples/samples/csharp_dotnetcore/13.Basic-Bot-Template` sample folder.
+- Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/13.Basic-Bot-Template` folder.
 - Type 'dotnet run'.
 ## Testing the bot using Bot Framework Emulator
 [Microsoft Bot Framework Emulator](https://aka.ms/botframework-emulator) is a desktop application that allows bot developers to test and debug
@@ -44,7 +44,7 @@ their bots on localhost or running remotely through a tunnel.
 - Install the Bot Framework Emulator from [here](https://aka.ms/botframework-emulator).
 ### Connect to bot using Bot Framework Emulator
 - Launch the Bot Framework Emulator
-- File -> Open bot and navigate to `BotBuilder-Samples\samples\csharp_dotnetcore\13.Basic-Bot-Template` folder
+- File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/13.Basic-Bot-Template` folder
 - Select `BotConfiguration.bot` file
 
 # Deploy this bot to Azure

--- a/samples/csharp_dotnetcore/14.nlp-with-dispatch/README.md
+++ b/samples/csharp_dotnetcore/14.nlp-with-dispatch/README.md
@@ -27,10 +27,10 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
 ## Install BotBuilder tools
 
-- In a terminal, navigate to the samples folder (`BotBuilder-Samples\csharp_dotnetcore\14.NLP-With-Dispatch`) 
+- In a terminal, navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/14.NLP-With-Dispatch`) 
 
     ```bash
-    cd BotBuilder-Samples\csharp_dotnetcore\samples\14.nlp-with-dispatch
+    cd botbuilder-samples/samples/csharp_dotnetcore/14.nlp-with-dispatch
     ```
 
 - Install required tools - to successfully setup and configure all services this bot depend on, you need to install the MSBOT, LUIS, QnAMaker, Ludown, Dispatch CLI tools. 
@@ -85,7 +85,7 @@ To create required LUIS applications for this sample bot,
 
 To create the LUIS application this bot needs and update the .bot file configuration, in a terminal, 
 - Clone this repository
-- Navigate to BotBuilder-Samples\csharp_dotnetcore\samples\14.nlp-with-dispatch
+- Navigate to botbuilder-samples/csharp_dotnetcore/samples/14.nlp-with-dispatch
 - Run the following commands
 ```bash 
 > ludown parse toluis --in Resources/homeautomation.lu -o CognitiveModels --out homeAutomation.luis -n "Home Automation" -d "Home Automation LUIS application - Bot Builder Samples" --verbose
@@ -119,12 +119,12 @@ To create a new QnA Maker application for the bot,
 
 To create the QnA Maker application and update the .bot file with the QnA Maker configuration,  
 - Open a terminal
-- Navigate to samples\14.NLP-With-Dispatch
+- Navigate to samples/csharp_dotnetcore/14.nlp-with-dispatch
 - Run the following commands
 ```bash
 > ludown parse toqna --in resources/sample-qna.lu -o cognitiveModels --out dispatch.qna --verbose
 
-> qnamaker create kb --in cognitiveModels/dispatch.qna --subscriptionKey d30ebbcc44ef4f07bae1a0e31b69f709 --msbot | msbot connect qna --stdin
+> qnamaker create kb --in cognitiveModels/dispatch.qna --subscriptionKey <QNA-MAKER-SUBSCRIPTION-KEY> --msbot | msbot connect qna --stdin
 ```
 ### Train and publish the QnA Maker KB
 You need to train and publish the QnA Maker Knowledge Bases that were created for this sample to work. You can do so using the following CLI commands
@@ -137,7 +137,7 @@ You need to train and publish the QnA Maker Knowledge Bases that were created fo
 [Dispatch](https://github.com/Microsoft/botbuilder-tools/tree/master/packages/Dispatch) is a CLI tool that enables you to create a dispatch NLP model across the different LUIS applications and / or QnA Maker Knowledge Bases you have for your bot. For this sample, you would have already created 2 LUIS applications (Home Automation and Weather) and one QnA Maker Knowledge base. 
 
 To create a new dispatch model for these services and update the .bot file configuration, in a terminal:
-- Navigate to samples\14.nlp-with-dispatch
+- Navigate to samples/csharp_dotnetcore/14.nlp-with-dispatch
 - Run the following commands
 ```bash
 > dispatch create -b BotConfiguration.bot | msbot connect dispatch --stdin
@@ -153,12 +153,12 @@ This will generate a strong key, encrypt the bot file and print the key. Please 
 Any time the bot file is encrypted, make sure to set the botFileSecret environment variable this sample relies on (either through the .env file or other means).
 
 ## Visual Studio
-- Navigate to the samples folder (`BotBuilder-Samples\csharp_dotnetcore\14.NLP-With-Dispatch`) and open NLP-With-Dispatch-Bot.csproj in Visual Studio 
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/14.nlp-with-dispatch`) and open NLP-With-Dispatch-Bot.csproj in Visual Studio 
 - Hit F5
 
 ## Visual Studio Code
-- Open `BotBuilder-Samples\csharp_dotnetcore\14.NLP-With-Dispatch` sample folder.
-- Bring up a terminal, navigate to BotBuilder-Samples\14.NLP-With-Dispatch folder
+- Open `botbuilder-samples/samples/csharp_dotnetcore/14.nlp-with-dispatch` sample folder.
+- Bring up a terminal, navigate to botbuilder-samples/14.NLP-With-Dispatch folder
 - type 'dotnet run'
 
 ## Testing the bot using Bot Framework Emulator
@@ -168,7 +168,7 @@ Any time the bot file is encrypted, make sure to set the botFileSecret environme
 
 ### Connect to bot using Bot Framework Emulator **V4**
 - Launch Bot Framework Emulator
-- File -> Open bot and navigate to `BotBuilder-Samples\csharp_dotnetcore\14.NlpWithDispatch` folder
+- File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/14.nlp-with-dispatch` folder
 - Select BotConfiguration.bot file
 
 # Further reading

--- a/samples/csharp_dotnetcore/14.nlp-with-dispatch/README.md
+++ b/samples/csharp_dotnetcore/14.nlp-with-dispatch/README.md
@@ -27,7 +27,7 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
 ## Install BotBuilder tools
 
-- In a terminal, navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/14.NLP-With-Dispatch`) 
+- In a terminal, navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/14.nlp-with-dispatch`) 
 
     ```bash
     cd botbuilder-samples/samples/csharp_dotnetcore/14.nlp-with-dispatch

--- a/samples/csharp_dotnetcore/15.handling-attachments/readme.md
+++ b/samples/csharp_dotnetcore/15.handling-attachments/readme.md
@@ -12,14 +12,14 @@ The types of attachments that may be sent and recieved varies by channel. Additi
 ```bash
 git clone https://github.com/microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `botbuilder-samples\samples\csharp_dotnetcore\15.handling-attachments` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/15.handling-attachments` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 # Prerequisites
 ## Visual Studio
-- Navigate to the samples folder (`botbuilder-samples\samples\csharp_dotnetcore\15.handling-attachments`) and open HandlingAttachmentsBot.csproj in Visual Studio 
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/15.handling-attachments`) and open HandlingAttachmentsBot.csproj in Visual Studio 
 - Hit F5
 ## Visual Studio Code
-- Open `BotBuilder-Samples\csharp_dotnetcore\16.Handling-Attachments` folder
-- Bring up a terminal, navigate to botbuilder-samples\samples\csharp_dotnetcore\15.handling-attachments
+- Open `botbuilder-samples/samples/csharp_dotnetcore/15.handling-attachments` folder
+- Bring up a terminal, navigate to botbuilder-samples/samples/csharp_dotnetcore/15.handling-attachments
 - Type 'dotnet run'.
 ## Update packages
 - In Visual Studio right click on the solution and select "Restore NuGet Packages".

--- a/samples/csharp_dotnetcore/16.proactive-messages/README.md
+++ b/samples/csharp_dotnetcore/16.proactive-messages/README.md
@@ -21,15 +21,15 @@ question, it will share that information with the user.
 ```bash
 git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `botbuilder-samples\samples\csharp_dotnetcore\16.proactive-messages` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/16.proactive-messages` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 # Prerequisites
 ## Visual Studio
-- Navigate to the samples folder (`botbuilder-samples\samples\csharp_dotnetcore\16.proactive-messages`) and open `ProactiveBot.csproj` in Visual Studio.
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/16.proactive-messages`) and open `ProactiveBot.csproj` in Visual Studio.
 - Press F5.
 
 ## Visual Studio Code
-- Open `botbuilder-samples\samples\csharp_dotnetcore\16.proactive-messages` sample folder.
-- Bring up a console, navigate to `botbuilder-samples\samples\csharp_dotnetcore\16.proactive-messages` folder.
+- Open `botbuilder-samples/samples/csharp_dotnetcore/16.proactive-messages` sample folder.
+- Bring up a console, navigate to `botbuilder-samples/samples/csharp_dotnetcore/16.proactive-messages` folder.
 - type `dotnet run`
 
 ## Testing the bot using Bot Framework Emulator
@@ -38,7 +38,7 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 
 ### Connect to bot using Bot Framework Emulator V4
 - Launch Bot Framework Emulator
-- File -> Open bot and navigate to `botbuilder-samples\samples\csharp_dotnetcore\16.proactive-messages` folder
+- File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/16.proactive-messages` folder
 - Select `BotConfiguration.bot` file
 - Open two conversations in the emulator, see that the proactive message goes to the correct conversation
 

--- a/samples/csharp_dotnetcore/17.multilingual-bot/readme.md
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/readme.md
@@ -23,7 +23,7 @@ A more ellaborated next step would be to use the Microsoft Translator Text API t
 ```bash
 git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `botbuilder-samples\samples\csharp_dotnetcore\18.multilingual-bot` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/17.multilingual-bot` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 # Prerequisites
 
 ## Microsoft Translator Text API
@@ -33,12 +33,12 @@ Paste the key in the ```translationKey``` placeholder within the appsettings.jso
 
 
 ## Visual Studio
-- Navigate to the samples folder (`botbuilder-samples\samples\csharp_dotnetcore\18.multilingual-bot`) and open MessageRoutingBot.csproj in Visual Studio 
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/17.multilingual-bot`) and open MessageRoutingBot.csproj in Visual Studio 
 - Hit F5
 
 ## Visual Studio Code
-- Open `botbuilder-samples\samples\csharp_dotnetcore\18.multilingual-bot` sample folder.
-- Bring up a terminal, navigate to BotBuilder-Samples\18.Multi-Lingual-Bot folder
+- Open `botbuilder-samples/samples/csharp_dotnetcore/17.multilingual-bot` sample folder.
+- Bring up a terminal, navigate to botbuilder-samples/samples/csharp_dotnetcore/17.multilingual-bot folder
 - type 'dotnet run'
 
 ## Testing the bot using Bot Framework Emulator
@@ -48,7 +48,7 @@ Paste the key in the ```translationKey``` placeholder within the appsettings.jso
 
 ### Connect to bot using Bot Framework Emulator V4
 - Launch Bot Framework Emulator
-- File -> Open bot and navigate to `botbuilder-samples\samples\csharp_dotnetcore\18.multilingual-bot` folder
+- File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/17.multilingual-bot` folder
 - Select MessageRouting.bot file
 
 # Deploy this bot to Azure

--- a/samples/csharp_dotnetcore/18.bot-authentication/readme.md
+++ b/samples/csharp_dotnetcore/18.bot-authentication/readme.md
@@ -13,13 +13,13 @@ updates also take steps towards an improved user experience by eliminating the m
 ```bash
 git clone https://github.com/microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `BotBuilder-Samples\samples\csharp_dotnetcore\18.bot-authentication` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/18.bot-authentication` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 ## Visual Studio
-- Navigate to the samples folder (`BotBuilder-Samples\samples\csharp_dotnetcore\18.bot-authentication`) and open AuthenticationBot.csproj in Visual Studio 
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/18.bot-authentication`) and open AuthenticationBot.csproj in Visual Studio 
 - Hit F5
 ## Visual Studio Code
-- Open `BotBuilder-Samples\csharp_dotnetcore\7.Using-Adaptive-Cards` folder
-- Bring up a terminal, navigate to BotBuilder-Samples\samples\csharp_dotnetcore\18.bot-authentication
+- Open `botbuilder-samples/samples/csharp_dotnetcore/18.bot-authentication` folder
+- Bring up a terminal, navigate to botbuilder-samples/samples/csharp_dotnetcore/18.bot-authentication
 - Type 'dotnet run'.
 ## Update packages
 - In Visual Studio right click on the solution and select "Restore NuGet Packages".
@@ -31,7 +31,7 @@ developers to test and debug their bots on localhost or running remotely through
 
 ## Connect to bot using Bot Framework Emulator **V4**
 - Launch the Bot Framework Emulator.
-- File -> Open bot and navigate to `botbuilder-samples\samples\csharp_dotnetcore\02.echo-with-counter` folder.
+- File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/18.bot-authentication` folder.
 - Select `BotConfiguration.bot` file.
 # Deploy this bot to Azure
 You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. 

--- a/samples/csharp_dotnetcore/19.custom-dialogs/readme.md
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/readme.md
@@ -5,15 +5,15 @@ This sample demonstrates a the use of prompts with ASP.Net Core 2.
 ```bash
 git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `botbuilder-samples\samples\csharp_dotnetcore\19.custom-dialogs` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/19.custom-dialogs` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 # Prerequisites
 ## Visual Studio
-- Navigate to the samples folder (`BotBuilder-Samples\samples\csharp_dotnetcore\19.custom-dialogs`) and open Custom-Dialogs.csproj in Visual Studio.
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/19.custom-dialogs`) and open Custom-Dialogs.csproj in Visual Studio.
 - Hit F5.
 
 ## Visual Studio Code
-- Open `BotBuilder-Samples\samples\csharp_dotnetcore\19.custom-dialogs` sample folder.
-- Bring up a terminal, navigate to `BotBuilder-Samples\samples\csharp_dotnetcore\19.custom-dialogs` folder.
+- Open `botbuilder-samples/samples/csharp_dotnetcore/19.custom-dialogs` sample folder.
+- Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/19.custom-dialogs` folder.
 - Type 'dotnet run'.
 
 ## Update packages
@@ -26,7 +26,7 @@ developers to test and debug their bots on localhost or running remotely through
 
 ## Connect to bot using Bot Framework Emulator **V4**
 - Launch the Bot Framework Emulator.
-- File -> Open bot and navigate to `BotBuilder-Samples\samples\csharp_dotnetcore\19.custom-dialogs` folder.
+- File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/19.custom-dialogs` folder.
 - Select `BotConfiguration.bot` file.
 # Deploy this bot to Azure
 You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. 

--- a/samples/csharp_dotnetcore/20.qna-with-appinsights/README.md
+++ b/samples/csharp_dotnetcore/20.qna-with-appinsights/README.md
@@ -14,7 +14,7 @@ In this sample, we demonstrate how to use the QnA Maker service to answer questi
 ```bash
 git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `botbuilder-samples\samples\csharp_dotnetcore\12.nlp-with-luis` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/20.qna-with-appinsights` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 
 ## Prerequisites
 - Follow instructions [here](https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/how-to/set-up-qnamaker-service-azure)
@@ -31,12 +31,12 @@ Qna Maker CLI to deploy the model.
 
 
 ## Visual Studio
-- Navigate to the samples folder (`BotBuilder-Samples\csharp_dotnetcore\22.qna-with-appinsightss`) and open QnABot.csproj in Visual Studio.
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/20.qna-with-appinsights`) and open QnABot.csproj in Visual Studio.
 - Hit F5
 
 ## Visual Studio Code
-- Open `botbuilder-samples\samples\csharp_dotnetcore\22.qna-with-appinsightss` sample folder
-- Bring up a terminal, navigate to `botbuilder-samples\samples\csharp_dotnetcore\22.qna-with-appinsights` folder.
+- Open `botbuilder-samples/samples/csharp_dotnetcore/20.qna-with-appinsights` sample folder
+- Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/20.qna-with-appinsights` folder.
 - Type 'dotnet run'.
 
 ## Testing the bot using Bot Framework Emulator
@@ -46,7 +46,7 @@ Qna Maker CLI to deploy the model.
 
 ## Connect to bot using Bot Framework Emulator **V4**
 - Launch the Bot Framework Emulator
-- File -> Open bot and navigate to `BotBuilder-Samples\samples\csharp_dotnetcore\22.qna-with-appinsights` folder.
+- File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/20.qna-with-appinsights` folder.
 - Select the BotConfiguration.bot file.
 
 # Deploy this bot to Azure

--- a/samples/csharp_dotnetcore/21.luis-with-appinsights/README.md
+++ b/samples/csharp_dotnetcore/21.luis-with-appinsights/README.md
@@ -5,7 +5,7 @@
 ```bash
 git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `botbuilder-samples\samples\csharp_dotnetcore\23.luis-with-appsinsights` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples\samples\csharp_dotnetcore\21.luis-with-appsinsights` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 
 ## Prerequisites
 ### Set up LUIS
@@ -33,12 +33,12 @@ NOTE: Once you publish your app on LUIS portal for the first time, it takes some
   - Note: The Application Insights will automatically update the [appsettings.json](appsettings.json) file.
 
 ### Visual Studio
-- Navigate to the samples folder (`botbuilder-samples\samples\csharp_dotnetcore\12.nlp-with-luis`) and open `LuisBotAllInsights.csproj` in Visual Studio 
+- Navigate to the samples folder (`botbuilder-samples\samples\csharp_dotnetcore\21.luis-with-appsinsights`) and open `LuisBotAllInsights.csproj` in Visual Studio 
 - Hit F5
 
 ### Visual Studio Code
-- Open `botbuilder-samples\samples\csharp_dotnetcore\23.luis-with-appsinsights` sample folder
-- Bring up a terminal, navigate to `botbuilder-samples\samples\csharp_dotnetcore\23.luis-with-appsinsights` folder.
+- Open `botbuilder-samples\samples\csharp_dotnetcore\21.luis-with-appsinsights` sample folder
+- Bring up a terminal, navigate to `botbuilder-samples\samples\csharp_dotnetcore\21.luis-with-appsinsights` folder.
 - Type 'dotnet run'.
 
 ## Testing the bot using Bot Framework Emulator
@@ -48,7 +48,7 @@ NOTE: Once you publish your app on LUIS portal for the first time, it takes some
 
 ## Connect to bot using Bot Framework Emulator V4
 - Launch the Bot Framework Emulator
-- File -> Open bot and navigate to `BotBuilder-Samples\csharp_dotnetcore\23.LUIS-with-AppInsights` folder.
+- File -> Open bot and navigate to `botbuilder-samples\samples\csharp_dotnetcore\21.luis-with-appsinsights` folder.
 - Select BotConfiguration.bot file.
 
 # Deploy this bot to Azure

--- a/samples/csharp_dotnetcore/22.conversation-history/README.md
+++ b/samples/csharp_dotnetcore/22.conversation-history/README.md
@@ -5,17 +5,17 @@
 ```bash
 git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `BotConfiguration.bot` file under `botbuilder-samples\samples\csharp_dotnetcore\22.conversation-history` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `BotConfiguration.bot` file under `botbuilder-samples/samples/csharp_dotnetcore/22.conversation-history` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 # Prerequisites
 ## Visual Studio
-- Navigate to the samples folder (`botbuilder-samples\samples\csharp_dotnetcore\22.conversation-history`) and open ConversationHistory.csproj in Visual Studio.
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/22.conversation-history`) and open ConversationHistory.csproj in Visual Studio.
 - Set the BLOB store connection-string in BotConfiguration.bot
 - Hit F5.
 
 ## Visual Studio Code
-- Open `botbuilder-samples\samples\csharp_dotnetcore\22.conversation-history` sample folder.
+- Open `botbuilder-samples/samples/csharp_dotnetcore/22.conversation-history` sample folder.
 - Set the BLOB store connection-string in BotConfiguration.bot
-- Bring up a terminal, navigate to `botbuilder-samples\samples\csharp_dotnetcore\22.conversation-history` folder.
+- Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/22.conversation-history` folder.
 - Type 'dotnet run'.
 
 ## Testing the bot using Bot Framework Emulator
@@ -25,7 +25,7 @@ developers to test and debug their bots on localhost or running remotely through
 
 ## Connect to bot using Bot Framework Emulator **V4**
 - Launch the Bot Framework Emulator.
-- File -> Open bot and navigate to `botbuilder-samples\samples\csharp_dotnetcore\22.conversation-history` folder.
+- File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/22.conversation-history` folder.
 - Select `ConversationHistory.bot` file.
 
 # Further reading

--- a/samples/csharp_dotnetcore/23.facebook-events/README.md
+++ b/samples/csharp_dotnetcore/23.facebook-events/README.md
@@ -11,15 +11,15 @@ Since Bot Framework supports multiple Facebook pages for a single bot, we also s
 ```bash
 git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `botbuilder-samples\samples\csharp_dotnetcore\23.facebook-events` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/23.facebook-events` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 # Prerequisites
 ## Visual Studio
-- Navigate to the samples folder (`botbuilder-samples\samples\csharp_dotnetcore\23.facebook-events`) and open Facebook-Events-Bot.csproj in Visual Studio 
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/23.facebook-events`) and open Facebook-Events-Bot.csproj in Visual Studio 
 - Hit F5
 
 ## Visual Studio Code
-- Open `botbuilder-samples\samples\csharp_dotnetcore\23.facebook-events` sample folder.
-- Bring up a terminal, navigate to BotBuilder-Samples\81.Facebook-Events folder
+- Open `botbuilder-samples/samples/csharp_dotnetcore/23.facebook-events` sample folder.
+- Bring up a terminal, navigate to botbuilder-samples/samples/csharp_dotnetcore/23.Facebook-Events folder
 - type 'dotnet run'
 
 ## Testing the bot using Bot Framework Emulator
@@ -29,7 +29,7 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 
 ### Connect to bot using Bot Framework Emulator V4
 - Launch Bot Framework Emulator
-- File -> Open bot and navigate to `botbuilder-samples\samples\csharp_dotnetcore\23.facebook-events` folder
+- File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/23.facebook-events` folder
 - Select BotConfiguration.bot file
 
 ### Enable Facebook Channel

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/readme.md
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/readme.md
@@ -25,13 +25,13 @@ including Windows, Office 365, and Azure.
 ```bash
 git clone https://github.com/microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `botbuilder-samples\samples\csharp_dotnetcore\24.bot-authentication-msgraph` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/24.bot-authentication-msgraph` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 ## Visual Studio
-- Navigate to the samples folder (`botbuilder-samples\samples\csharp_dotnetcore\24.bot-authentication-msgraph`) and open BotAuthenticationMSGraph.csproj in Visual Studio 
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/24.bot-authentication-msgraph`) and open BotAuthenticationMSGraph.csproj in Visual Studio 
 - Hit F5
 ## Visual Studio Code
-- Open `botbuilder-samples\samples\csharp_dotnetcore\24.bot-authentication-msgraph\` folder
-- Bring up a terminal, navigate to botbuilder-samples\samples\csharp_dotnetcore\24.bot-authentication-msgraph
+- Open `botbuilder-samples/samples/csharp_dotnetcore/24.bot-authentication-msgraph` folder
+- Bring up a terminal, navigate to botbuilder-samples/samples/csharp_dotnetcore/24.bot-authentication-msgraph
 - Type 'dotnet run'.
 ## Update packages
 - In Visual Studio right click on the solution and select "Restore NuGet Packages".
@@ -42,7 +42,7 @@ developers to test and debug their bots on localhost or running remotely through
 
 ## Connect to bot using Bot Framework Emulator **V4**
 - Launch the Bot Framework Emulator.
-- File -> Open bot and navigate to `botbuilder-samples\samples\csharp_dotnetcore\02.echo-with-counter` folder.
+- File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/24.bot-authentication-msgraph` folder.
 - Select `BotConfiguration.bot` file.
 # Deploy this bot to Azure
 You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. 

--- a/samples/csharp_dotnetcore/51.cafe-bot/README.md
+++ b/samples/csharp_dotnetcore/51.cafe-bot/README.md
@@ -47,11 +47,11 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 
 ```
 ## Visual Studio
-- Navigate to the samples folder (`BotBuilder-Samples\samples\csharp_dotnetcore\51.cafe-bot`) and open `CafeBot.csproj` in Visual Studio.
+- Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/51.cafe-bot`) and open `CafeBot.csproj` in Visual Studio.
 - Press F5.
 ## Visual Studio Code
-- Open `BotBuilder-Samples\csharp_dotnetcore\51.cafe-bot` sample folder.
-- Bring up a terminal, navigate to `BotBuilder-Samples\samples\csharp_dotnetcore\51.cafe-bot` folder.
+- Open `botbuilder-samples/samples/csharp_dotnetcore/51.cafe-bot` sample folder.
+- Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/51.cafe-bot` folder.
 - Type 'dotnet run'.
 
 
@@ -62,7 +62,7 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 
 ## Connect to bot using Bot Framework Emulator V4
 - Launch Bot Framework Emulator
-- File -> Open Bot Configuration and navigate to `BotBuilder-Samples\samples\csharp_dotnetcore\51.cafe-bot`
+- File -> Open Bot Configuration and navigate to `botbuilder-samples/samples/csharp_dotnetcore/51.cafe-bot`
 - Select CafeBot.bot
 
 # Prerequisites
@@ -94,26 +94,26 @@ Optionally, you can use the LUIS, QnA Maker portals to manually import the model
 ## Building and creating services
 - Parse .lu files into LUIS models
     ```bash
-    > ludown parse toluis --in Dialogs\Dispatcher\Resources\cafeDispatchModel.lu -o cognitiveModels -n cafeDispatchModel --out cafeDispatchModel.luis
-    > ludown parse toluis --in Dialogs\BookTable\Resources\turn-N.lu -o cognitiveModels -n cafeBotBookTableTurnNModel --out cafeBotBookTableTurnN.luis
-    > ludown parse toluis --in Dialogs\WhoAreYou\Resources\getUserProfile.lu -o cognitiveModels -n getUserProfile --out getUserProfile.luis
+    > ludown parse toluis --in Dialogs/Dispatcher/Resources/cafeDispatchModel.lu -o cognitiveModels -n cafeDispatchModel --out cafeDispatchModel.luis
+    > ludown parse toluis --in Dialogs/BookTable/Resources/turn-N.lu -o cognitiveModels -n cafeBotBookTableTurnNModel --out cafeBotBookTableTurnN.luis
+    > ludown parse toluis --in Dialogs/WhoAreYou/Resources/getUserProfile.lu -o cognitiveModels -n getUserProfile --out getUserProfile.luis
     ```
 - Parse .lu files into QnA Maker KB and QnA Maker alterations file
     ```bash
-    > ludown parse toqna --in Dialogs\Dispatcher\Resources\cafeFAQ_ChitChat.lu -o cognitiveModels -n
+    > ludown parse toqna --in Dialogs/Dispatcher/Resources/cafeFAQ_ChitChat.lu -o cognitiveModels -n
 cafeFaqChitChat --out cafeFaqChitChat.qna -a
     ```
 - Import LUIS applications (Note: You don't need this if you have already run MSBOT clone)
     ```bash
-    > luis import application --in CognitiveModels\cafeDispatchModel.luis --authoringKey <Your LUIS authoring key> --region <LUIS-Authoring-Region> --msbot | msbot connect luis --stdin
-    > luis import application --in CognitiveModels\cafeBotBookTableTurnN.luis --authoringKey <Your LUIS authoring key> --region <LUIS-Authoring-Region> --msbot | msbot connect luis --stdin
-    > luis import application --in CgnitiveModels\getUserProfile.luis --authoringKey <Your LUIS authoring key> --region <LUIS-Authoring-Region> --msbot | msbot connect luis --stdin
+    > luis import application --in CognitiveModels/cafeDispatchModel.luis --authoringKey <Your LUIS authoring key> --region <LUIS-Authoring-Region> --msbot | msbot connect luis --stdin
+    > luis import application --in CognitiveModels/cafeBotBookTableTurnN.luis --authoringKey <Your LUIS authoring key> --region <LUIS-Authoring-Region> --msbot | msbot connect luis --stdin
+    > luis import application --in CgnitiveModels/getUserProfile.luis --authoringKey <Your LUIS authoring key> --region <LUIS-Authoring-Region> --msbot | msbot connect luis --stdin
     ```
     **Note**: LUIS authoring region can be one of westus or westeurope or australiaeast
 
 - Import QnA Maker KBs (Note: You don't need this if you have already run MSBOT clone)
     ```bash
-    > qnamaker create kb --in CognitiveModels\cafeFaqChitChat.qna --subscriptionKey <YOUR QnA Maker Subscription Key> --msbot | msbot connect qna --stdin
+    > qnamaker create kb --in CognitiveModels/cafeFaqChitChat.qna --subscriptionKey <YOUR QnA Maker Subscription Key> --msbot | msbot connect qna --stdin
     ```
     **Note**: See [here](https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/quickstarts/create-new-kb-nodejs) for instructions on setting up a Cognitive Service API account and fetching your QnA Maker subscription Key. 
 
@@ -138,7 +138,7 @@ cafeFaqChitChat --out cafeFaqChitChat.qna -a
     ```
 - Replace QnA Maker alterations
     ```bash
-    > msbot get cafeFaqChitChat | qnamaker replace alterations --in CognitiveModels\cafeFaqChitChat.qna_Alterations.json --stdin
+    > msbot get cafeFaqChitChat | qnamaker replace alterations --in CognitiveModels/cafeFaqChitChat.qna_Alterations.json --stdin
     ```
 
 ## Updating and publishing LUIS models
@@ -148,7 +148,7 @@ cafeFaqChitChat --out cafeFaqChitChat.qna -a
     ```
 - Import a LUIS application version
     ```bash
-    > msbot get cafeDispatchModel | luis import version --stdin --in CognitiveModels\cafeDispatchModel.luis
+    > msbot get cafeDispatchModel | luis import version --stdin --in CognitiveModels/cafeDispatchModel.luis
     ```
 - Deleting old LUIS application version
     ```bash
@@ -159,5 +159,5 @@ cafeFaqChitChat --out cafeFaqChitChat.qna -a
 
 - Replace KB contents
     ```bash
-    > msbot get cafeFaqChitChat | qnamaker replace kb --in CognitiveModels\cafeFaqChitChat.qna --stdin
+    > msbot get cafeFaqChitChat | qnamaker replace kb --in CognitiveModels/cafeFaqChitChat.qna --stdin
     ```

--- a/samples/csharp_dotnetcore/52.enterprise-bot/readme.md
+++ b/samples/csharp_dotnetcore/52.enterprise-bot/readme.md
@@ -25,7 +25,7 @@
 
 4. Run the following command from the project directory:
  
-    `msbot clone services --name "<NAME>" --luisAuthoringKey "<YOUR AUTHORING KEY>" --folder "DeploymentScripts\msbotClone" --location "westus" --verbose`
+    `msbot clone services --name "<NAME>" --luisAuthoringKey "<YOUR AUTHORING KEY>" --folder "DeploymentScripts/msbotClone" --location "westus" --verbose`
 
     **NOTE**: By default your Luis Applications will be deployed to your free starter endpoint. An Azure LUIS service will be deployed along with your bot but you must manually add and publish to it from the luis.ai portal and update your key in the .bot file.
 


### PR DESCRIPTION
Fixes #578 for .netcore READMEs

Also a lot of other fixes in the READMEs to have better support for non-Windows devs (i.e. casing on the `git clone` matches the casing in `cd botbuilder-samples/samples/csharp_dotnetcore/<some-sample>`)