### PR TITLE
[generator-botbuilder] Typo fixes, whitespace removal, broken markdown fix

### DIFF
--- a/generators/generator-botbuilder/README.md
+++ b/generators/generator-botbuilder/README.md
@@ -3,10 +3,10 @@ Yeoman generator for [Microsoft Bot Framework][1].  Will let you quickly set up 
 using core AI capabilities.
 
 # About
-generator-botbuilder will help you build new converstational AI bots using the [Microsoft Bot Framework][1].
+generator-botbuilder will help you build new conversational AI bots using the [Microsoft Bot Framework][1].
 
 # Features
-The generator supports two different templates.  The features the generator produces depends on the template you choose.  The `Echo` template produces a "Hello World!" capable bot.  It is the simpliest bot you can write, providing the minimal features required by a bot.  The `Basic` template builds on the capabilities of the `Echo` template and add features typically found in most every bot.  Here is a table that shows what features exist in the different templates.
+The generator supports two different templates.  The features the generator produces depends on the template you choose.  The `Echo` template produces a "Hello World!" capable bot.  It is the simplest bot you can write, providing the minimal features required by a bot.  The `Basic` template builds on the capabilities of the `Echo` template and add features typically found in most every bot.  Here is a table that shows what features exist in the different templates.
 
 |  Feature  |  Echo   |  Basic  |
 | --------- | :-----: | :-----: |
@@ -66,8 +66,8 @@ The generator supports a number of commandline options that can be used to chang
 | --botname, -N     | The name given to the bot project |
 | --description, -D | A brief bit of text that describes the purpose of your bot |
 | --language, -L    | The programming language the generator should use to generate the project.  Supported options are JavaScript or TypeScript. |
-| --template, -T    | The template used to generate your project.  Supported options are `echo` which is the simpliest bot you can build, or `basic` which contains a core set of AI capabilities demonstrating basic bot functionality. |
-| --noprompt        | If passed on the command-line, will tell the generator to *not* prompt the user for any information.  This option is intented to allow automated bot generation for testing purposes. *NOTE* when using the --noprompt option, if no template is specified, the `basic` template is used.|
+| --template, -T    | The template used to generate your project.  Supported options are `echo` which is the simplest bot you can build, or `basic` which contains a core set of AI capabilities demonstrating basic bot functionality. |
+| --noprompt        | If passed on the command-line, will tell the generator to *not* prompt the user for any information.  This option is intended to allow automated bot generation for testing purposes. *NOTE* when using the --noprompt option, if no template is specified, the `basic` template is used.|
 
 ## Generating a project using --noprompt
 In the following example, all required options are specified on the command-line.  In addition, passing the `--noprompt` option will cause the
@@ -90,7 +90,7 @@ The table below describes the reasonable set of defaults used when `--noprompt` 
 | Commandline Option | Description |
 | ------------------ | ----------- |
 | --botname, -N      | `myChatBot` |
-| --description, -D  | `Demonstrate the core capabilties of the Microsoft Bot Framework` |
+| --description, -D  | `Demonstrate the core capabilities of the Microsoft Bot Framework` |
 | --language, -L     | `JavaScript` |
 | --template, -T     | `basic` |
 
@@ -110,7 +110,7 @@ Launch the [Microsoft Bot Framework Emulator][3] and open the generated project'
 Once the Emulator is connected, you can interact with and receive messages from your bot.
 
 ## Developing your bot locally
-It's often easeier to develop the capabilities of your bot locally, and to use the Microsoft Bot Framework Emulator to test your changes.  When the generator generated your bot project it added a file watcher to the project.  When run, the watcher which will cause nodejs to reload the bot whenever any of the bot's files change.  Causing nodejs to reload your bot under these circumstances will ensure you are always running the latest version of your bot.  Enable the watch feature by typing the following in your conole:
+It's often easier to develop the capabilities of your bot locally, and to use the Microsoft Bot Framework Emulator to test your changes.  When the generator generated your bot project it added a file watcher to the project.  When run, the watcher which will cause nodejs to reload the bot whenever any of the bot's files change.  Causing nodejs to reload your bot under these circumstances will ensure you are always running the latest version of your bot.  Enable the watch feature by typing the following in your console:
 
 ```bash
 # From the directory that contains your bot

--- a/generators/generator-botbuilder/generators/app/index.js
+++ b/generators/generator-botbuilder/generators/app/index.js
@@ -84,7 +84,7 @@ module.exports = class extends Generator {
             this.log(thankYouMsg);
         } else {
             const noThankYouMsg = "------------------- \n" +
-                "Bot creation has been cancelled.  \n" +
+                "Bot creation has been canceled.  \n" +
                 "Thank you for using the Microsoft Bot Framework. \n" +
                 "\n< ** > The Bot Framework Team";
             this.log(noThankYouMsg);

--- a/generators/generator-botbuilder/generators/app/templates/basic/README.md.js
+++ b/generators/generator-botbuilder/generators/app/templates/basic/README.md.js
@@ -8,7 +8,7 @@ This samples shows how to:
 - Implement a multi-turn conversation using Dialogs
 - Handle user interruptions for such things as Help or Cancel
 - Prompt for and validate requests for information from the user
-- Demonstrate how to handle any unexptected errors
+- Demonstrate how to handle any unexpected errors
 
 
 ## To run this bot
@@ -63,7 +63,7 @@ See [DEPLOYMENT.md][3] to learn more about deploying this bot to Azure and using
 
 The generator created a `.env` file with the two necessary keys `botFilePath` and `botFileSecret`.  The `botFilePath` key is set to `<%= botName %>.bot`.  All of the services and their respective configuration settings are stored in the .bot file.
   - For Azure Bot Service bots, you can find the `botFileSecret` under application settings.
-  - It is recommended that you encrypt your bot file before you commit it to your souce control system and/or before you deploy your bot to Azure or similar hosting service.  There are two ways to encrypt your `<%= botName %>.bot` file.  You can use [MSBot CLI][15] to encrypt your bot file or you can use [Bot Framework Emulator **V4**][16] to encrypt your bot file.  Both options will product a `botFileSecret` for you.  You will need to remember this in order to decrypt your .bot file.
+  - It is recommended that you encrypt your bot file before you commit it to your source control system and/or before you deploy your bot to Azure or similar hosting service.  There are two ways to encrypt your `<%= botName %>.bot` file.  You can use [MSBot CLI][15] to encrypt your bot file or you can use [Bot Framework Emulator **V4**][16] to encrypt your bot file.  Both options will product a `botFileSecret` for you.  You will need to remember this in order to decrypt your .bot file.
 
 ### Running the bot
 

--- a/generators/generator-botbuilder/generators/app/templates/basic/README.md.ts
+++ b/generators/generator-botbuilder/generators/app/templates/basic/README.md.ts
@@ -8,7 +8,7 @@ This samples shows how to:
 - Implement a multi-turn conversation using Dialogs
 - Handle user interruptions for such things as Help or Cancel
 - Prompt for and validate requests for information from the user
-- Demonstrate how to handle any unexptected errors
+- Demonstrate how to handle any unexpected errors
 
 
 ## To run this bot
@@ -70,7 +70,7 @@ See [DEPLOYMENT.md][3] to learn more about deploying this bot to Azure and using
 
 The generator created a `.env` file with the two necessary keys `botFilePath` and `botFileSecret`.  The `botFilePath` key is set to `<%= botName %>.bot`.  All of the services and their respective configuration settings are stored in the .bot file.
   - For Azure Bot Service bots, you can find the `botFileSecret` under application settings.
-  - It is recommended that you encrypt your bot file before you commit it to your souce control system and/or before you deploy your bot to Azure or similar hosting service.  There are two ways to encrypt your `<%= botName %>.bot` file.  You can use [MSBot CLI][15] to encrypt your bot file or you can use [Bot Framework Emulator **V4**][16] to encrypt your bot file.  Both options will product a `botFileSecret` for you.  You will need to remember this in order to decrypt your .bot file.
+  - It is recommended that you encrypt your bot file before you commit it to your source control system and/or before you deploy your bot to Azure or similar hosting service.  There are two ways to encrypt your `<%= botName %>.bot` file.  You can use [MSBot CLI][15] to encrypt your bot file or you can use [Bot Framework Emulator **V4**][16] to encrypt your bot file.  Both options will product a `botFileSecret` for you.  You will need to remember this in order to decrypt your .bot file.
 
 ### Running the bot
 

--- a/generators/generator-botbuilder/generators/app/templates/basic/bot.js
+++ b/generators/generator-botbuilder/generators/app/templates/basic/bot.js
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// bot.js is your main bot dialog entry point for handilng activity types
+// bot.js is your main bot dialog entry point for handling activity types
 
 // Import required Bot Builder
 const { ActivityTypes, CardFactory } = require('botbuilder');
@@ -118,7 +118,7 @@ class BasicBot {
         if (dc.activeDialog !== undefined) {
           // issue a re-prompt on the active dialog
           dialogResult = await dc.repromptDialog();
-        } // Else: We dont have an active dialog so nothing to continue here.
+        } // Else: We don't have an active dialog so nothing to continue here.
       } else {
         // No interruption. Continue any active dialogs.
         dialogResult = await dc.continueDialog();
@@ -195,7 +195,7 @@ class BasicBot {
   async isTurnInterrupted(dc, luisResults) {
     const topIntent = LuisRecognizer.topIntent(luisResults);
 
-    // see if there are anh conversation interrupts we need to handle
+    // see if there are any conversation interrupts we need to handle
     if (topIntent === CANCEL_INTENT) {
       if (dc.activeDialog) {
         // cancel all active dialog (clean the stack)

--- a/generators/generator-botbuilder/generators/app/templates/basic/bot.ts
+++ b/generators/generator-botbuilder/generators/app/templates/basic/bot.ts
@@ -64,7 +64,7 @@ export class BasicBot {
     if (!userState) throw new Error('Missing parameter.  userState is required');
     if (!botConfig) throw new Error('Missing parameter.  botConfig is required');
 
-    // add the LUIS recogizer
+    // add the LUIS recognizer
     let luisConfig: LuisService;
     luisConfig = <LuisService>botConfig.findServiceByNameOrId(LUIS_CONFIGURATION);
     if (!luisConfig || !luisConfig.appId) throw ('Missing LUIS configuration. Please follow README.MD to create required LUIS applications.\n\n');
@@ -122,7 +122,7 @@ export class BasicBot {
         if (dc.activeDialog !== undefined) {
           // issue a re-prompt on the active dialog
           await dc.repromptDialog();
-        } // Else: We dont have an active dialog so nothing to continue here.
+        } // Else: We don't have an active dialog so nothing to continue here.
       } else {
         // No interruption. Continue any active dialogs.
         dialogResult = await dc.continueDialog();
@@ -199,7 +199,7 @@ export class BasicBot {
   private isTurnInterrupted = async (dc: DialogContext, luisResults: RecognizerResult) => {
     const topIntent = LuisRecognizer.topIntent(luisResults);
 
-    // see if there are anh conversation interrupts we need to handle
+    // see if there are any conversation interrupts we need to handle
     if (topIntent === CANCEL_INTENT) {
       if (dc.activeDialog) {
         // cancel all active dialog (clean the stack)

--- a/generators/generator-botbuilder/generators/app/templates/basic/dialogs/greeting/greeting.js
+++ b/generators/generator-botbuilder/generators/app/templates/basic/dialogs/greeting/greeting.js
@@ -43,7 +43,7 @@ class Greeting extends ComponentDialog {
     if (!userProfileAccessor) throw new Error('Missing parameter.  userProfileAccessor is required');
 
     // Add a water fall dialog with 4 steps.
-    // The order of step function registration is importent
+    // The order of step function registration is important
     // as a water fall dialog executes steps registered in order
     this.addDialog(new WaterfallDialog(PROFILE_DIALOG, [
       this.initializeStateStep.bind(this),

--- a/generators/generator-botbuilder/generators/app/templates/basic/dialogs/greeting/greeting.ts
+++ b/generators/generator-botbuilder/generators/app/templates/basic/dialogs/greeting/greeting.ts
@@ -7,7 +7,7 @@ import { StatePropertyAccessor, TurnContext } from 'botbuilder';
 // User state for greeting dialog
 import { UserProfile } from './userProfile';
 
-// Minimum lengh requirements for city and name
+// Minimum length requirements for city and name
 const CITY_LENGTH_MIN = 5;
 const NAME_LENGTH_MIN = 3;
 
@@ -43,7 +43,7 @@ export class GreetingDialog extends ComponentDialog {
     if (!userProfileAccessor) throw ('Missing parameter.  userProfileAccessor is required');
 
     // Add a water fall dialog with 4 steps.
-    // The order of step function registration is importent
+    // The order of step function registration is important
     // as a water fall dialog executes steps registered in order
     this.addDialog(new WaterfallDialog<UserProfile>(PROFILE_DIALOG, [
       this.initializeStateStep.bind(this),
@@ -144,7 +144,7 @@ export class GreetingDialog extends ComponentDialog {
    * @param {PromptValidatorContext} validation context for this validator.
    */
   private validateName = async (validatorContext: PromptValidatorContext<String>) => {
-    // Validate that the user entered a minimum lenght for their name
+    // Validate that the user entered a minimum length for their name
     const value = (validatorContext.recognized.value || '').trim();
     if (value.length >= NAME_LENGTH_MIN) {
       return VALIDATION_SUCCEEDED;
@@ -159,7 +159,7 @@ export class GreetingDialog extends ComponentDialog {
    * @param {PromptValidatorContext} validation context for this validator.
    */
   private validateCity = async (validatorContext: PromptValidatorContext<String>) => {
-    // Validate that the user entered a minimum lenght for their name
+    // Validate that the user entered a minimum length for their name
     const value = (validatorContext.recognized.value || '').trim();
     if (value.length >= CITY_LENGTH_MIN) {
       return VALIDATION_SUCCEEDED;

--- a/generators/generator-botbuilder/generators/app/templates/basic/index.js
+++ b/generators/generator-botbuilder/generators/app/templates/basic/index.js
@@ -3,7 +3,7 @@
 
 // index.js is used to setup and configure your bot
 
-// Import required pckages
+// Import required packages
 const path = require('path');
 const restify = require('restify');
 

--- a/generators/generator-botbuilder/generators/app/templates/echo/README.md.js
+++ b/generators/generator-botbuilder/generators/app/templates/echo/README.md.js
@@ -66,4 +66,4 @@ msbot clone services -f deploymentScripts/msbotClone -n myChatBot -l <Azure-loca
 [7]: https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-storage-concept?view=azure-bot-service-4.0
 [8]: https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-storage?view=azure-bot-service-4.0&tabs=jsechoproperty%2Ccsetagoverwrite%2Ccsetag
 [9]: https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-state?view=azure-bot-service-4.0&tabs=js
-[10] https://dev.botframework.com
+[10]: https://dev.botframework.com

--- a/generators/generator-botbuilder/generators/app/templates/echo/README.md.ts
+++ b/generators/generator-botbuilder/generators/app/templates/echo/README.md.ts
@@ -73,4 +73,4 @@ msbot clone services -f deploymentScripts/msbotClone -n myChatBot -l <Azure-loca
 [7]: https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-storage-concept?view=azure-bot-service-4.0
 [8]: https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-storage?view=azure-bot-service-4.0&tabs=jsechoproperty%2Ccsetagoverwrite%2Ccsetag
 [9]: https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-state?view=azure-bot-service-4.0&tabs=js
-[10] https://dev.botframework.com
+[10]: https://dev.botframework.com

--- a/generators/generator-botbuilder/generators/app/templates/echo/index.js
+++ b/generators/generator-botbuilder/generators/app/templates/echo/index.js
@@ -20,7 +20,7 @@ const ENV_FILE = path.join(__dirname, '.env');
 const env = require('dotenv').config({path: ENV_FILE});
 
 // bot endpoint name as defined in .bot file
-// See https://aka.ms/about-bot-file to learn more about .bot file its use and bot configuration .
+// See https://aka.ms/about-bot-file to learn more about .bot file its use and bot configuration.
 const DEV_ENVIRONMENT = 'development';
 
 // bot name as defined in .bot file
@@ -54,7 +54,7 @@ try {
 const endpointConfig = botConfig.findServiceByNameOrId(BOT_CONFIGURATION);
 
 // Create adapter.
-// See https://aka.ms/about-bot-adapter to learn more about .bot file its use and bot configuration .
+// See https://aka.ms/about-bot-adapter to learn more about .bot file its use and bot configuration.
 const adapter = new BotFrameworkAdapter({
     appId: endpointConfig.appId || process.env.microsoftAppID,
     appPassword: endpointConfig.appPassword || process.env.microsoftAppPassword

--- a/generators/generator-botbuilder/generators/app/templates/echo/index.ts
+++ b/generators/generator-botbuilder/generators/app/templates/echo/index.ts
@@ -20,7 +20,7 @@ const ENV_FILE = path.join(__dirname, '..', '.env');
 const env = config({ path: ENV_FILE });
 
 // bot endpoint name as defined in .bot file
-// See https://aka.ms/about-bot-file to learn more about .bot file its use and bot configuration .
+// See https://aka.ms/about-bot-file to learn more about .bot file its use and bot configuration.
 const DEV_ENVIRONMENT = 'development';
 
 // bot name as defined in .bot file
@@ -53,7 +53,7 @@ try {
 const endpointConfig = <IEndpointService>botConfig.findServiceByNameOrId(BOT_CONFIGURATION);
 
 // Create adapter.
-// See https://aka.ms/about-bot-adapter to learn more about .bot file its use and bot configuration .
+// See https://aka.ms/about-bot-adapter to learn more about .bot file its use and bot configuration.
 const adapter = new BotFrameworkAdapter({
     appId: endpointConfig.appId || process.env.microsoftAppID,
     appPassword: endpointConfig.appPassword || process.env.microsoftAppPassword


### PR DESCRIPTION
This code/behavior I see in `generator-botbuilder` `v4.0.10`.
https://www.npmjs.com/package/generator-botbuilder?activeTab=readme

Typos people, typos :) 

How do u write the code, with no language hints or what? It's not popular to write correct words in USA? I see that many sentences written in old USA way - using 2 white spaces between sentesnes 
=> `abc.  Hello world`. I realize it's habit, by typos? It's rather plugin disabled :) 

+ fix for Broken markdown:
<img width="384" alt="screen shot 2018-10-27 at 23 05 38" src="https://user-images.githubusercontent.com/2131633/47609476-a7ee3080-da3f-11e8-8067-38c59e42bb45.png">
