### PR TITLE
[nodejs][01.console echo] Fix typo and add missing ampersand

### DIFF
--- a/samples/javascript_nodejs/01.console-echo/README.md
+++ b/samples/javascript_nodejs/01.console-echo/README.md
@@ -11,7 +11,7 @@ This sample shows how to create a simple echo bot that you can talk to from the 
     ```
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
 
 # Testing the bot 

--- a/samples/javascript_nodejs/01.console-echo/consoleAdapter.js
+++ b/samples/javascript_nodejs/01.console-echo/consoleAdapter.js
@@ -39,7 +39,7 @@ const console = require('console');
 class ConsoleAdapter extends botbuilderCore.BotAdapter {
     /**
      * Creates a new ConsoleAdapter instance.
-     * @param reference (Optional) reference used to customize the address information of activites sent from the adapter.
+     * @param reference (Optional) reference used to customize the address information of activities sent from the adapter.
      */
     constructor(reference) {
         super();


### PR DESCRIPTION
## Proposed Changes
  - Fix typo in `consoleAdapter.js` file
  -  Change `&` to `&&` in installation step since only one ampersand makes the commands run asynchronously. This way, we ensure `npm start` is executed after `npm i` finishes installing the dependencies.