### PR TITLE
Fixes 1015 - cannot install 'botbuilder-applicationinsights' in qna-with app insights

### DIFF
--- a/samples/javascript_nodejs/20.qna-with-appinsights/index.js
+++ b/samples/javascript_nodejs/20.qna-with-appinsights/index.js
@@ -4,7 +4,7 @@
 const path = require('path');
 const restify = require('restify');
 const { BotFrameworkAdapter } = require('botbuilder');
-const { ApplicationInsightsTelemetryClient, ApplicationInsightsWebserverMiddleware } = require('botbuilder-applicationinsights');
+const { ApplicationInsightsTelemetryClient, ApplicationInsightsWebserverMiddleware } = require('applicationinsights');
 const { BotConfiguration } = require('botframework-config');
 const { QnAMakerBot } = require('./bot');
 const { MyAppInsightsMiddleware } = require('./middleware');


### PR DESCRIPTION
Fixes #1015 

## Proposed Changes
- incorrect require statement
- use correct require statement

## Testing
From the sample's root folder
- npm I
- npm start
