### PR TITLE
added concurrency dependency and watch script for typescript

### DIFF
--- a/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
@@ -9,7 +9,7 @@
         "test": "echo \"Error: no test specified\" && exit 1",
         "build": "tsc",
         "start": "tsc && node ./lib/index.js",
-        "watch": "tsc && node ./lib/index.js"
+        "watch": "concurrently --kill-others \"tsc -w\" \"nodemon ./lib/index.js\""
       },
     "dependencies": {
         "botbuilder": "^4.0.6",
@@ -18,6 +18,7 @@
         "restify": "^6.3.4"
     },
     "devDependencies": {
+        "concurrently": "^4.0.1",
         "eslint": "^5.6.0",
         "eslint-config-standard": "^12.0.0",
         "eslint-plugin-import": "^2.14.0",


### PR DESCRIPTION
Fixes #819 

## Proposed Changes
1. Adds yeoman dependency on ```concurrently```, a package that allows for running multiple commands concurrently
2. Adds working ```watch``` script: 
        ```"watch": "concurrently --kill-others \"tsc -w\" \"nodemon ./lib/index.js\""```
This script runs tsc -w and nodemon concurrently, and kills both processes if either fails. 