### PR TITLE
fixing watch script for typescript samples

### DIFF
--- a/samples/javascript_typescript/01.console-echo/package.json
+++ b/samples/javascript_typescript/01.console-echo/package.json
@@ -7,7 +7,7 @@
     "build-sample": "tsc",
     "start": "tsc && node ./lib/index.js",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "watch": "nodemon ./lib/index.js"
+    "watch": "nodemon -e ts --exec \"npm start\""
   },
   "author": "Microsoft",
   "license": "MIT",

--- a/samples/javascript_typescript/02.echobot-with-counter/package.json
+++ b/samples/javascript_typescript/02.echobot-with-counter/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build-sample": "tsc",
     "start": "tsc && node ./lib/index.js",
-    "watch": "nodemon ./lib/index.js"
+    "watch": "nodemon -e ts --exec \"npm start\""
   },
   "author": "Microsoft",
   "license": "MIT",

--- a/samples/javascript_typescript/11.qnamaker/package.json
+++ b/samples/javascript_typescript/11.qnamaker/package.json
@@ -7,7 +7,7 @@
     "build-sample": "tsc",
     "start": "tsc && node ./lib/index.js",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "watch": "nodemon ./lib/index.js"
+    "watch": "nodemon -e ts --exec \"npm start\""
   },
   "author": "Microsoft",
   "license": "MIT",

--- a/samples/javascript_typescript/12.nlp-with-luis/package.json
+++ b/samples/javascript_typescript/12.nlp-with-luis/package.json
@@ -7,7 +7,7 @@
     "build-sample": "tsc",
     "start": "tsc && node ./lib/index.js",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "watch": "nodemon ./lib/index.js"
+    "watch": "nodemon -e ts --exec \"npm start\""
   },
   "author": "Microsoft",
   "license": "MIT",

--- a/samples/javascript_typescript/13.basic-bot/package.json
+++ b/samples/javascript_typescript/13.basic-bot/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "build-sample": "tsc",
         "start": "tsc && node ./lib/index.js",
-        "watch": "tsc && nodemon ./lib/index.js",
+        "watch": "nodemon -e ts --exec \"npm start\"",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {


### PR DESCRIPTION
Nodemon was only watching for javascript file changes in `lib` folder, and that prevented re-starting the project when you change a typescript file in `src` folder.

So I simply added `ts` file watch to nodemon. Nodemon will be running `npm start` whenever a `ts` file is changed in this way.