### PR TITLE
Remove "Update Packages" Text from Readme.md

### DIFF
--- a/samples/csharp_dotnetcore/01.console-echo/README.md
+++ b/samples/csharp_dotnetcore/01.console-echo/README.md
@@ -27,11 +27,6 @@ git clone https://github.com/microsoft/botbuilder-samples.git
 - Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/01.console-echo` folder
 - Type `dotnet run`.
 
-## Update packages
-- In Visual Studio right click on the solution and select "Restore NuGet Packages".
-  **Note:** this sample requires `Microsoft.Bot.Builder`.
-- In Visual Studio Code type `dotnet restore`
-
 # Further reading
 - [Azure Bot Service Introduction](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 - [Bot basics](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-basics?view=azure-bot-service-4.0)

--- a/samples/csharp_dotnetcore/03.welcome-user/readme.md
+++ b/samples/csharp_dotnetcore/03.welcome-user/readme.md
@@ -16,11 +16,6 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 - Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/03.welcome-user`
 - Type `dotnet run`.
 
-## Update packages
-
-- In Visual Studio right click on the solution and select "Restore NuGet Packages".
-- In Visual Studio Code type `dotnet restore`
-
 # Deploy this bot to Azure
 
 You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).

--- a/samples/csharp_dotnetcore/04.simple-prompt/readme.md
+++ b/samples/csharp_dotnetcore/04.simple-prompt/readme.md
@@ -16,9 +16,6 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 - Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/04.simple-prompt` folder.
 - Type `dotnet run`.
 
-## Update packages
-- In Visual Studio right click on the solution and select "Restore NuGet Packages".
-- In Visual Studio Code type `dotnet restore`
 ## Testing the bot using Bot Framework Emulator
 [Microsoft Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot 
 developers to test and debug their bots on localhost or running remotely through a tunnel.

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/readme.md
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/readme.md
@@ -17,11 +17,6 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 - Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/05.multi-turn-prompt` folder.
 - Type `dotnet run`.
 
-## Update packages
-- In Visual Studio right click on the solution and select "Restore NuGet Packages".
-  **Note:** this sample requires `Microsoft.Bot.Builder`, `Microsoft.Bot.Builder.Dialogs` and `Microsoft.Bot.Builder.Integration.AspNet.Core`.
-- In Visual Studio Code type `dotnet restore`
-
 ## Testing the bot using Bot Framework Emulator
 [Microsoft Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot 
 developers to test and debug their bots on localhost or running remotely through a tunnel.

--- a/samples/csharp_dotnetcore/06.using-cards/readme.md
+++ b/samples/csharp_dotnetcore/06.using-cards/readme.md
@@ -20,7 +20,6 @@ git clone https://github.com/microsoft/botbuilder-samples.git
 ## Visual Studio Code
 - Open `botbuilder-samples/samples/csharp_dotnetcore/06.using-cards` folder
 - Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/06.using-cards`
-- In the Visual Studio Code terminal type `dotnet restore`
 - Type `dotnet run`.
 ## Testing the bot using Bot Framework Emulator
 [Microsoft Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot 

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/readme.md
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/readme.md
@@ -25,9 +25,6 @@ git clone https://github.com/microsoft/botbuilder-samples.git
 - Open `botbuilder-samples/samples/csharp_dotnetcore/07.using-adaptive-cards` folder
 - Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/07.using-adaptive-cards`
 - Type `dotnet run`.
-## Update packages
-- In Visual Studio right click on the solution and select "Restore NuGet Packages".
-- In Visual Studio Code type `dotnet restore`
 # Deploy this bot to Azure
 
 You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).

--- a/samples/csharp_dotnetcore/08.suggested-actions/readme.md
+++ b/samples/csharp_dotnetcore/08.suggested-actions/readme.md
@@ -19,15 +19,16 @@ git clone https://github.com/microsoft/botbuilder-samples.git
 ```
 - [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/08.suggested-actions` with your botFileSecret.  For Azure Bot Service bots, you can find the botFileSecret under application settings.
 # Prerequisites
+
 ## Visual studio
 - Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/08.suggested-actions`) and open `SuggestedActionsBot.csproj` in Visual Studio 
 - Run the project (press `F5` key)
+
 ## Visual studio code
 - Open `botbuilder-samples/samples/csharp_dotnetcore/08.suggested-actions` folder
 - Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/08.suggested-actions`
 - Type `dotnet run`.
-## Update packages
-- In Visual Studio right click on the solution and select "Restore NuGet Packages".
+
 # Deploy this bot to Azure
 You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
 

--- a/samples/csharp_dotnetcore/10.prompt-validations/readme.md
+++ b/samples/csharp_dotnetcore/10.prompt-validations/readme.md
@@ -13,9 +13,6 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 - Open `botbuilder-samples/samples/csharp_dotnetcore/04.simple-prompt` sample folder.
 - Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/10.prompt-validations` folder.
 - Type `dotnet run`.
-## Update packages
-- In Visual Studio right click on the solution and select "Restore NuGet Packages".
-  **Note:** this sample requires `Microsoft.Bot.Builder.Dialogs` and `Microsoft.Bot.Builder.Integration.AspNet.Core`.
 ## Testing the bot using Bot Framework Emulator
 [Microsoft Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot 
 developers to test and debug their bots on localhost or running remotely through a tunnel.

--- a/samples/csharp_dotnetcore/11.qnamaker/README.md
+++ b/samples/csharp_dotnetcore/11.qnamaker/README.md
@@ -32,10 +32,6 @@ QnA Maker CLI to deploy the model.
 - Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/11.qnamaker` folder.
 - Type `dotnet run`.
 
-## Update packages
-- In Visual Studio right click on the solution and select "Restore NuGet Packages".
-  **Note:** this sample requires `Microsoft.Bot.Builder`, `Microsoft.Bot.Builder.AI.QnA` and `Microsoft.Bot.Builder.Integration.AspNet.Core`.
-
 ## Testing the bot using Bot Framework Emulator
 [Microsoft Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
 

--- a/samples/csharp_dotnetcore/15.handling-attachments/readme.md
+++ b/samples/csharp_dotnetcore/15.handling-attachments/readme.md
@@ -22,10 +22,6 @@ git clone https://github.com/microsoft/botbuilder-samples.git
 - Open `botbuilder-samples/samples/csharp_dotnetcore/15.handling-attachments` folder
 - Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/15.handling-attachments`
 - Type `dotnet run`.
-## Update packages
-
-- In Visual Studio right click on the solution and select "Restore NuGet Packages".
-- In Visual Studio Code type `dotnet restore`
 
 ## Testing the bot using Bot Framework Emulator
 

--- a/samples/csharp_dotnetcore/16.proactive-messages/README.md
+++ b/samples/csharp_dotnetcore/16.proactive-messages/README.md
@@ -25,13 +25,11 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 # Prerequisites
 ## Visual Studio
 - Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/16.proactive-messages`) and open `ProactiveBot.csproj` in Visual Studio.
-- In Visual Studio right click on the solution and select "Restore NuGet Packages".
 - Run the project (press `F5` key)
 
 ## Visual Studio Code
 - Open `botbuilder-samples/samples/csharp_dotnetcore/16.proactive-messages` sample folder.
 - Bring up a console, navigate to `botbuilder-samples/samples/csharp_dotnetcore/16.proactive-messages` folder.
-- In the Visual Studio Code terminal type `dotnet restore`
 - Type `dotnet run`.
 
 ## Testing the bot using Bot Framework Emulator

--- a/samples/csharp_dotnetcore/18.bot-authentication/readme.md
+++ b/samples/csharp_dotnetcore/18.bot-authentication/readme.md
@@ -32,7 +32,6 @@ With the OAuth 2 provider configured, please update `ConnectionName` in `Authent
 ## Visual Studio Code
 - Open `botbuilder-samples/samples/csharp_dotnetcore/18.bot-authentication` folder
 - Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/18.bot-authentication`
-- In the Visual Studio Code terminal type `dotnet restore`
 - Type `dotnet run`.
 
 ## Testing the bot using Bot Framework Emulator

--- a/samples/csharp_dotnetcore/19.custom-dialogs/readme.md
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/readme.md
@@ -16,9 +16,6 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 - Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/19.custom-dialogs` folder.
 - Type `dotnet run`.
 
-## Update packages
-- In Visual Studio right click on the solution and select "Restore NuGet Packages".
-
 ## Testing the bot using Bot Framework Emulator
 [Microsoft Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot 
 developers to test and debug their bots on localhost or running remotely through a tunnel.

--- a/samples/csharp_dotnetcore/20.qna-with-appinsights/README.md
+++ b/samples/csharp_dotnetcore/20.qna-with-appinsights/README.md
@@ -31,13 +31,11 @@ Qna Maker CLI to deploy the model.
 
 ## Visual Studio
 - Navigate to the samples folder (`botbuilder-samples/samples/csharp_dotnetcore/20.qna-with-appinsights`) and open QnABot.csproj in Visual Studio.
-- In Visual Studio right click on the solution and select "Restore NuGet Packages".
 - Run the project (press `F5` key)
 
 ## Visual Studio Code
 - Open `botbuilder-samples/samples/csharp_dotnetcore/20.qna-with-appinsights` sample folder
 - Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/20.qna-with-appinsights` folder.
-- In the Visual Studio Code terminal type `dotnet restore`.
 - Type `dotnet run`.
 
 ## Testing the bot using Bot Framework Emulator

--- a/samples/csharp_dotnetcore/22.conversation-history/README.md
+++ b/samples/csharp_dotnetcore/22.conversation-history/README.md
@@ -20,7 +20,6 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 - Open `botbuilder-samples/samples/csharp_dotnetcore/22.conversation-history` sample folder.
 - Set the BLOB store connection-string in BotConfiguration.bot
 - Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/22.conversation-history` folder.
-- In the Visual Studio Code terminal type `dotnet restore`
 - Type `dotnet run`.
 
 ## Testing the bot using Bot Framework Emulator

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/readme.md
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/readme.md
@@ -40,7 +40,6 @@ git clone https://github.com/microsoft/botbuilder-samples.git
 ## Visual Studio Code
 - Open `botbuilder-samples/samples/csharp_dotnetcore/24.bot-authentication-msgraph` folder
 - Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/24.bot-authentication-msgraph`
-- In the Visual Studio Code terminal type `dotnet restore`
 - Type `dotnet run`.
 ## Testing the bot using Bot Framework Emulator
 [Microsoft Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot 

--- a/samples/csharp_dotnetcore/40.timex-resolution/Readme.md
+++ b/samples/csharp_dotnetcore/40.timex-resolution/Readme.md
@@ -41,11 +41,6 @@ git clone https://github.com/microsoft/botbuilder-samples.git
 - Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/40.timex-resolution` folder
 - Type `dotnet run`.
 
-## Update packages
-- In Visual Studio right click on the solution and select "Restore NuGet Packages".
-  **Note:** this sample requires `Microsoft.Recognizers.Text.DataTypes.TimexExpression` and `Microsoft.Recognizers.Text.DateTime`.
-- In Visual Studio Code type `dotnet restore`
-
 # Further reading
 - [Azure Bot Service Introduction](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 - [Bot basics](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-basics?view=azure-bot-service-4.0)

--- a/samples/csharp_dotnetcore/42.scaleout/readme.md
+++ b/samples/csharp_dotnetcore/42.scaleout/readme.md
@@ -24,9 +24,6 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 - Bring up a terminal, navigate to `botbuilder-samples/samples/csharp_dotnetcore/42.scaleout` folder.
 - Type `dotnet run`.
 
-## Update packages
-- In Visual Studio right click on the solution and select "Restore NuGet Packages".
-
 ## Testing the bot using Bot Framework Emulator
 [Microsoft Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot 
 developers to test and debug their bots on localhost or running remotely through a tunnel.


### PR DESCRIPTION
The readme.md for each of our samples has a section around updating packages. This section is not relevent, and should be removed. This PR removes the package updates ("dotnet restore" / VS right click) steps from all the readme.md files. 

Per [the docs](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet?tabs=netcore21), the following is true for .Net Core 2:
> Starting with .NET Core 2.0, you don't have to run dotnet restore because it's run implicitly by all commands that require a restore to occur, such as dotnet new, dotnet build and dotnet run. 