### PR TITLE
Update nlp-with-luis (fix for #627)

### DIFF
--- a/samples/javascript_typescript/12.nlp-with-luis/README.md
+++ b/samples/javascript_typescript/12.nlp-with-luis/README.md
@@ -56,7 +56,8 @@ In order to run this sample, you must have TypeScript installed.  To install Typ
     The Version is listed on the page. [See an example .bot service configuration for using LUIS here](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-luis?view=azure-bot-service-4.0&tabs=js#configure-your-bot-to-use-your-luis-app).    
 - Update [nlp-with-luis.bot](nlp-with-luis.bot) file with your Authoring Key.
     You can find this under your user settings at [luis.ai](https://www.luis.ai).  Click on your name in the upper right hand corner of the portal, and click on the "Settings" menu option. Add this to your .bot file's service configuration as `authoringKey`.
-NOTE: Once you publish your app on LUIS portal for the first time, it may take some time to go live.
+    
+    NOTE: Once you publish your app on LUIS portal for the first time, it may take some time to go live.
 - Your .bot file should now include an item in the services array that looks like this:
 
 ```javascript

--- a/samples/javascript_typescript/12.nlp-with-luis/README.md
+++ b/samples/javascript_typescript/12.nlp-with-luis/README.md
@@ -53,10 +53,24 @@ In order to run this sample, you must have TypeScript installed.  To install Typ
     - SubscriptionKey = YYYYYYYYYYYY
     - Region = westus
 
-    The Version is listed on the page.
+    The Version is listed on the page. [See an example .bot service configuration for using LUIS here](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-luis?view=azure-bot-service-4.0&tabs=js#configure-your-bot-to-use-your-luis-app).    
 - Update [nlp-with-luis.bot](nlp-with-luis.bot) file with your Authoring Key.
-    You can find this under your user settings at [luis.ai](https://www.luis.ai).  Click on your name in the upper right hand corner of the portal, and click on the "Settings" menu option.
+    You can find this under your user settings at [luis.ai](https://www.luis.ai).  Click on your name in the upper right hand corner of the portal, and click on the "Settings" menu option. Add this to your .bot file's service configuration as `authoringKey`.
 NOTE: Once you publish your app on LUIS portal for the first time, it may take some time to go live.
+- Your .bot file should now include an item in the services array that looks like this:
+
+```javascript
+{
+    "type":"luis",
+    "name":"<some name>",
+    "appId":"<an app id>",
+    "version":"<a version number>",
+    "authoringKey":"<your authoring key>",
+    "subscriptionKey":"<your subscription key>",
+    "region":"<region>",
+    "id":"<some number>"
+}
+```
 
 ### (Optional) Install `ludown` and `luis`
 - Install the `ludown` CLI tool [here](https://aka.ms/using-ludown) to help describe language understanding components for your bot.
@@ -82,5 +96,6 @@ msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-loc
 ```
 
 # Further reading
+- [Using LUIS for Language Understanding](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-luis?view=azure-bot-service-4.0&tabs=js)
 - [Azure Bot Service](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 - [LUIS documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/LUIS/)

--- a/samples/javascript_typescript/12.nlp-with-luis/README.md
+++ b/samples/javascript_typescript/12.nlp-with-luis/README.md
@@ -73,6 +73,8 @@ In order to run this sample, you must have TypeScript installed.  To install Typ
 }
 ```
 
+- Update [index.ts](src/index.ts) and set the `LUIS_CONFIGURATION` value to match the `name` field in your service declaration.
+
 ### (Optional) Install `ludown` and `luis`
 - Install the `ludown` CLI tool [here](https://aka.ms/using-ludown) to help describe language understanding components for your bot.
 - Install the `luis` CLI tool [here](https://aka.ms/using-luis-cli) to create and manage your LUIS applications.

--- a/samples/javascript_typescript/12.nlp-with-luis/src/index.ts
+++ b/samples/javascript_typescript/12.nlp-with-luis/src/index.ts
@@ -33,7 +33,12 @@ const DEV_ENVIRONMENT = 'development';
 const BOT_CONFIGURATION = (process.env.NODE_ENV || DEV_ENVIRONMENT);
 
 // Language Understanding (LUIS) service name as defined in the .bot file.
-const LUIS_CONFIGURATION = 'luis';
+const LUIS_CONFIGURATION = '';
+
+if (!LUIS_CONFIGURATION) {
+    console.error('Make sure to update the index.ts file with a LUIS_CONFIGURATION name that matches your .bot file.');
+    process.exit();
+}
 
 // Get endpoint and LUIS configurations by service name.
 const endpointConfig = <IEndpointService>botConfig.findServiceByNameOrId(BOT_CONFIGURATION);

--- a/samples/javascript_typescript/12.nlp-with-luis/src/index.ts
+++ b/samples/javascript_typescript/12.nlp-with-luis/src/index.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as restify from 'restify';
 import { BotFrameworkAdapter } from 'botbuilder';
 import { LuisApplication, LuisPredictionOptions } from 'botbuilder-ai';
-import { BotConfiguration, IEndpointService, ILuisService } from 'botframework-config';
+import { BotConfiguration, IEndpointService, LuisService } from 'botframework-config';
 import { LuisBot } from './bot';
 
 // Read botFilePath and botFileSecret from .env file.
@@ -33,11 +33,11 @@ const DEV_ENVIRONMENT = 'development';
 const BOT_CONFIGURATION = (process.env.NODE_ENV || DEV_ENVIRONMENT);
 
 // Language Understanding (LUIS) service name as defined in the .bot file.
-const LUIS_CONFIGURATION = '';
+const LUIS_CONFIGURATION = 'luis';
 
 // Get endpoint and LUIS configurations by service name.
 const endpointConfig = <IEndpointService>botConfig.findServiceByNameOrId(BOT_CONFIGURATION);
-const luisConfig = <ILuisService>botConfig.findServiceByNameOrId(LUIS_CONFIGURATION);
+const luisConfig = <LuisService>botConfig.findServiceByNameOrId(LUIS_CONFIGURATION);
 
 // Map the contents to the required format for `LuisRecognizer`.
 const luisApplication: LuisApplication = {


### PR DESCRIPTION
Change the type of the declared type of the LUIS configuration option from ILuisService (which is the abstract class interface) to LuisService (the implemented class with required features). 

I also updated readme to add instructions about format .bot file section for LUIS, which I had to track down.

Fixes #627