### PR TITLE
Use obj spread instead of Object.assign

### DIFF
--- a/samples/javascript_es6/01.a.browser-echo/src/webChatAdapter.js
+++ b/samples/javascript_es6/01.a.browser-echo/src/webChatAdapter.js
@@ -25,12 +25,14 @@ export class WebChatAdapter extends BotAdapter {
             },
             postActivity: activity => {
                 const id = Date.now().toString();
-                return Observable.fromPromise(this
-                    .onReceive(Object.assign({}, activity, {
+
+                return Observable.fromPromise(
+                    this.onReceive({
+                        ...activity,
                         id,
                         conversation: { id: 'bot' },
                         channelId: 'WebChat'
-                    }))
+                    })
                     .then(() => id)
                 );
             }


### PR DESCRIPTION
It's a chore, just :nail_care: 

## Proposed Changes
Instead of using object.assign, we can use obj spread in `activity` and simple object