### PR TITLE
included Bot Framework.zip in solution and VSIX by editing csproj

### DIFF
--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/BotBuilderTemplatesVSIX.csproj
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/BotBuilderTemplatesVSIX.csproj
@@ -71,6 +71,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="ProjectTemplates\Bot Framework.zip">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>


### PR DESCRIPTION
Fixes https://github.com/Microsoft/botbuilder-dotnet/issues/1101

## Proposed Changes
  - included `Bot Framework.zip` (what contains the templates) in solution and VSIX by editing `csproj`