### PR TITLE
Update README.md

### DIFF
--- a/samples/csharp_dotnetcore/12.nlp-with-luis/README.md
+++ b/samples/csharp_dotnetcore/12.nlp-with-luis/README.md
@@ -48,7 +48,7 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
     You can find this under your user settings at [luis.ai](https://www.luis.ai).  Click on your name in the upper right hand corner of the portal, and click on the "Settings" menu option.
     NOTE: Once you publish your app on LUIS portal for the first time, it takes some time for the endpoint to become available, about 5 minutes of wait should be sufficient.
 ### (Optional) Install LUDown
-- (Optional) Install the LUDown [here](https://github.com/Microsoft/botbuilder-tools/tree/master/packages/LUDown) to help describe language understanding components for your bot.
+- (Optional) Install the LUDown [here](https://github.com/Microsoft/botbuilder-tools/tree/master/packages/Ludown) to help describe language understanding components for your bot.
 
 ## Visual Studio
 - Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/12.nlp-with-luis`) and open `LuisBot.csproj` in Visual Studio 


### PR DESCRIPTION
## Proposed Changes

Simple change to the web-address used to redirect to the Ludown GitHub repo, current link is broken due to incorrect formatting as repo addresses are case sensitive. 

## Testing
Confirmed new link works in forked repo and now redirects to correct Ludown Repo.