### PR TITLE
[nodejs][26.transcript logger bot] Fix typos, error messages and '.env' file, and improve Readme structure

### DIFF
--- a/samples/javascript_nodejs/26.transcript-logger-bot/README.md
+++ b/samples/javascript_nodejs/26.transcript-logger-bot/README.md
@@ -17,7 +17,7 @@ In this example, the bot creates a new folder in the project directory called `l
     ```bash
     cd samples/javascript_nodejs/26.bot-transcript-logging
     ```
-- [Optional] Update the .env file under `samples/javascript_nodejs/26.bot-transcript-logging` with your botFileSecret For Azure Bot Service bots, you can find the botFileSecret under application settings.
+- [Optional] Update the `.env` file under `samples/javascript_nodejs/26.bot-transcript-logging` with your `botFileSecret` For Azure Bot Service bots, you can find the `botFileSecret` under application settings.
 - Install modules and start the bot
     ```bash
     npm i

--- a/samples/javascript_nodejs/26.transcript-logger-bot/README.md
+++ b/samples/javascript_nodejs/26.transcript-logger-bot/README.md
@@ -8,7 +8,16 @@ In this example, the bot creates a new folder in the project directory called `l
 
  This bot example uses [restify](https://www.npmjs.com/package/restify).
 
-# To run the bot
+# To try this sample
+- Clone the repository
+    ```bash
+    git clone https://github.com/microsoft/botbuilder-samples.git
+    ```
+- In a terminal, navigate to `samples/javascript_nodejs/26.bot-transcript-logging`
+    ```bash
+    cd samples/javascript_nodejs/26.bot-transcript-logging
+    ```
+- [Optional] Update the .env file under `samples/javascript_nodejs/26.bot-transcript-logging` with your botFileSecret For Azure Bot Service bots, you can find the botFileSecret under application settings.
 - Install modules and start the bot
     ```bash
     npm i
@@ -16,7 +25,7 @@ In this example, the bot creates a new folder in the project directory called `l
     ```
     Alternatively you can also use nodemon via
     ```bash
-    npm i & npm run watch
+    npm i && npm run watch
     ```
 
 # Testing the bot using Bot Framework Emulator
@@ -41,23 +50,13 @@ In this example, the bot's state is used to track number of messages.
     - User properties can be used for many purposes, such as determining where the user's prior conversation left off or simply greeting a returning user by name. If you store a user's preferences, you can use that information to customize the conversation the next time you chat. For example, you might alert the user to a news article about a topic that interests her, or alert a user when an appointment becomes available. You should clear them if the bot receives a delete user data activity.
 
 # Deploy this bot to Azure
-You can use the [MSBot][5] Bot Builder CLI tool to clone and configure the services this sample depends on.
-
-To install all Bot Builder tools -
-
-Ensure you have [Node.js](https://nodejs.org/) version 8.5 or higher
-
-```bash
-npm i -g msbot chatdown ludown qnamaker luis-apis botdispatch luisgen
-```
+You can use the [MSBot][5] Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools][11]
 
 To clone this bot, run
+```bash
+msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <App-Id> --appSecret <App-Secret>
 ```
-msbot clone services -f deploymentScripts/msbotClone -n myChatBot -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
-```
-
-**NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)
-
+**NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal][12]
 
 # Further reading
 - [Azure Bot Service Introduction][6]
@@ -76,3 +75,5 @@ msbot clone services -f deploymentScripts/msbotClone -n myChatBot -l <Azure-loca
 [8]: https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-storage?view=azure-bot-service-4.0&tabs=jsechoproperty%2Ccsetagoverwrite%2Ccsetag
 [9]: https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-state?view=azure-bot-service-4.0&tabs=js
 [10]: https://dev.botframework.com
+[11]: ../../../Installing_CLI_tools.md
+[12]: https://apps.dev.microsoft.com/

--- a/samples/javascript_nodejs/26.transcript-logger-bot/bot.js
+++ b/samples/javascript_nodejs/26.transcript-logger-bot/bot.js
@@ -37,7 +37,7 @@ class LoggerBot {
         this.dialogs.add(new NumberPrompt(AGE_PROMPT, async (prompt) => {
             if (prompt.recognized.succeeded) {
                 if (prompt.recognized.value <= 0) {
-                    await prompt.context.sendActivity(`Your age can't be less than zero.`);
+                    await prompt.context.sendActivity(`Your age can't be less than or equal to zero.`);
                     return false;
                 } else {
                     return true;
@@ -78,8 +78,8 @@ class LoggerBot {
     // Otherwise, the bot will skip the age step.
     async promptForAge(step) {
         if (step.result && step.result.value === 'yes') {
-            return await step.prompt(AGE_PROMPT, `What is your age?`,
-                {
+            return await step.prompt(AGE_PROMPT, {
+                    prompt: `What is your age?`,
                     retryPrompt: 'Sorry, please specify your age as a positive number or say cancel.'
                 }
             );


### PR DESCRIPTION
## Proposed Changes
  - Fix minor typos
  - Add `--appId` and `--appSecret` arguments to `msbot clone services` command, and instructions on how to obtain them
  - Fix `.env` file; `botFilePath` is incorrect, it should be `./transcriptloggerBot.bot`
  - Improve Readme file to match other samples' Readme
  - Fix error messages related to `user age`; the messages now explicitly says that `the age can't be less than or equal to zero` and shows the users how to dismiss the age input (after first input failed, with the word `cancel`)