### PR TITLE
Fix #794 [generator-botbuilder] - Added hyperlink to LUIS Authoring Regions list in DEPLOYMENT.md

### DIFF
--- a/generators/generator-botbuilder/generators/app/templates/basic/deploymentScripts/DEPLOYMENT.md
+++ b/generators/generator-botbuilder/generators/app/templates/basic/deploymentScripts/DEPLOYMENT.md
@@ -59,3 +59,4 @@ See [Bot Builder tools](https://github.com/microsoft/botbuilder-tools) to learn 
 [7]: https://www.github.com/microsoft/botframework-emulator
 [8]: https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-how-to-account-settings
 [9]: https://blogs.msdn.microsoft.com/mschray/2016/03/18/getting-your-azure-subscription-guid-new-portal/
+[10]: https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-reference-regions#publishing-regions


### PR DESCRIPTION
Fixes #794 

How it looks on my fork:

<img width="499" alt="screen shot 2018-10-28 at 23 11 52" src="https://user-images.githubusercontent.com/2131633/47622578-eac70b80-db06-11e8-82b3-1a019afdcd47.png">
