### PR TITLE
Remove ConfigureAwait calls from user code.

### DIFF
--- a/samples/csharp_dotnetcore/09.message-routing/Dialogs/Greeting/GreetingDialog.cs
+++ b/samples/csharp_dotnetcore/09.message-routing/Dialogs/Greeting/GreetingDialog.cs
@@ -182,7 +182,7 @@ namespace Microsoft.BotBuilderSamples
             }
             else
             {
-                await promptContext.Context.SendActivityAsync($"Names needs to be at least `{NameLengthMinValue}` characters long.").ConfigureAwait(false);
+                await promptContext.Context.SendActivityAsync($"Names needs to be at least `{NameLengthMinValue}` characters long.");
                 return false;
             }
         }
@@ -205,7 +205,7 @@ namespace Microsoft.BotBuilderSamples
             }
             else
             {
-                await promptContext.Context.SendActivityAsync($"City names needs to be at least `{CityLengthMinValue}` characters long.").ConfigureAwait(false);
+                await promptContext.Context.SendActivityAsync($"City names needs to be at least `{CityLengthMinValue}` characters long.");
                 return false;
             }
         }

--- a/samples/csharp_dotnetcore/09.message-routing/MessageRoutingBot.cs
+++ b/samples/csharp_dotnetcore/09.message-routing/MessageRoutingBot.cs
@@ -134,7 +134,7 @@ namespace Microsoft.BotBuilderSamples
                         {
                             var welcomeCard = CreateAdaptiveCardAttachment();
                             var response = CreateResponse(activity, welcomeCard);
-                            await dc.Context.SendActivityAsync(response).ConfigureAwait(false);
+                            await dc.Context.SendActivityAsync(response);
                         }
                     }
                 }

--- a/samples/csharp_dotnetcore/13.basic-bot/BasicBot.cs
+++ b/samples/csharp_dotnetcore/13.basic-bot/BasicBot.cs
@@ -80,7 +80,7 @@ namespace Microsoft.BotBuilderSamples
             if (activity.Type == ActivityTypes.Message)
             {
                 // Perform a call to LUIS to retrieve results for the current activity message.
-                var luisResults = await _services.LuisServices[LuisConfiguration].RecognizeAsync(dc.Context, cancellationToken).ConfigureAwait(false);
+                var luisResults = await _services.LuisServices[LuisConfiguration].RecognizeAsync(dc.Context, cancellationToken);
 
                 // If any entities were updated, treat as interruption.
                 // For example, "no my name is tony" will manifest as an update of the name to be "tony".
@@ -155,7 +155,7 @@ namespace Microsoft.BotBuilderSamples
                         {
                             var welcomeCard = CreateAdaptiveCardAttachment();
                             var response = CreateResponse(activity, welcomeCard);
-                            await dc.Context.SendActivityAsync(response).ConfigureAwait(false);
+                            await dc.Context.SendActivityAsync(response);
                         }
                     }
                 }

--- a/samples/csharp_dotnetcore/13.basic-bot/Dialogs/Greeting/GreetingDialog.cs
+++ b/samples/csharp_dotnetcore/13.basic-bot/Dialogs/Greeting/GreetingDialog.cs
@@ -181,7 +181,7 @@ namespace Microsoft.BotBuilderSamples
             }
             else
             {
-                await promptContext.Context.SendActivityAsync($"Names needs to be at least `{NameLengthMinValue}` characters long.").ConfigureAwait(false);
+                await promptContext.Context.SendActivityAsync($"Names needs to be at least `{NameLengthMinValue}` characters long.");
                 return false;
             }
         }
@@ -204,7 +204,7 @@ namespace Microsoft.BotBuilderSamples
             }
             else
             {
-                await promptContext.Context.SendActivityAsync($"City names needs to be at least `{CityLengthMinValue}` characters long.").ConfigureAwait(false);
+                await promptContext.Context.SendActivityAsync($"City names needs to be at least `{CityLengthMinValue}` characters long.");
                 return false;
             }
         }

--- a/samples/csharp_dotnetcore/14.nlp-with-dispatch/NlpDispatch/NlpDispatchBot.cs
+++ b/samples/csharp_dotnetcore/14.nlp-with-dispatch/NlpDispatch/NlpDispatchBot.cs
@@ -180,7 +180,7 @@ namespace NLP_With_Dispatch_Bot
         {
             if (!string.IsNullOrEmpty(context.Activity.Text))
             {
-                var results = await _services.QnAServices[appName].GetAnswersAsync(context).ConfigureAwait(false);
+                var results = await _services.QnAServices[appName].GetAnswersAsync(context);
                 if (results.Any())
                 {
                     await context.SendActivityAsync(results.First().Answer, cancellationToken: cancellationToken);

--- a/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Dispatcher/MainDispatcher.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Dispatcher/MainDispatcher.cs
@@ -101,7 +101,7 @@ namespace Microsoft.BotBuilderSamples
             var context = innerDc.Context;
 
             // Get on turn property through the property accessor.
-            var onTurnProperty = await _onTurnAccessor.GetAsync(context, () => new OnTurnProperty()).ConfigureAwait(false);
+            var onTurnProperty = await _onTurnAccessor.GetAsync(context, () => new OnTurnProperty());
 
             // Evaluate if the requested operation is possible/ allowed.
             var activeDialog = (innerDc.ActiveDialog != null) ? innerDc.ActiveDialog.Id : string.Empty;

--- a/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/WhatCanYouDo/WhatCanYouDo.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/WhatCanYouDo/WhatCanYouDo.cs
@@ -25,7 +25,7 @@ namespace Microsoft.BotBuilderSamples
         {
             var activity = dc.Context.Activity.CreateReply();
             activity.Attachments = new List<Attachment> { Helpers.CreateAdaptiveCardAttachment(@".\Dialogs\WhatCanYouDo\Resources\whatCanYouDoCard.json"), };
-            await dc.Context.SendActivityAsync(activity).ConfigureAwait(false);
+            await dc.Context.SendActivityAsync(activity);
             await dc.Context.SendActivityAsync("Pick a query from the card or you can use the suggestions below.");
             return await dc.EndDialogAsync();
         }

--- a/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/WhoAreYou/WhoAreYouDialog.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/WhoAreYou/WhoAreYouDialog.cs
@@ -84,8 +84,8 @@ namespace Microsoft.BotBuilderSamples
                 turnCounterAccessor,
                 async (promptContext, cancellationToken) =>
                 {
-                    var userProfile = await userProfileAccessor.GetAsync(promptContext.Context).ConfigureAwait(false);
-                    var counter = await turnCounterAccessor.GetAsync(promptContext.Context).ConfigureAwait(false);
+                    var userProfile = await userProfileAccessor.GetAsync(promptContext.Context);
+                    var counter = await turnCounterAccessor.GetAsync(promptContext.Context);
 
                     // Prompt validator
                     // Examine if we have a user name and validate it.
@@ -96,10 +96,10 @@ namespace Microsoft.BotBuilderSamples
                         {
                             await promptContext.Context.SendActivityAsync("Sorry, I can only accept two words for a name.");
                             await promptContext.Context.SendActivityAsync("You can always say 'My name is <your name>' to introduce yourself to me.");
-                            await userProfileAccessor.SetAsync(promptContext.Context, new UserProfile("Human")).ConfigureAwait(false);
+                            await userProfileAccessor.SetAsync(promptContext.Context, new UserProfile("Human"));
 
                             // Set updated turn counter
-                            await turnCounterAccessor.SetAsync(promptContext.Context, counter).ConfigureAwait(false);
+                            await turnCounterAccessor.SetAsync(promptContext.Context, counter);
                             return false;
                         }
                         else
@@ -108,7 +108,7 @@ namespace Microsoft.BotBuilderSamples
                             userProfile.UserName = char.ToUpper(userProfile.UserName[0]) + userProfile.UserName.Substring(1);
 
                             // Create user profile and set it to state.
-                            await userProfileAccessor.SetAsync(promptContext.Context, userProfile).ConfigureAwait(false);
+                            await userProfileAccessor.SetAsync(promptContext.Context, userProfile);
                             return true;
                         }
                     }


### PR DESCRIPTION
Fixes #773 

This PR removes all ConfigureAwait calls from code that is considered "User" code. 

Note that ConfigureAwait calls remain - and should be considered needed - in Middleware and Adapter sample code. 