### PR TITLE
[nodejs][21.luis-with-appinsights] Fix luis configuration & typos

### DIFF
--- a/samples/javascript_nodejs/21.luis-with-appinsights/index.js
+++ b/samples/javascript_nodejs/21.luis-with-appinsights/index.js
@@ -55,7 +55,7 @@ const luisApplication = {
 const logMessage = true;
 const logName = true;
 
-// Map the contents of appInsightsConfig to a consumable format for MyAppInsightsMiddleawre.
+// Map the contents of appInsightsConfig to a consumable format for MyAppInsightsMiddleware.
 const appInsightsSettings = {
     instrumentationKey: appInsightsConfig.instrumentationKey,
     logOriginalMessage: logMessage,

--- a/samples/javascript_nodejs/21.luis-with-appinsights/index.js
+++ b/samples/javascript_nodejs/21.luis-with-appinsights/index.js
@@ -45,7 +45,7 @@ const appInsightsConfig = botConfig.findServiceByNameOrId(APP_INSIGHTS_CONFIGURA
 // Map the contents of luisConfig to a consumable format for our MyAppInsightsLuisRecognizer class.
 const luisApplication = {
     applicationId: luisConfig.appId,
-    endpointKey: luisConfig.endpointKey,
+    endpointKey: luisConfig.subscriptionKey || luisConfig.authoringKey,
     endpoint: luisConfig.getEndpoint()
 };
 

--- a/samples/javascript_nodejs/21.luis-with-appinsights/index.js
+++ b/samples/javascript_nodejs/21.luis-with-appinsights/index.js
@@ -46,7 +46,7 @@ const appInsightsConfig = botConfig.findServiceByNameOrId(APP_INSIGHTS_CONFIGURA
 const luisApplication = {
     applicationId: luisConfig.appId,
     endpointKey: luisConfig.endpointKey,
-    ednpoint: `https://${luisConfig.region}.api.cognitive.microsoft.com`
+    endpoint: luisConfig.getEndpoint()
 };
 
 // Create two variables to indicate whether or not the bot should include messages' text and usernames when

--- a/samples/javascript_nodejs/21.luis-with-appinsights/luis-with-appinsights.bot
+++ b/samples/javascript_nodejs/21.luis-with-appinsights/luis-with-appinsights.bot
@@ -16,7 +16,7 @@
             "name": "reminders",
             "appId": "",
             "subscriptionKey": "",
-            "endpointKey": "",
+            "authoringKey": "",
             "region": ""
         },
         {

--- a/samples/javascript_nodejs/21.luis-with-appinsights/middleware/myAppInsightsMiddleware.js
+++ b/samples/javascript_nodejs/21.luis-with-appinsights/middleware/myAppInsightsMiddleware.js
@@ -5,7 +5,7 @@ const { TelemetryClient } = require('applicationinsights');
 const { TurnContext } = require('botbuilder');
 
 /**
- * Middleware for logging incoming activitites into Application Insights.
+ * Middleware for logging incoming activities into Application Insights.
  * In addition, registers a service so other components can log telemetry.
  * If this component is not registered, visibility within the Bot is not logged.
  */
@@ -40,7 +40,7 @@ class MyAppInsightsMiddleware {
      */
     async onTurn(turnContext, next) {
         if (turnContext.activity) {
-            // Store the TelemetryClient on the TurnCotnext's turnState so MyAppInsightsLuisRecognizer can use it.
+            // Store the TelemetryClient on the TurnContext's turnState so MyAppInsightsLuisRecognizer can use it.
             turnContext.turnState.set(this.appInsightsServiceKey, this._telemetryClient);
 
             const activity = turnContext.activity;


### PR DESCRIPTION
## Proposed Changes
  - Use `getEndpoint()` method instead of `https://${luisConfig.region}.api.cognitive.microsoft.com`.
  - Use `authoringKey` if `subscriptionKey` is not in luisConfiguration.
  - Fix typos.