### PR TITLE
Use await more consistently in index.js files

### DIFF
--- a/samples/javascript_nodejs/02.echobot-with-counter/index.js
+++ b/samples/javascript_nodejs/02.echobot-with-counter/index.js
@@ -54,7 +54,7 @@ adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     console.error(`\n [onTurnError]: ${ error }`);
     // Send a message to the user
-    context.sendActivity(`Oops. Something went wrong!`);
+    await context.sendActivity(`Oops. Something went wrong!`);
     // Clear out state
     await conversationState.clear(context);
     // Save state changes.

--- a/samples/javascript_nodejs/03.welcome-users/index.js
+++ b/samples/javascript_nodejs/03.welcome-users/index.js
@@ -54,7 +54,7 @@ adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     console.error(`\n [onTurnError]: ${ error }`);
     // Send a message to the user
-    context.sendActivity(`Oops. Something went wrong!`);
+    await context.sendActivity(`Oops. Something went wrong!`);
     // Clear out state
     await userState.clear(context);
     // Save state changes.

--- a/samples/javascript_nodejs/04.simple-prompt/index.js
+++ b/samples/javascript_nodejs/04.simple-prompt/index.js
@@ -91,7 +91,7 @@ adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     console.error(`\n [onTurnError]: ${ error }`);
     // Send a message to the user
-    context.sendActivity(`Oops. Something went wrong!`);
+    await context.sendActivity(`Oops. Something went wrong!`);
     // Clear out state
-    conversationState.clear(context);
+    await conversationState.clear(context);
 };

--- a/samples/javascript_nodejs/05.multi-turn-prompt/index.js
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/index.js
@@ -94,7 +94,7 @@ adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     console.error(`\n [onTurnError]: ${ error }`);
     // Send a message to the user
-    context.sendActivity(`Oops. Something went wrong!`);
+    await context.sendActivity(`Oops. Something went wrong!`);
     // Clear out state
-    conversationState.clear(context);
+    await conversationState.clear(context);
 };

--- a/samples/javascript_nodejs/09.message-routing/index.js
+++ b/samples/javascript_nodejs/09.message-routing/index.js
@@ -49,7 +49,7 @@ adapter.onTurnError = async (context, error) => {
     //       application insights.
     console.error(`\n [onTurnError]: ${ error }`);
     // Send a message to the user
-    context.sendActivity(`Oops. Something went wrong!`);
+    await context.sendActivity(`Oops. Something went wrong!`);
     // Clear out state
     await conversationState.clear(context);
     // Save state changes.

--- a/samples/javascript_nodejs/10.prompt-validations/index.js
+++ b/samples/javascript_nodejs/10.prompt-validations/index.js
@@ -92,7 +92,7 @@ adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     console.error(`\n [onTurnError]: ${ error }`);
     // Send a message to the user
-    context.sendActivity(`Oops. Something went wrong!`);
+    await context.sendActivity(`Oops. Something went wrong!`);
     // Clear out state
-    conversationState.clear(context);
+    await conversationState.clear(context);
 };

--- a/samples/javascript_nodejs/13.basic-bot/index.js
+++ b/samples/javascript_nodejs/13.basic-bot/index.js
@@ -58,7 +58,7 @@ adapter.onTurnError = async (context, error) => {
     //       application insights.
     console.error(`\n [onTurnError]: ${ error }`);
     // Send a message to the user
-    context.sendActivity(`Oops. Something went wrong!`);
+    await context.sendActivity(`Oops. Something went wrong!`);
     // Clear out state
     await conversationState.clear(context);
     // Save state changes.

--- a/samples/javascript_nodejs/16.proactive-messages/index.js
+++ b/samples/javascript_nodejs/16.proactive-messages/index.js
@@ -91,5 +91,5 @@ adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     console.error(`\n [onTurnError]: ${ error }`);
     // Send a message to the user
-    context.sendActivity(`Oops. Something went wrong!`);
+    await context.sendActivity(`Oops. Something went wrong!`);
 };

--- a/samples/javascript_nodejs/17.multilingual-conversations/index.js
+++ b/samples/javascript_nodejs/17.multilingual-conversations/index.js
@@ -59,7 +59,7 @@ adapter.onTurnError = async (turnContext, error) => {
     // Load and then clear out state. This is to prevent the user from being stuck
     // in a conversation due to bad state.
     await conversationState.load(turnContext);
-    conversationState.clear(turnContext);
+    await conversationState.clear(turnContext);
     await conversationState.saveChanges(turnContext);
 };
 

--- a/samples/javascript_nodejs/18.bot-authentication/index.js
+++ b/samples/javascript_nodejs/18.bot-authentication/index.js
@@ -52,7 +52,7 @@ adapter.onTurnError = async (context, error) => {
     //       application insights.
     console.error(`\n [onTurnError]: ${ error }`);
     // Send a message to the user
-    context.sendActivity(`Oops. Something went wrong!`);
+    await context.sendActivity(`Oops. Something went wrong!`);
     // Clear out state
     await conversationState.clear(context);
     // Save state changes.

--- a/samples/javascript_nodejs/19.custom-dialogs/index.js
+++ b/samples/javascript_nodejs/19.custom-dialogs/index.js
@@ -92,7 +92,7 @@ adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     console.error(`\n [onTurnError]: ${ error }`);
     // Send a message to the user
-    context.sendActivity(`Oops. Something went wrong!`);
+    await context.sendActivity(`Oops. Something went wrong!`);
     // Clear out state
-    conversationState.clear(context);
+    await conversationState.clear(context);
 };

--- a/samples/javascript_nodejs/23.facebook-events/index.js
+++ b/samples/javascript_nodejs/23.facebook-events/index.js
@@ -86,7 +86,7 @@ adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     console.error(`\n [onTurnError]: ${ error }`);
     // Send a message to the user
-    context.sendActivity(`Oops. Something went wrong!`);
+    await context.sendActivity(`Oops. Something went wrong!`);
     // Clear out state
-    conversationState.clear(context);
+    await conversationState.clear(context);
 };

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/index.js
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/index.js
@@ -55,7 +55,7 @@ adapter.onTurnError = async (turnContext, error) => {
     // Load and then clear out state. This is to prevent the user from being stuck
     // in a conversation due to bad state.
     await conversationState.load(turnContext);
-    conversationState.clear(turnContext);
+    await conversationState.clear(turnContext);
     await conversationState.saveChanges(turnContext);
 };
 

--- a/samples/javascript_nodejs/25.logger-bot/index.js
+++ b/samples/javascript_nodejs/25.logger-bot/index.js
@@ -102,7 +102,7 @@ adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     console.error(`\n [onTurnError]: ${error}`);
     // Send a message to the user
-    context.sendActivity(`Oops. Something went wrong!`);
+    await context.sendActivity(`Oops. Something went wrong!`);
     // Clear out state
     await conversationState.load(context);
     await conversationState.clear(context);

--- a/samples/javascript_nodejs/26.transcript-logger-bot/index.js
+++ b/samples/javascript_nodejs/26.transcript-logger-bot/index.js
@@ -101,7 +101,7 @@ adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     console.error(`\n [onTurnError]: ${error}`);
     // Send a message to the user
-    context.sendActivity(`Oops. Something went wrong!`);
+    await context.sendActivity(`Oops. Something went wrong!`);
     // Clear out state
     await conversationState.load(context);
     await conversationState.clear(context);


### PR DESCRIPTION
Fixes #822

## Proposed Changes

  - Use await for async methods in the 15 index.js files where await was missing
  - Some of the index.js files were already using await consistently, some were using await inconsistently, and some weren't using await at all
  - await was missing for calls to context.sendActivity and conversationState.clear


## Testing

The changes all pertain to unhandled errors in NodeJS, samples, so you can test by introducing errors into the code of each affected sample and making sure `onTurnError` works correctly.