### PR TITLE
Fixing issue 990 [.net-core][22.conversation-history] Calling scriptActivitiesAsync results in infinite loop

### DIFF
--- a/samples/csharp_dotnetcore/22.conversation-history/ConversationHistoryBot.cs
+++ b/samples/csharp_dotnetcore/22.conversation-history/ConversationHistoryBot.cs
@@ -74,7 +74,7 @@ namespace Microsoft.BotBuilderSamples
                     var count = 0;
                     do
                     {
-                        var pagedTranscript = await _transcriptStore.GetTranscriptActivitiesAsync(activity.ChannelId, activity.Conversation.Id);
+                        var pagedTranscript = await _transcriptStore.GetTranscriptActivitiesAsync(activity.ChannelId, activity.Conversation.Id, continuationToken);
                         var activities = pagedTranscript.Items
                             .Where(a => a.Type == ActivityTypes.Message)
                             .Select(ia => (Activity)ia)


### PR DESCRIPTION
Fixing the issue described here: [Endless loop issue](https://github.com/Microsoft/BotBuilder-Samples/issues/990)
