### PR TITLE
Fix random number generation sample 7

### DIFF
--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/AdaptiveCardsBot.cs
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/AdaptiveCardsBot.cs
@@ -61,7 +61,7 @@ namespace Microsoft.BotBuilderSamples
             if (turnContext.Activity.Type == ActivityTypes.Message)
             {
                 Random r = new Random();
-                var cardAttachment = CreateAdaptiveCardAttachment(this._cards[r.Next(0, this._cards.Length - 1)]);
+                var cardAttachment = CreateAdaptiveCardAttachment(this._cards[r.Next(this._cards.Length)]);
                 var reply = turnContext.Activity.CreateReply();
                 reply.Attachments = new List<Attachment>() { cardAttachment };
                 await turnContext.SendActivityAsync(reply, cancellationToken);


### PR DESCRIPTION
## Proposed Changes

In [Random.Next(Int32, Int32)](https://docs.microsoft.com/en-us/dotnet/api/system.random.next?view=netcore-2.0#System_Random_Next_System_Int32_System_Int32_), the maxValue parameter is exclusive, but in this sample it's mistakenly treated as though it's inclusive. This means `random.Next(0, 4)` will only return 0, 1, 2, or 3, thus excluding the fifth card which is at index 4. I've not only changed it to use a maxValue of 5 (the length of the card array), I'm using the overload [Random.Next(Int32)](https://docs.microsoft.com/en-us/dotnet/api/system.random.next?view=netcore-2.0#System_Random_Next_System_Int32_) because there's no need to supply a minValue of 0.