### PR TITLE
Fixes to CafeBots OnTurnProperty and BookTableDialog classes

### DIFF
--- a/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/BookTable/BookTableDialog.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/BookTable/BookTableDialog.cs
@@ -162,12 +162,7 @@ namespace Microsoft.BotBuilderSamples
                 // Start the prompt with the initial feedback based on update results.
                 var options = new PromptOptions()
                 {
-                    /* Had to change this to fix an issue with the bot emulator. The emulator was
-                       receiving a message from the bot that was missing the 'message' type in the JSON object.*/
-
-                       //TODO: Review 
                     Prompt = MessageFactory.Text(reservationResult.Outcome[0].Message),
-                    //Prompt = new Activity(text: reservationResult.Outcome[0].Message),
                 };
                 return await stepContext.PromptAsync(GetLocationDateTimePartySizePrompt, options);
             }
@@ -181,12 +176,7 @@ namespace Microsoft.BotBuilderSamples
 
                 var options = new PromptOptions()
                 {
-                    /* Had to change this to fix an issue with the bot emulator. The emulator was
-                       receiving a message from the bot that was missing the 'message' type in the JSON object.*/
-                       
-                       //TODO: Review 
                     Prompt = MessageFactory.Text(reservationResult.NewReservation.GetMissingPropertyReadOut()),
-                    //Prompt = new Activity(text: reservationResult.NewReservation.GetMissingPropertyReadOut()),
                 };
 
                 // Start the prompt with the first missing piece of information.

--- a/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/BookTable/BookTableDialog.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/BookTable/BookTableDialog.cs
@@ -162,7 +162,12 @@ namespace Microsoft.BotBuilderSamples
                 // Start the prompt with the initial feedback based on update results.
                 var options = new PromptOptions()
                 {
-                    Prompt = new Activity(text: reservationResult.Outcome[0].Message),
+                    /* Had to change this to fix an issue with the bot emulator. The emulator was
+                       receiving a message from the bot that was missing the 'message' type in the JSON object.*/
+
+                       //TODO: Review 
+                    Prompt = MessageFactory.Text(reservationResult.Outcome[0].Message),
+                    //Prompt = new Activity(text: reservationResult.Outcome[0].Message),
                 };
                 return await stepContext.PromptAsync(GetLocationDateTimePartySizePrompt, options);
             }
@@ -176,7 +181,12 @@ namespace Microsoft.BotBuilderSamples
 
                 var options = new PromptOptions()
                 {
-                    Prompt = new Activity(text: reservationResult.NewReservation.GetMissingPropertyReadOut()),
+                    /* Had to change this to fix an issue with the bot emulator. The emulator was
+                       receiving a message from the bot that was missing the 'message' type in the JSON object.*/
+                       
+                       //TODO: Review 
+                    Prompt = MessageFactory.Text(reservationResult.NewReservation.GetMissingPropertyReadOut()),
+                    //Prompt = new Activity(text: reservationResult.NewReservation.GetMissingPropertyReadOut()),
                 };
 
                 // Start the prompt with the first missing piece of information.

--- a/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Shared/StateProperties/OnTurnProperty.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Shared/StateProperties/OnTurnProperty.cs
@@ -52,8 +52,6 @@ namespace Microsoft.BotBuilderSamples
                 if (value is JArray)
                 {
                     // ConfirmList is nested arrays.
-                    
-                    //TODO: Review fix:
                     value = (from val in (JArray)value
                               select val).FirstOrDefault();
                 }

--- a/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Shared/StateProperties/OnTurnProperty.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Shared/StateProperties/OnTurnProperty.cs
@@ -52,7 +52,10 @@ namespace Microsoft.BotBuilderSamples
                 if (value is JArray)
                 {
                     // ConfirmList is nested arrays.
-                    value = value.Children().FirstOrDefault().FirstOrDefault();
+                    
+                    //TODO: Review fix:
+                    value = (from val in (JArray)value
+                              select val).FirstOrDefault();
                 }
 
                 strVal = (string)value;


### PR DESCRIPTION
Fixes #636 
Line 55 of OnTurnProperty.cs file
Line 168 and 186 on BookTableDialog.cs file

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->
<!-- If you are introducing a new sample, make sure that the sample adheres to sample guidelines -->

  - The fix in OnTurnProperty is to prevent an error being given for not being able to find the Method "FirstOrDefault" on JToken
  - The fixes in the BookTableDialog file fixes an issue where the bot was not returning an actual message to the emulator. 
 
