### PR TITLE
Updated npm scripts for TS Yeoman generators

### DIFF
--- a/generators/generator-botbuilder/generators/app/templates/basic/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/basic/package.json.ts
@@ -6,10 +6,10 @@
     "license": "MIT",
     "main": "<%= npmMain %>",
     "scripts": {
-        "build": "node_modules/typescript/bin/tsc --build",
-        "start": "node_modules/typescript/bin/tsc --build && node ./lib/index.js",
-        "watch": "concurrently --kill-others \"node_modules/typescript/bin/tsc -w\" \"nodemon ./lib/index.js\"",
-        "lint": "node_modules/tslint/bin/tslint -c tslint.json 'src/**/*.ts'",
+        "build": "node_modules/.bin/tsc --build",
+        "start": "node_modules/.bin/tsc --build && node ./lib/index.js",
+        "watch": "node_modules/.bin/nodemon --watch ./src -e ts --exec \"npm run start\"",
+        "lint": "node_modules/.bin/tslint -c tslint.json 'src/**/*.ts'",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "repository": {
@@ -30,7 +30,6 @@
     "devDependencies": {
         "@types/dotenv": "6.1.0",
         "@types/restify": "7.2.6",
-        "concurrently": "^4.0.1",
         "nodemon": "^1.18.6",
         "tslint": "^5.11.0",
         "typescript": "^3.1.6"

--- a/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
@@ -6,10 +6,10 @@
     "license": "MIT",
     "main": "<%= npmMain %>",
     "scripts": {
-        "build": "node_modules/typescript/bin/tsc --build",
-        "start": "node_modules/typescript/bin/tsc --build && node ./lib/index.js",
-        "watch": "concurrently --kill-others \"node_modules/typescript/bin/tsc -w\" \"nodemon ./lib/index.js\"",
-        "lint": "node_modules/tslint/bin/tslint -c tslint.json 'src/**/*.ts'",
+        "build": "node_modules/.bin/tsc --build",
+        "start": "node_modules/.bin/tsc --build && node ./lib/index.js",
+        "watch": "node_modules/.bin/nodemon --watch ./src -e ts --exec \"npm run start\"",
+        "lint": "node_modules/.bin/tslint -c tslint.json 'src/**/*.ts'",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "repository": {
@@ -25,7 +25,6 @@
     "devDependencies": {
         "@types/dotenv": "6.1.0",
         "@types/restify": "7.2.6",
-        "concurrently": "^4.0.1",
         "nodemon": "^1.18.6",
         "tslint": "^5.11.0",
         "typescript": "^3.1.6"

--- a/generators/generator-botbuilder/generators/app/templates/empty/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/empty/package.json.ts
@@ -6,10 +6,10 @@
     "license": "MIT",
     "main": "<%= npmMain %>",
     "scripts": {
-        "build": "node_modules/typescript/bin/tsc --build",
-        "start": "node_modules/typescript/bin/tsc --build && node ./lib/index.js",
-        "watch": "concurrently --kill-others \"node_modules/typescript/bin/tsc -w\" \"nodemon ./lib/index.js\"",
-        "lint": "node_modules/tslint/bin/tslint -c tslint.json 'src/**/*.ts'",
+        "build": "node_modules/.bin/tsc --build",
+        "start": "node_modules/.bin/tsc --build && node ./lib/index.js",
+        "watch": "node_modules/.bin/nodemon --watch ./src -e ts --exec \"npm run start\"",
+        "lint": "node_modules/.bin/tslint -c tslint.json 'src/**/*.ts'",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "repository": {
@@ -22,7 +22,6 @@
     },
     "devDependencies": {
         "@types/restify": "7.2.6",
-        "concurrently": "^4.0.1",
         "nodemon": "^1.18.6",
         "tslint": "^5.11.0",
         "typescript": "^3.1.6"


### PR DESCRIPTION
Applies to #980 for the generators, but not the samples

## Proposed Changes
  - Resolves incorrect path to local commands (e.g. "node_modules/typescript/bin/tsc" should be "node_modules/.bin/tsc"). **Note**: There's a pretty good argument for using ```npx``` for this - it looks for local commands in .bin, and falls back on global commands if they don't exist. I chose to fix the path issue to get the watch issue resolved, but this should be revisited. 
  - Removes concurrently dependency given race condition
  - Uses nodemon typescript watch functionality (-e ts) to watch changes to TS files
  - Runs the start script each time a change is detected in any ts files in src (--watch ./src)

## Testing
I tested this by using ```npm link``` to run my local version of the generator. The watch script (and other fixed scripts) work as expected on the first run and on consecutive runs. 