### PR TITLE
Add FileExists check for .bot file to samples

### DIFF
--- a/samples/csharp_dotnetcore/02.echo-with-counter/Startup.cs
+++ b/samples/csharp_dotnetcore/02.echo-with-counter/Startup.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.IO;
 using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -62,7 +63,10 @@ namespace Microsoft.BotBuilderSamples
 
                 var secretKey = Configuration.GetSection("botFileSecret")?.Value;
                 var botFilePath = Configuration.GetSection("botFilePath")?.Value;
-
+                if (!File.Exists(botFilePath))
+                {
+                    throw new FileNotFoundException($"The .bot configuration file was not found. botFilePath: {botFilePath}");
+                }
                 // Loads .bot configuration file and adds a singleton that your Bot can access through dependency injection.
                 BotConfiguration botConfig = null;
                 try


### PR DESCRIPTION
Fixes https://github.com/Microsoft/BotBuilder-Samples/issues/730

## Proposed Changes
I have added a `File.Exists` check for the `botFilePath` to the Echobot. I've tested this and it currently works and sends an error message to the browser, but I'd like to confirm that this implementation is what we'd like to go with before adding it to the rest of the C# samples. 

Additionally note that the sample bot `02.echo-with-counter` already includes a try-catch for if the file was read properly after the current check, most other bot samples do not include this try-catch block.

## Testing
Delete the .bot file from the sample and then attempt to run it.