### PR TITLE
[nodejs] Replace single ampersand for double ampersand in remaining samples

### DIFF
--- a/samples/javascript_nodejs/03.welcome-users/README.MD
+++ b/samples/javascript_nodejs/03.welcome-users/README.MD
@@ -13,11 +13,11 @@ This sample creates an echo bot that also welcomes user when they join the conve
     For Azure Bot Service bots, you can find the botFileSecret under application settings.
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
     Alternatively you can also use nodemon via
     ```bash
-    npm i & npm run watch
+    npm i && npm run watch
     ```
 
 # Testing the bot using Bot Framework Emulator V4

--- a/samples/javascript_nodejs/04.simple-prompt/README.md
+++ b/samples/javascript_nodejs/04.simple-prompt/README.md
@@ -11,7 +11,7 @@ This sample shows how to use the prompts classes included in `botbuilder-dialogs
     ```
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
 
 # Testing the bot using Bot Framework Emulator

--- a/samples/javascript_nodejs/05.multi-turn-prompt/README.md
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/README.md
@@ -14,7 +14,7 @@ store and retrieve values.
     ```
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
 
 # Testing the bot using Bot Framework Emulator

--- a/samples/javascript_nodejs/06.using-cards/README.md
+++ b/samples/javascript_nodejs/06.using-cards/README.md
@@ -13,11 +13,11 @@ This sample shows how to create a bot that uses Rich Cards. This bot example use
     For Azure Bot Service bots, you can find the botFileSecret under application settings.
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
     Alternatively you can also use nodemon via
     ```bash
-    npm i & npm run watch
+    npm i && npm run watch
     ```
 
 # Testing the bot using Bot Framework Emulator

--- a/samples/javascript_nodejs/07.using-adaptive-cards/README.MD
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/README.MD
@@ -13,11 +13,11 @@ This sample shows how to send an Adaptive Card. This bot example uses [`restify`
     For Azure Bot Service bots, you can find the botFileSecret under application settings.
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
     Alternatively you can also use nodemon via
     ```bash
-    npm i & npm run watch
+    npm i && npm run watch
     ```
 
 # Testing the bot using Bot Framework Emulator

--- a/samples/javascript_nodejs/08.suggested-actions/README.MD
+++ b/samples/javascript_nodejs/08.suggested-actions/README.MD
@@ -13,11 +13,11 @@ This sample shows how to use suggested actions. This bot example uses [`restify`
     For Azure Bot Service bots, you can find the botFileSecret under application settings.
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
     Alternatively you can also use nodemon via
     ```bash
-    npm i & npm run watch
+    npm i && npm run watch
     ```
 
 # Testing the bot using Bot Framework Emulator

--- a/samples/javascript_nodejs/10.prompt-validations/README.md
+++ b/samples/javascript_nodejs/10.prompt-validations/README.md
@@ -14,7 +14,7 @@ demonstrates using the `ComponentDialog` class to encapsulate related sub-dialog
     ```
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
 
 # Testing the bot using Bot Framework Emulator

--- a/samples/javascript_nodejs/11.qnamaker/README.MD
+++ b/samples/javascript_nodejs/11.qnamaker/README.MD
@@ -18,7 +18,7 @@ In this sample, we demonstrate how to use the QnA Maker service to answer questi
     For Azure Bot Service bots, you can find the botFileSecret under application settings.
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
 
 # Testing the bot using Bot Framework Emulator

--- a/samples/javascript_nodejs/12.nlp-with-luis/README.MD
+++ b/samples/javascript_nodejs/12.nlp-with-luis/README.MD
@@ -18,11 +18,11 @@ In this sample, we demonstrate how to call LUIS to extract the intents from a us
     For Azure Bot Service bots, you can find the botFileSecret under application settings.
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
     Alternatively you can also use nodemon via
     ```bash
-    npm i & npm run watch
+    npm i && npm run watch
     ```
 
 # Testing the bot using Bot Framework Emulator

--- a/samples/javascript_nodejs/15.handling-attachments/README.MD
+++ b/samples/javascript_nodejs/15.handling-attachments/README.MD
@@ -13,7 +13,7 @@ This sample shows how to send outgoing attachments and how to save attachments t
     For Azure Bot Service bots, you can find the botFileSecret under application settings.
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
 
 # Testing the bot using Bot Framework Emulator

--- a/samples/javascript_nodejs/16.proactive-messages/README.md
+++ b/samples/javascript_nodejs/16.proactive-messages/README.md
@@ -26,7 +26,7 @@ question, it will share that information with the user.
     ```
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
 
 # Testing the bot using Bot Framework Emulator

--- a/samples/javascript_nodejs/17.multilingual-conversations/README.MD
+++ b/samples/javascript_nodejs/17.multilingual-conversations/README.MD
@@ -15,11 +15,11 @@ This sample shows how to translate incoming and outgoing text using a custom mid
     For Azure Bot Service bots, you can find the botFileSecret under application settings.
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
     Alternatively you can also use nodemon via
     ```bash
-    npm i & npm run watch
+    npm i && npm run watch
     ```
 ## Microsoft Translator Text API
 

--- a/samples/javascript_nodejs/18.bot-authentication/README.MD
+++ b/samples/javascript_nodejs/18.bot-authentication/README.MD
@@ -11,11 +11,11 @@ This sample shows how to use authentication in your bot using OAuth. This bot ex
     ```
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
     Alternatively you can also use nodemon via
     ```bash
-    npm i & npm run watch
+    npm i && npm run watch
     ```
 
 # Testing the bot using Bot Framework Emulator

--- a/samples/javascript_nodejs/20.qna-with-appinsights/README.MD
+++ b/samples/javascript_nodejs/20.qna-with-appinsights/README.MD
@@ -20,7 +20,7 @@ In this sample, we demonstrate how to use the QnA Maker service to answer questi
     For Azure Bot Service bots, you can find the botFileSecret under application settings.
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
 
 # Testing the bot using Bot Framework Emulator

--- a/samples/javascript_nodejs/21.luis-with-appinsights/README.md
+++ b/samples/javascript_nodejs/21.luis-with-appinsights/README.md
@@ -20,7 +20,7 @@ In this sample, we demonstrate how to call LUIS to extract the intents from a us
     For Azure Bot Service bots, you can find the botFileSecret under application settings.
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
 
 # Testing the bot using Bot Framework Emulator

--- a/samples/javascript_nodejs/23.facebook-events/README.MD
+++ b/samples/javascript_nodejs/23.facebook-events/README.MD
@@ -16,11 +16,11 @@ This bot example uses [`restify`](https://www.npmjs.com/package/restify) and [`d
     ```
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
     Alternatively you can also use nodemon via
     ```bash
-    npm i & npm run watch
+    npm i && npm run watch
     ```
 
 # Testing the bot using Bot Framework Emulator

--- a/samples/javascript_nodejs/50.diceroller-skill/README.md
+++ b/samples/javascript_nodejs/50.diceroller-skill/README.md
@@ -16,7 +16,7 @@ events.
     ```
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
 - To reset registry, you can do
     ```bash

--- a/samples/javascript_nodejs/51.cafe-bot/README.MD
+++ b/samples/javascript_nodejs/51.cafe-bot/README.MD
@@ -55,7 +55,7 @@ Contoso cafe bot is a fairly sophisticated bot sample that uses the following co
     - [Manually import models using Ludown, LUIS and QnA Maker CLI](#building-and-creating-services)
 - Install modules and start the bot
     ```bash
-    npm i & npm start
+    npm i && npm start
     ```
 
 # Testing the bot using Bot Framework Emulator


### PR DESCRIPTION
## Proposed Changes
  - Change `&` to `&&` since only one ampersand makes the commands run asynchronously. This way, we ensure `npm start` is executed after `npm i` finishes installing the dependencies.