### PR TITLE
[es6][1.a.browser echo] Fix missing ampersand and udpate botbuilder-core version

### DIFF
--- a/samples/javascript_es6/01.a.browser-echo/README.md
+++ b/samples/javascript_es6/01.a.browser-echo/README.md
@@ -12,7 +12,7 @@ After running the bot, to see it in action, visit `http://localhost:8080`.
     ```
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
 - To see the bot in action, visit `http://localhost:8080` in a browser.
 

--- a/samples/javascript_es6/01.a.browser-echo/package-lock.json
+++ b/samples/javascript_es6/01.a.browser-echo/package-lock.json
@@ -62,9 +62,9 @@
       }
     },
     "@types/node": {
-      "version": "9.6.31",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/node/-/@types/node-9.6.31.tgz",
-      "integrity": "sha1-TRcimH+NgItMGU3OuMITvZLwKOU="
+      "version": "9.6.34",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.34.tgz",
+      "integrity": "sha512-PzJpSs2afoYqBA4yLBgaKUdZRk8+1yvkxcUBW6958h4vYOC+pc4k4C+QmQ6AO5Pt7uA4EIIboFog6YNCuITD0g=="
     },
     "@types/react": {
       "version": "15.0.38",
@@ -1177,12 +1177,12 @@
       }
     },
     "botbuilder-core": {
-      "version": "4.0.5",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/botbuilder-core/-/botbuilder-core-4.0.5.tgz",
-      "integrity": "sha1-hJtUEAP8CzvqJg9ImyK60udpuXA=",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.0.6.tgz",
+      "integrity": "sha512-23OE1MOQStQDIL2379O9gMgq/t4LcgXzr9+odFTK8WYpl9FSTelwntb8PIeW4fToqV/palQbmCDLNrFtQ/X7ug==",
       "requires": {
         "assert": "^1.4.1",
-        "botframework-schema": "4.0.5"
+        "botframework-schema": "^4.0.6"
       }
     },
     "botframework-directlinejs": {
@@ -1194,9 +1194,9 @@
       }
     },
     "botframework-schema": {
-      "version": "4.0.5",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/botframework-schema/-/botframework-schema-4.0.5.tgz",
-      "integrity": "sha1-080u8EfqM7PLHlfFMPP9E+JbGQ4=",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.0.6.tgz",
+      "integrity": "sha512-FoOSWio0ZkpE3nCGsv5Yz5GbmT29uuFBwTsK9t0+MTv7pAmM+MDrqG3A1Ed99N0oQXr59yacEvx5Zdaeb6Xw5Q==",
       "requires": {
         "@types/node": "^9.3.0"
       }
@@ -3447,7 +3447,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3862,7 +3863,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3918,6 +3920,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3961,12 +3964,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/samples/javascript_es6/01.a.browser-echo/package.json
+++ b/samples/javascript_es6/01.a.browser-echo/package.json
@@ -10,7 +10,7 @@
   "author": "Microsoft",
   "license": "MIT",
   "dependencies": {
-    "botbuilder-core": "^4.0.5",
+    "botbuilder-core": "^4.0.6",
     "botframework-webchat": "^0.11.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Proposed Changes
Since this sample is using a version of the `botbuilder-core` package that doesn't exists anymore, the installation fails when running `npm i`.
- Change the version found in the `package.json` to `^4.0.6`
- Change `&` to `&&` in installation step since only one ampersand makes the commands run asynchronously. This way, we ensure `npm start` is executed after `npm i` finishes installing the dependencies.