### PR TITLE
Remove versions on Emulator references and unused links from README

### DIFF
--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/ProjectTemplates/Multi-project/EchoBot/README.md
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/ProjectTemplates/Multi-project/EchoBot/README.md
@@ -14,14 +14,14 @@ This bot has been created using [Microsoft Bot Framework][1], it shows how to cr
 * Type `dotnet run`.
 
 ## Interacting With Your Bot Using the Emulator
-Launch the [Microsoft Bot Framework Emulator v4][3] and open the generated project's `.bot` file.
+Launch the [Microsoft Bot Framework Emulator v4][3] and open the `$safeprojectname$.bot` file.
 
-# Testing the bot using Bot Framework Emulator **v4**
+# Testing the bot using Bot Framework Emulator
 [Microsoft Bot Framework Emulator][3] is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
 
-* Install the Bot Framework Emulator version 4.1.0 or greater from [here][4].
+* Install the Bot Framework Emulator. (Download [here][4].)
 
-## Connect to the bot using Bot Framework Emulator **v4**
+## Connect to the bot using Bot Framework Emulator 
 * Launch Bot Framework Emulator
 * File -> Open Bot Configuration
 * Navigate to $safeprojectname$ folder
@@ -59,7 +59,3 @@ If you are new to Microsoft Azure, please refer to [Getting started with Azure][
 [13]: https://github.com/Microsoft/botbuilder-tools/tree/master/packages/MSBot
 [14]: https://portal.azure.com
 [15]: https://luis.ai
-
-[50]: https://visualstudio.microsoft.com/downloads/
-[51]: https://azure.microsoft.com/en-us/free/
-[52]: https://docs.microsoft.com/en-us/powershell/azure/overview?

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/ProjectTemplates/Multi-project/EchoBot/README.md
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/ProjectTemplates/Multi-project/EchoBot/README.md
@@ -13,13 +13,13 @@ This bot has been created using [Microsoft Bot Framework][1], it shows how to cr
 * Using the command line, navigate to your project's root folder.
 * Type `dotnet run`.
 
-## Interacting With Your Bot Using the Emulator
+## Interacting With Your Bot Using the Emulator **v4**
 Launch the [Microsoft Bot Framework Emulator v4][3] and open the `$safeprojectname$.bot` file.
 
-# Testing the bot using Bot Framework Emulator
+# Testing the bot using Bot Framework Emulator **v4**
 [Microsoft Bot Framework Emulator][3] is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
 
-* Install the Bot Framework Emulator. (Download [here][4].)
+* Install the Bot Framework Emulator version 4.1.0 or greater from [here][4]
 
 ## Connect to the bot using Bot Framework Emulator 
 * Launch Bot Framework Emulator


### PR DESCRIPTION
Regards to requests by @cleemullins in PR https://github.com/Microsoft/BotBuilder-Samples/pull/999

## Proposed Changes
  - removed "v4" in references to Bot Framework Emulator
  - removed extra, unused links from the bottom of Echo README
 
