### PR TITLE
[netcore][51.bot cafe] Fix QnA results validation

### DIFF
--- a/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/QnA/QnADialog.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/QnA/QnADialog.cs
@@ -34,7 +34,7 @@ namespace Microsoft.BotBuilderSamples
         {
             // Call QnA Maker and get results.
             var qnaResult = await _services.QnaServices[QnaConfiguration].GetAnswersAsync(dc.Context);
-            if (qnaResult == null || qnaResult.Count() > 0)
+            if (qnaResult == null || qnaResult.Count() <= 0)
             {
                 // No answer found.
                 await dc.Context.SendActivityAsync("I'm still learning.. Sorry, I do not know how to help you with that.");


### PR DESCRIPTION
## Proposed Changes
  - The validation for QnA results in [Line 37](https://github.com/Microsoft/BotBuilder-Samples/blob/eeeee2e909da45096db9dba78c2cbc8fe67b9260/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/QnA/QnADialog.cs#L37) of `QnADialog.cs` is not validating correctly; if there is at least one result, it will reply with the `No answer found` reply.
## Testing
The bot will start replying with the results found.