### PR TITLE
[generator-botbuilder] Typo fixes in comments and string value for 'description' fielld in result 'package.json' file.

### DIFF
--- a/generators/generator-botbuilder/components/prompts.js
+++ b/generators/generator-botbuilder/components/prompts.js
@@ -3,7 +3,7 @@
 
 /**
  * configureCommandlineOptions
- * does the work to confiure the commandline options that this template will accept
+ * does the work to configure the commandline options that this template will accept
  * this is mostly made available so that we can run the template without user
  * intervention.  e.g. automated test runs
  * @param {Generator} gen Yeoman's generator object
@@ -16,19 +16,19 @@ module.exports.configureCommandlineOptions = gen => {
     alias: "N"
   });
   gen.option("description", {
-    desc: "A brief bit of text used to decribe what your bot does",
+    desc: "A brief bit of text used to describe what your bot does",
     type: String,
-    default: "Demonstrate the core capabilties of the Microsoft Bot Framework",
+    default: "Demonstrate the core capabilities of the Microsoft Bot Framework",
     alias: "D"
   });
   gen.option("language", {
-    desc: "The programming language you want to use.  (JavaScript / TypeScript)",
+    desc: "The programming language you want to use. (JavaScript / TypeScript)",
     type: String,
     default: "JavaScript",
     alias: "L"
   });
   gen.option("template", {
-    desc: "The initial AI capabilities your bot will have.  (Echo / Basic)",
+    desc: "The initial AI capabilities your bot will have. (Echo / Basic)",
     type: String,
     default: "basic",
     alias: "T"
@@ -38,7 +38,7 @@ module.exports.configureCommandlineOptions = gen => {
 
 /**
  * getPrompts
- * constructs an array of promps name/value pairs.  this is the input we need from the user
+ * constructs an array of prompts name/value pairs. This is the input we need from the user
  * or passed into the command line to successfully configure a new bot
  * @param {Object} options
  */
@@ -52,7 +52,7 @@ module.exports.getPrompts = options => {
     {
       name: "description",
       message: "What will your bot do?",
-      default: (options.description ? options.description : "Demonstrate the core capabilties of a Conversational AI bot")
+      default: (options.description ? options.description : "Demonstrate the core capabilities of a Conversational AI bot")
     },
     {
       name: "language",


### PR DESCRIPTION
As I searched - no issue.

## Proposed Changes
Typos

## Testing
Read and realize the English :) 