### PR TITLE
[typescript][13.basic bot] Fix typo and add missing link in Readme

### DIFF
--- a/samples/javascript_typescript/13.basic-bot/README.md
+++ b/samples/javascript_typescript/13.basic-bot/README.md
@@ -5,7 +5,7 @@ This bot has been created using [Microsoft Bot Framework](https://dev.botframewo
 This samples shows how to:
 - Use [LUIS](https://luis.ai) to implement core AI capabilities
 - Implement a multi-turn conversation using Dialogs
-- Handle user interruptions for such things as Help or Cancel
+- Handle user interruptions for such things as 'Help' or 'Cancel'
 - Prompt for and validate requests for information from the user
 
 

--- a/samples/javascript_typescript/13.basic-bot/deploymentScripts/DEPLOY.md
+++ b/samples/javascript_typescript/13.basic-bot/deploymentScripts/DEPLOY.md
@@ -24,22 +24,22 @@ You can get your LUIS authoring key by following steps [here][8] and get your Az
 ```
 
 # Using the CLI tools to create and configure services
-The LUIS application created for this bot is described in a markdown based .lu file(s) [here](../dialogs/greeting/resources/main.lu). To update your published LUIS application with any changes made to the .lu files,  run the following commands.
+The LUIS application created for this bot is described in a markdown based `.lu` file(s) [here](../dialogs/greeting/resources/main.lu). To update your published LUIS application with any changes made to the .lu files,  run the following commands.
 
 ```bash
 > cd samples/javascript_nodejs/13.basic-bot
 ```
 
-1. To parse the .lu files to a LUIS model:
+1. To parse the `.lu` files to a LUIS model:
     ```bash
     > ludown parse toluis --in resources/main.lu -o cognitiveModels/ --out basicBot.luis -n basic-bot-LUIS -d 'Basic bot Bot Builder V4 sample.' --verbose
     ```
-2. To create a new LUIS application using the LUIS model generated in step 1 and update the .bot file with the LUIS service configuration:
+2. To create a new LUIS application using the LUIS model generated in step 1 and update the `.bot` file with the LUIS service configuration:
     ```bash
     > luis import application --in cognitiveModels/basicBot.luis --authoringKey <YOUR-LUIS-AUTHORING-KEY> --msbot --region <LUIS-AUTHORING-REGION> | msbot connect luis --stdin
     ```
     You can obtain your LUIS authoring key by following instructions [here][8]
-    LUIS authoring regions are listed [here][10]. They can be one of westus | westeurope | australiaeast.
+    LUIS authoring regions are listed [here][10]. They can be one of `westus | westeurope | australiaeast`.
 3. To train the LUIS application,
     ```bash
     > msbot get basic-bot-LUIS | luis train version --wait --stdin
@@ -60,3 +60,4 @@ See [Bot Builder tools](https://github.com/microsoft/botbuilder-tools) to learn 
 [7]: https://www.github.com/microsoft/botframework-emulator
 [8]: https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-how-to-account-settings
 [9]: https://blogs.msdn.microsoft.com/mschray/2016/03/18/getting-your-azure-subscription-guid-new-portal/
+[10]: https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-reference-regions

--- a/samples/javascript_typescript/13.basic-bot/src/bot.ts
+++ b/samples/javascript_typescript/13.basic-bot/src/bot.ts
@@ -63,7 +63,7 @@ export class BasicBot {
         if (!userState) throw ('Missing parameter.  userState is required');
         if (!botConfig) throw ('Missing parameter.  botConfig is required');
 
-        // add the LUIS recogizer
+        // add the LUIS recognizer
         let luisConfig: LuisService;
         luisConfig = <LuisService>botConfig.findServiceByNameOrId(LUIS_CONFIGURATION);
         if (!luisConfig || !luisConfig.appId) throw ('Missing LUIS configuration. Please follow README.MD to create required LUIS applications.\n\n');


### PR DESCRIPTION
## Proposed Changes
  - Fix typo in `bot.ts` file
  - Improve formatting
  - Add missing link for LUIS regions