### PR TITLE
Fix #792 [generator-botbuilder] - "id" in Basic LUIS botName.bot file should be either "1" or empty, but not an url.

### DIFF
--- a/generators/generator-botbuilder/generators/app/templates/basic/botName.bot
+++ b/generators/generator-botbuilder/generators/app/templates/basic/botName.bot
@@ -5,7 +5,7 @@
     {
       "type": "endpoint",
       "name": "development",
-      "id": "http://localhost:3978/api/messages",
+      "id": "1",
       "appId": "",
       "appPassword": "",
       "endpoint": "http://localhost:3978/api/messages"


### PR DESCRIPTION
Fixes #792

## Proposed Changes
Replacing wrong value containing URL to numeric value. Similary to Echo Bot `botName.bot` file.

PLEASE DO NOT MERGE, if you don't know it's really bug.
I'm personally new to Bot Service, so I may not understand many things, and I may not see bigger picture with LUIS-kind of bots.

Hope for more people, who are more into this codebase to review my change:
cc/ @JasonSowers; @daveta; @benbrown @stevengum @dfavretto @joseques 
