### PR TITLE
CafeBot not dispatching to BookTable correctly.

### DIFF
--- a/samples/csharp_dotnetcore/51.cafe-bot/CafeBot.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/CafeBot.cs
@@ -32,14 +32,11 @@ namespace Microsoft.BotBuilderSamples
         public const string OnTurnPropertyName = "onTurnStateProperty";
         public const string DialogStateProperty = "dialogStateProperty";
 
-        // The name of the bot you deployed.
-        public static readonly string MsBotName = "cafe66";
-
         /// <summary>
         /// Key in the bot config (.bot file) for the LUIS instances.
         /// In the .bot file, multiple instances of LUIS can be configured.
         /// </summary>
-        public static readonly string LuisConfiguration = MsBotName + "_" + "cafeDispatchModel";
+        public static readonly string LuisConfiguration = "cafeDispatchModel";
 
         // Greeting Dialog ID.
         public static readonly string GreetingDialogId = "greetingDialog";
@@ -152,6 +149,7 @@ namespace Microsoft.BotBuilderSamples
                     {
                         await SendWelcomeMessageAsync(turnContext);
                     }
+
                     break;
                 default:
                     // Handle other activity types as needed.

--- a/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Dispatcher/MainDispatcher.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Dispatcher/MainDispatcher.cs
@@ -166,7 +166,7 @@ namespace Microsoft.BotBuilderSamples
                 case WhoAreYouDialog.Name:
                     return await dc.BeginDialogAsync(WhoAreYouDialog.Name);
                 case WhatCanYouDo.Name:
-                    return await dc.BeginDialogAsync(WhatCanYouDo.Name);
+                    return await BeginWhatCanYouDoDialogAsync(dc, onTurnProperty);
                 case "None":
                 default:
                     await dc.Context.SendActivityAsync("I'm still learning.. Sorry, I do not know how to help you with that.");

--- a/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/QnA/QnADialog.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/QnA/QnADialog.cs
@@ -52,7 +52,7 @@ namespace Microsoft.BotBuilderSamples
         private async Task<string> UserSalutationAsync(ITurnContext context)
         {
             var salutation = string.Empty;
-            var userProfile = await _userProfileAccessor.GetAsync(context);
+            var userProfile = await _userProfileAccessor.GetAsync(context, () => new UserProfile(string.Empty));
             if (userProfile == null && !string.IsNullOrWhiteSpace(userProfile.UserName))
             {
                 var userName = userProfile.UserName;

--- a/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Shared/Prompts/GetLocationDateTimePartySizePrompt.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Shared/Prompts/GetLocationDateTimePartySizePrompt.cs
@@ -13,9 +13,6 @@ namespace Microsoft.BotBuilderSamples
 {
     public class GetLocationDateTimePartySizePrompt : TextPrompt
     {
-        // The name of the bot you deployed.
-        public static readonly string MsBotName = "cafe66";
-
         private const string ContinuePromptIntent = "GetLocationDateTimePartySize";
         private const string HelpIntent = "Help";
         private const string CancelIntent = "Cancel";
@@ -25,7 +22,7 @@ namespace Microsoft.BotBuilderSamples
         private const string ConfirmCancelPrompt = "confirmCancelPrompt";
 
         // LUIS service type entry for turn.n book table LUIS model in the .bot file.
-        private static readonly string LuisConfiguration = $"{MsBotName}_cafeBotBookTableTurnNModel";
+        private static readonly string LuisConfiguration = $"cafeBotBookTableTurnNModel";
 
         private readonly BotServices _botServices;
         private readonly IStatePropertyAccessor<UserProfile> _userProfileAccessor;
@@ -77,7 +74,7 @@ namespace Microsoft.BotBuilderSamples
 
                 // Return and do not continue if there is an error.
                 await turnContext.SendActivityAsync(updateResult.Outcome[0].Message);
-                return await ContinueDialogAsync(dc);
+                return await base.ContinueDialogAsync(dc);
             }
 
             // Call LUIS and get results.
@@ -107,7 +104,7 @@ namespace Microsoft.BotBuilderSamples
 
                 // Return and do not continue if there is an error.
                 await turnContext.SendActivityAsync(updateResult.Outcome[0].Message);
-                return await ContinueDialogAsync(dc);
+                return await base.ContinueDialogAsync(dc);
             }
 
             // Did user ask for help or said cancel or continuing the conversation?
@@ -153,7 +150,7 @@ namespace Microsoft.BotBuilderSamples
 
             // Set reservation property based on OnTurn properties.
             await _reservationsAccessor.SetAsync(turnContext, updateResult.NewReservation);
-            return await ContinueDialogAsync(dc);
+            return await base.ContinueDialogAsync(dc);
         }
 
         public async override Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result, CancellationToken cancellationToken = default(CancellationToken))

--- a/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Shared/Prompts/GetUserNamePrompt.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Shared/Prompts/GetUserNamePrompt.cs
@@ -14,14 +14,11 @@ namespace Microsoft.BotBuilderSamples
 {
     public class GetUserNamePrompt : TextPrompt
     {
-        // The name of the bot you deployed.
-        public static readonly string MsBotName = "cafe66";
-
         /// <summary>
         /// Key in the bot config (.bot file) for the LUIS instances.
         /// In the .bot file, multiple instances of LUIS can be configured.
         /// </summary>
-        public static readonly string LuisConfiguration = $"{MsBotName}_getUserProfile";
+        public static readonly string LuisConfiguration = $"getUserProfile";
 
         // Dialog name
         private const string InterruptionDispatcher = "interruptionDispatcherDialog";

--- a/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Shared/StateProperties/EntityProperty.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Shared/StateProperties/EntityProperty.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-
 namespace Microsoft.BotBuilderSamples
 {
     public class EntityProperty
     {
-        public EntityProperty(string name, string value)
+        public EntityProperty(string name, object value)
         {
             EntityName = name;
             Value = value;

--- a/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Shared/StateProperties/OnTurnProperty.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Shared/StateProperties/OnTurnProperty.cs
@@ -45,24 +45,13 @@ namespace Microsoft.BotBuilderSamples
             // Gather entity values if available. Uses a const list of LUIS entity names.
             foreach (var entity in luisEntities)
             {
-                dynamic value = luisResults.Entities[entity];
-                string strVal = null;
-                if (value is JArray)
+                var value = luisResults.Entities.SelectTokens(entity).FirstOrDefault();
+                if (value == null)
                 {
-                    // ConfirmList is nested arrays.
-                    value = (from val in (JArray)value
-                              select val).FirstOrDefault();
-                }
-
-                strVal = (string)value;
-
-                if (strVal == null)
-                {
-                    // Don't add empty entities.
                     continue;
                 }
 
-                onTurnProperties.Entities.Add(new EntityProperty(entity, strVal));
+                onTurnProperties.Entities.Add(new EntityProperty(entity, value));
             }
 
             return onTurnProperties;

--- a/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Shared/StateProperties/ReservationResult.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Shared/StateProperties/ReservationResult.cs
@@ -13,7 +13,11 @@ namespace Microsoft.BotBuilderSamples
         Unknown,
     }
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
     public class ReservationOutcome
+#pragma warning restore SA1649 // File name should match first type name
+#pragma warning restore SA1402 // File may only contain a single type
     {
         public ReservationOutcome(string message, string entity)
         {
@@ -33,7 +37,10 @@ namespace Microsoft.BotBuilderSamples
             NewReservation = property ?? throw new ArgumentNullException(nameof(property));
             Status = status;
             Outcome = new List<ReservationOutcome>();
-            Outcome.Add(outcome);
+            if (outcome != null)
+            {
+                Outcome.Add(outcome);
+            }
         }
 
         public ReservationProperty NewReservation { get; }

--- a/samples/csharp_dotnetcore/51.cafe-bot/README.md
+++ b/samples/csharp_dotnetcore/51.cafe-bot/README.md
@@ -87,19 +87,18 @@ cd BotBuilder-Samples\samples\csharp_dotnetcore\51.cafe-bot
  - - To login, run:	
 
 ```bash
-Connect-AzureRmAccount
+az login
 ```
 - - To select your Azure subscription, run:
 
 ```bash
-Select-AzureRmSubscription -Subscription "<YOUR SUBSCRIPTION>"
 az account set --subscription "<YOUR SUBSCRIPTION>"
 ```
 
 - - Run MSbot Clone and pass in your LUIS authoring key and Azure subscription ID. This command will create required services for your bot and update the .bot file.
 
 ```bash
-msbot clone services --name <YOUR-BOT-NAME> --folder DeploymentScripts/msbotClone --location <Bot service location, ie "westus"> --luisAuthoringKey <YOUR LUIS AUTHORING KEY> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services --noDecorate --name <YOUR-BOT-NAME> --folder DeploymentScripts/msbotClone --location <Bot service location, ie "westus"> --luisAuthoringKey <YOUR LUIS AUTHORING KEY> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_dotnetcore/51.cafe-bot/Startup.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/Startup.cs
@@ -46,7 +46,7 @@ namespace Microsoft.BotBuilderSamples
             // See https://aka.ms/about-bot-file to learn more about .bot file its use and bot configuration.
             var secretKey = Configuration.GetSection("botFileSecret")?.Value;
             var botFilePath = Configuration.GetSection("botFilePath")?.Value;
-            var botConfig = BotConfiguration.Load(botFilePath ?? @".\CafeBot.bot", secretKey);
+            var botConfig = BotConfiguration.Load(botFilePath ?? @".\cafe-bot.bot", secretKey);
             services.AddSingleton(sp => botConfig ?? throw new InvalidOperationException($"The .bot configuration file could not be loaded. botFilePath: {botFilePath}"));
 
             // Add BotServices singleton


### PR DESCRIPTION
Fixes #937

## Proposed Changes
- Modify README.md to use `--noDecorate` in clone instructions.
- Modify code so user doesn't have to modify LUIS reference in code (--noDecorate).
- Fix BookTable dispatch so it runs BookTable correctly.
- Fix default bot file in startup (recently changed to `cafe-bot.bot`)
- Fix up storage issues associated with null SetAsync() which fail in ConcurrrentDirectionary.
- Fix JObject paths to reference LUIS results correctly.
- Remove SendAsync() with empty string.

## Testing
- Tested with latest msbot/az client with undecorated LUIS.