### PR TITLE
Add missing or broken LUIS setup steps to nodejs sample #12

### DIFF
--- a/samples/javascript_nodejs/12.nlp-with-luis/README.MD
+++ b/samples/javascript_nodejs/12.nlp-with-luis/README.MD
@@ -42,12 +42,14 @@ In this sample, we demonstrate how to call LUIS to extract the intents from a us
 - Click on `My Apps`.
 - Click on the `Import new app` button.
 - Click on the `Choose File` and select [reminders.json](cognitiveModels/reminders.json) from the `BotBuilder-Samples/javascript_nodejs/12.nlp-with-luis/cognitiveModels` folder.
+- Provide a name for the LUIS app
+- Click on the `Train` button. To train your language model.
+- Click on the `Publish` button.  To publish your trained language model.
 - Update [nlp-with-luis.bot](nlp-with-luis.bot) file with your AppId, SubscriptionKey, Region and Version. 
-    You can find this information under "Publish" tab for your LUIS application at [LUIS portal](https://www.luis.ai).  For example, for
-https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/{LuisAppID}?subscription-key={LuisSubscriptionKey}&verbose=true&timezoneOffset=0&q=
+    You can find this information under "Keys and Endpoint" tab for your LUIS application at [LUIS portal](https://www.luis.ai).  For example, for https://westus.settingsapi.cognitive.microsoft.com/luis/v2.0/apps/{LuisAppID}?subscription-key={LuisSubscriptionKey}&verbose=true&timezoneOffset=0&q=
 
     The Version is listed on the page.
-    Note: Enter the either "authoringKey" OR "subscriptionKey", not both.
+    Note: Enter either the "authoringKey" OR "subscriptionKey", not both.
     [See an example .bot service configuration for using LUIS here](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-luis?view=azure-bot-service-4.0&tabs=js#configure-your-bot-to-use-your-luis-app).    
 
 - Update [index.js](index.js) and set the `LUIS_CONFIGURATION` value to match the `name` field in your service declaration.


### PR DESCRIPTION
- add setup steps to train and publish the LUIS model
- keys are on the Keys and Endpoint settings page

