### PR TITLE
Fix readme to point to the sample repo

### DIFF
--- a/samples/javascript_nodejs/14.nlp-with-dispatch/README.MD
+++ b/samples/javascript_nodejs/14.nlp-with-dispatch/README.MD
@@ -12,7 +12,7 @@ Use the Dispatch model in cases when:
 # To try this sample
 - Clone the repository
     ```bash
-    git clone https://github.com/Microsoft/botbuilder-js.git
+    git clone https://github.com/Microsoft/botbuilder-samples.git
     ```
 - In a terminal, 
     ```bash

--- a/samples/javascript_nodejs/14.nlp-with-dispatch/homeAutomation.js
+++ b/samples/javascript_nodejs/14.nlp-with-dispatch/homeAutomation.js
@@ -19,7 +19,7 @@ const ROOM_PATTERNANY_ENTITY = 'Room_PatternAny';
 const { HomeAutomationState } = require('./home-automation-state');
 
 // this is the LUIS service type entry in the .bot file.
-const LUIS_CONFIGURATION = 'YK-10-29-mutantEBC_Home Automation';
+const LUIS_CONFIGURATION = 'Home Automation';
 
 class HomeAutomation {
     /**

--- a/samples/javascript_nodejs/14.nlp-with-dispatch/homeAutomation.js
+++ b/samples/javascript_nodejs/14.nlp-with-dispatch/homeAutomation.js
@@ -19,7 +19,7 @@ const ROOM_PATTERNANY_ENTITY = 'Room_PatternAny';
 const { HomeAutomationState } = require('./home-automation-state');
 
 // this is the LUIS service type entry in the .bot file.
-const LUIS_CONFIGURATION = 'Home Automation';
+const LUIS_CONFIGURATION = 'YK-10-29-mutantEBC_Home Automation';
 
 class HomeAutomation {
     /**
@@ -84,12 +84,19 @@ class HomeAutomation {
         // Find any additional device properties specified.
         const deviceProperties = findEntities(DEVICE_PROPERTY_ENTITY, homeAutoResults.entities);
         const numberProperties = findEntities(NUMBER_ENTITY, homeAutoResults.entities);
-        // Update device state.
-        await this.state.setDevice((devices || devicesPatternAny), (rooms || roomsPatternAny), operations[0], (deviceProperties || numberProperties), context);
-        await context.sendActivity(`You reached the "HomeAutomation" dialog.`);
-        await context.sendActivity(`Here's the current snapshot of your prior operations`);
-        // read out operations list
-        await context.sendActivity(await this.state.getDevices(context));
+
+        if (operations === undefined) {
+            await context.sendActivity(`You reached the "HomeAutomation" dialog. However you need to specific an operation, for example turn on bedroom light`);
+        }
+        else {
+            // Update device state.
+            await this.state.setDevice((devices || devicesPatternAny), (rooms || roomsPatternAny), operations[0], (deviceProperties || numberProperties), context);
+            await context.sendActivity(`You reached the "HomeAutomation" dialog.`);
+            await context.sendActivity(`Here's the current snapshot of your prior operations`);
+            // read out operations list
+            await context.sendActivity(await this.state.getDevices(context));
+        }
+
     }
 };
 


### PR DESCRIPTION
## Proposed Changes
Simple readme update to point to the correct samples repo

Handle error case when dispatch is wrong about the intent and the home automation dialog doesnt handle intent with no entities. 