### PR TITLE
changing luis.Region to luis.GetEndpoint()

### DIFF
--- a/samples/csharp_webapi/12.NLP-With-LUIS/App_Start/BotConfig.cs
+++ b/samples/csharp_webapi/12.NLP-With-LUIS/App_Start/BotConfig.cs
@@ -87,7 +87,7 @@ namespace LuisBot
                                 throw new InvalidOperationException("The Region ('region') is required to run this sample.  Please update your '.bot' file.");
                             }
 
-                            var app = new LuisApplication(luis.AppId, luis.SubscriptionKey, luis.Region);
+                            var app = new LuisApplication(luis.AppId, luis.SubscriptionKey, luis.GetEndpoint());
                             var recognizer = new LuisRecognizer(app);
                             luisServices.Add(LuisBot.LuisKey, recognizer);
                             break;


### PR DESCRIPTION
(No issue no.)

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->
<!-- If you are introducing a new sample, make sure that the sample adheres to sample guidelines -->

  - Updated BotConfig.cs file with luis.GetEndpoint() as the previous luis.Region caused a 'xxxregion not valid LUIS endpoint' error.
