### PR TITLE
Cafe Contoso bot is missing .bot file #724

### DIFF
--- a/samples/csharp_dotnetcore/51.cafe-bot/CafeBot.csproj
+++ b/samples/csharp_dotnetcore/51.cafe-bot/CafeBot.csproj
@@ -6,12 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="CafeBot.bot">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.7" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.0.7" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.0.7" />


### PR DESCRIPTION
Related to open issue 
https://github.com/Microsoft/BotBuilder-Samples/issues/724
The sample project CafeBot still had the .*bot as copy always in the project.

Appeared after this commit.
https://github.com/Microsoft/BotBuilder-Samples/pull/685

Fixes #724 