### PR TITLE
[webapi][13.basic bot] Add missing resource files

### DIFF
--- a/samples/csharp_webapi/13.Basic-Bot-Template/Dialogs/Greeting/resources/cancel.lu
+++ b/samples/csharp_webapi/13.Basic-Bot-Template/Dialogs/Greeting/resources/cancel.lu
@@ -1,0 +1,19 @@
+> Cancel intent and utterances
+> See https://github.com/Microsoft/botbuilder-tools/tree/master/packages/Ludown to learn more about .lu files and the Ludown CLI tool.
+# Cancel
+- please cancel
+- cancel
+- quit
+- stop
+- abort
+- don't do it
+- don't do that
+- i would like to cancel
+- i will not give you my name
+- i won't give you my name
+- no way, I won't give you my location
+- I'm not going to tell you where i live
+- I will not give you my location or name
+- no way
+- please stop
+- I'm bailing

--- a/samples/csharp_webapi/13.Basic-Bot-Template/Dialogs/Greeting/resources/greeting.chat
+++ b/samples/csharp_webapi/13.Basic-Bot-Template/Dialogs/Greeting/resources/greeting.chat
@@ -1,0 +1,9 @@
+user=Vishwac
+bot=BasicBot
+
+user: hi
+bot: What is your name?
+user: my name is vishwac
+bot: Hello Vishwac, what city do you live in? 
+user: I'm from seattle
+bot: Hi Vishwac, from Seattle, nice to meet you! 

--- a/samples/csharp_webapi/13.Basic-Bot-Template/Dialogs/Greeting/resources/greeting.lu
+++ b/samples/csharp_webapi/13.Basic-Bot-Template/Dialogs/Greeting/resources/greeting.lu
@@ -1,0 +1,61 @@
+> Greeting intent and utterances
+> See https://github.com/Microsoft/botbuilder-tools/tree/master/packages/Ludown to learn more about .lu files and the Ludown CLI tool.
+# Greeting
+- good evening
+- good morning
+- hello
+- hello bot
+- hey
+- hey there
+- hi
+- hi bot
+- hiya
+- how are you
+- how are you today
+- what's your name
+- who am i speaking to
+- who am i speaking with
+- who are you
+- yo
+
+> Add utterances with machine learned simple entity values
+- call me {userName=scott}
+- {userName=dan}
+- {userLocation=delhi}
+- {userLocation=dhaka}
+- i live in {userLocation=london}
+- i reside in {userLocation=san francisco}
+- i'm from {userLocation=georgia}
+- i'm {userName=john} from {userLocation=cairo}
+- i'm {userName=lauren}, and i'm from {userLocation=madrid}
+- i'm {userName=lili}
+- {userName=melanie}
+- {userLocation=mumbai}
+- my location is {userLocation=new york}
+- my name is {userName=maria} and i'm from {userLocation=sydney}
+- my name is {userName=tom}
+- {userLocation=paris}
+- {userLocation=portland}
+- {userLocation=seattle} is my current city
+- {userLocation=shangai}
+- {userName=tony} is my name
+- {userLocation=toronto}
+- {userName=vishwac} is my name
+- you can assume i live in {userLocation=cairo}
+- you can call me {userName=steve}
+
+> Add patterns with pattern.any entitiy
+- some people call me {userName_patternAny}
+- {userName_patternAny}.
+- i'm {userName_patternAny}
+- {userName_patternAny} is my name
+- my name is {userName_patternAny} and i'm from {userLocation_patternAny}
+- {userLocation_patternAny} is where i live
+- i'm from {userLocation_patternAny}
+- my name is {userName_patternAny}
+- i reside in {userLocation_patternAny}
+- you can call me {userName_patternAny}
+- you can assume i live in {userLocation_patternAny}
+- call me {userName_patternAny}
+- i live in {userLocation_patternAny}
+- i'm {userName_patternAny}[,] [and i'm] from {userLocation_patternAny}

--- a/samples/csharp_webapi/13.Basic-Bot-Template/Dialogs/Greeting/resources/help.lu
+++ b/samples/csharp_webapi/13.Basic-Bot-Template/Dialogs/Greeting/resources/help.lu
@@ -1,0 +1,22 @@
+> Help intent and utterances
+> See https://github.com/Microsoft/botbuilder-tools/tree/master/packages/Ludown to learn more about .lu files and the Ludown CLI tool.
+# Help
+- what can you do
+- ?
+- I'm lost
+- lost
+- confused
+- frustrated
+- what are your capabilities
+- help me
+- help
+- how do I interact with you
+- help please
+- i'm stuck
+- i don't understand
+- what can I say
+- what can you help me with
+- what can you do
+- what do i do now
+- why doesn't this work
+- can you help me

--- a/samples/csharp_webapi/13.Basic-Bot-Template/Dialogs/Greeting/resources/main.lu
+++ b/samples/csharp_webapi/13.Basic-Bot-Template/Dialogs/Greeting/resources/main.lu
@@ -1,0 +1,3 @@
+> Reference to other .lu files
+> See https://github.com/Microsoft/botbuilder-tools/tree/master/packages/Ludown to learn more about .lu files and the Ludown CLI tool.
+[All intents](./*)

--- a/samples/csharp_webapi/13.Basic-Bot-Template/Dialogs/Greeting/resources/none.lu
+++ b/samples/csharp_webapi/13.Basic-Bot-Template/Dialogs/Greeting/resources/none.lu
@@ -1,0 +1,21 @@
+> None intent and example utterances
+> See https://github.com/Microsoft/botbuilder-tools/tree/master/packages/Ludown to learn more about .lu files and the Ludown CLI tool.
+# None
+- spaghetti
+- gnocchi
+- her cat has no teeth
+- world wide pants
+- i'd rather be riding my bike
+- Cook me something
+- Have you any dreams?
+- Dont you ever sleep?
+- Do you play games?
+- Can you fly?
+- What's your age?
+- Are you old?
+- How old are you?
+- Getting tired of you
+- I am tired of you
+- You are boring
+- Who is your boss?
+- Are you busy?


### PR DESCRIPTION
Fixes https://github.com/Microsoft/BotBuilder-Samples/issues/752

## Proposed Changes
Add missing resource files to the sample **13.Basic-Bot-Template**.

## Testing
Running the following command should generate a LUIS model as mentioned in the [readme](https://github.com/Microsoft/BotBuilder-Samples/blob/a19da027f28b9dc74fa127aa505a2fb7726e67f6/samples/csharp_webapi/13.Basic-Bot-Template/README.md#set-up-luis-via-command-line):
```bash
ludown parse toluis -l .\Dialogs -s -o .\CognitiveModels -n BasicBot
```