### PR TITLE
fix samples broken by file exists check

### DIFF
--- a/samples/csharp_dotnetcore/03.welcome-user/Startup.cs
+++ b/samples/csharp_dotnetcore/03.welcome-user/Startup.cs
@@ -32,6 +32,8 @@ namespace Microsoft.BotBuilderSamples
 
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
                 .AddEnvironmentVariables();
 
             Configuration = builder.Build();

--- a/samples/csharp_dotnetcore/04.simple-prompt/Startup.cs
+++ b/samples/csharp_dotnetcore/04.simple-prompt/Startup.cs
@@ -33,6 +33,8 @@ namespace Microsoft.BotBuilderSamples
 
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
                 .AddEnvironmentVariables();
 
             Configuration = builder.Build();

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/Startup.cs
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/Startup.cs
@@ -32,6 +32,8 @@ namespace Microsoft.BotBuilderSamples
 
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
                 .AddEnvironmentVariables();
 
             Configuration = builder.Build();

--- a/samples/csharp_dotnetcore/06.using-cards/Startup.cs
+++ b/samples/csharp_dotnetcore/06.using-cards/Startup.cs
@@ -33,6 +33,8 @@ namespace Microsoft.BotBuilderSamples
 
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
                 .AddEnvironmentVariables();
 
             this.Configuration = builder.Build();

--- a/samples/csharp_dotnetcore/19.custom-dialogs/Startup.cs
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/Startup.cs
@@ -33,6 +33,8 @@ namespace Microsoft.BotBuilderSamples
 
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
                 .AddEnvironmentVariables();
 
             Configuration = builder.Build();


### PR DESCRIPTION
The commit:

https://github.com/Microsoft/BotBuilder-Samples/commit/351c4747a32b2e40c1fe2db6c73203720dea3e2b

Appears to have broken the following samples. This PR fixes them.
- 03.welcome-user
- 04.simple-prompt
- 05.multi-turn-prompt
- 06.using-cards
- 19.custom-dialogs

