### PR TITLE
Replaced breaking brackets <> with string placeholder in .NET samples

### DIFF
--- a/samples/csharp_dotnetcore/13.basic-bot/BasicBot.cs
+++ b/samples/csharp_dotnetcore/13.basic-bot/BasicBot.cs
@@ -30,7 +30,7 @@ namespace Microsoft.BotBuilderSamples
         /// Key in the bot config (.bot file) for the LUIS instance.
         /// In the .bot file, multiple instances of LUIS can be configured.
         /// </summary>
-        public static readonly string LuisConfiguration = < YOUR_BOT_NAME > + "_basic-bot-LUIS";
+        public static readonly string LuisConfiguration = "YOUR_LUIS_SERVICE_NAME";
 
         private readonly IStatePropertyAccessor<GreetingState> _greetingStateAccessor;
         private readonly IStatePropertyAccessor<DialogState> _dialogStateAccessor;

--- a/samples/csharp_dotnetcore/13.basic-bot/README.md
+++ b/samples/csharp_dotnetcore/13.basic-bot/README.md
@@ -57,12 +57,12 @@ Your project may be configured to rely on this secret and you should update it a
             ...
 ```
 
- 7. Update <YOUR_BOT_NAME> in `BasicBot.cs'.
+ 7. Update "YOUR_LUIS_SERVICE_NAME" in `BasicBot.cs'.
  ```dotnet
      public class BasicBot : IBot
     {
        ...
-        public static readonly string LuisConfiguration = <YOUR_BOT_NAME> +  "basic-bot-LUIS";
+        public static readonly string LuisConfiguration = "YOUR_LUIS_SERVICE_NAME";
  ```
  8. Right click on the generated bot configuration file, click "Properties".
   - Ensure "Copy to Output Directory" is set to "Copy always".

--- a/samples/csharp_dotnetcore/21.luis-with-appinsights/LuisBot.cs
+++ b/samples/csharp_dotnetcore/21.luis-with-appinsights/LuisBot.cs
@@ -27,7 +27,7 @@ namespace Microsoft.BotBuilderSamples
         /// Key in the bot config (.bot file) for the LUIS instance.
         /// In the .bot file, multiple instances of LUIS can be configured.
         /// </summary>
-        public static readonly string LuisKey = <YOUR_BOT_NAME> + "_LuisBot";
+        public static readonly string LuisKey = "YOUR_LUIS_SERVICE_NAME";
 
         /// <summary>
         /// Services configured from the ".bot" file.

--- a/samples/csharp_dotnetcore/21.luis-with-appinsights/README.md
+++ b/samples/csharp_dotnetcore/21.luis-with-appinsights/README.md
@@ -53,12 +53,12 @@ Your project may be configured to rely on this secret and you should update it a
             ...
 ```
 
- 7. Update <YOUR_BOT_NAME> in `botbuilder-samples\samples\csharp_dotnetcore\21.luis-with-appsinsights\LuisBot.cs'.
+ 7. Update "YOUR_LUIS_SERVICE_NAME" in `botbuilder-samples\samples\csharp_dotnetcore\21.luis-with-appsinsights\LuisBot.cs'.
  ```dotnet
      public class LuisBot : IBot
     {
        ...
-        public static readonly string LuisKey = <YOUR_BOT_NAME> + "_LuisBot";
+        public static readonly string LuisKey = "YOUR_LUIS_SERVICE_NAME";
  ```
  8. Right click on the generated bot configuration file, click "Properties".
   - Ensure "Copy to Output Directory" is set to "Copy always".


### PR DESCRIPTION
Fixes build errors in .NET samples 13. BasicBot and 21. LuisAppInsights

```
samples\csharp_dotnetcore\13.basic-bot\BasicBot.cs(33,59): Error CS1525: Invalid expression term '<'
samples\csharp_dotnetcore\21.luis-with-appinsights\LuisBot.cs(30,49): Error CS1525: Invalid expression term '<'
```

## Proposed Changes

  - changed angle brackets `< >` placeholder in sample to string `"YOUR_LUIS_SERVICE_NAME"` to no longer give `"Invalid expression term <"` error
