### PR TITLE
Update all Readme.Md files to point at www.luis.ai

### DIFF
--- a/generators/generator-botbuilder/generators/app/templates/basic/README.md.js
+++ b/generators/generator-botbuilder/generators/app/templates/basic/README.md.js
@@ -112,7 +112,7 @@ Would you like to perform this operation? [y/n]
 [8]: https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest
 [9]: https://github.com/Microsoft/botbuilder-tools/tree/master/packages/MSBot
 [10]: https://portal.azure.com
-[11]: https://luis.ai
+[11]: https://www.luis.ai
 [20]: https://docs.botframework.com
 [21]: https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0
 [22]: https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0

--- a/generators/generator-botbuilder/generators/app/templates/basic/README.md.ts
+++ b/generators/generator-botbuilder/generators/app/templates/basic/README.md.ts
@@ -112,7 +112,7 @@ Would you like to perform this operation? [y/n]
 [8]: https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest
 [9]: https://github.com/Microsoft/botbuilder-tools/tree/master/packages/MSBot
 [10]: https://portal.azure.com
-[11]: https://luis.ai
+[11]: https://www.luis.ai
 [20]: https://docs.botframework.com
 [21]: https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0
 [22]: https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0

--- a/generators/generator-botbuilder/generators/app/templates/echo/README.md.js
+++ b/generators/generator-botbuilder/generators/app/templates/echo/README.md.js
@@ -105,7 +105,7 @@ Would you like to perform this operation? [y/n]
 [8]: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest
 [9]: https://github.com/Microsoft/botbuilder-tools/tree/master/packages/MSBot
 [10]: https://portal.azure.com
-[11]: https://luis.ai
+[11]: https://www.luis.ai
 [20]: https://docs.botframework.com
 [21]: https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0
 [22]: https://docs.microsoft.com/en-us/azure/bot-service/?view=azure-bot-service-4.0

--- a/generators/generator-botbuilder/generators/app/templates/echo/README.md.ts
+++ b/generators/generator-botbuilder/generators/app/templates/echo/README.md.ts
@@ -104,7 +104,7 @@ Would you like to perform this operation? [y/n]
 [8]: https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest
 [9]: https://github.com/Microsoft/botbuilder-tools/tree/master/packages/MSBot
 [10]: https://portal.azure.com
-[11]: https://luis.ai
+[11]: https://www.luis.ai
 [20]: https://docs.botframework.com
 [21]: https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0
 [22]: https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0

--- a/generators/generator-botbuilder/generators/app/templates/empty/README.md.js
+++ b/generators/generator-botbuilder/generators/app/templates/empty/README.md.js
@@ -58,7 +58,7 @@ npm run watch
 [8]: https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest
 [9]: https://github.com/Microsoft/botbuilder-tools/tree/master/packages/MSBot
 [10]: https://portal.azure.com
-[11]: https://luis.ai
+[11]: https://www.luis.ai
 [20]: https://docs.botframework.com
 [21]: https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0
 [22]: https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0

--- a/generators/generator-botbuilder/generators/app/templates/empty/README.md.ts
+++ b/generators/generator-botbuilder/generators/app/templates/empty/README.md.ts
@@ -59,7 +59,7 @@ npm run watch
 [8]: https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest
 [9]: https://github.com/Microsoft/botbuilder-tools/tree/master/packages/MSBot
 [10]: https://portal.azure.com
-[11]: https://luis.ai
+[11]: https://www.luis.ai
 [20]: https://docs.botframework.com
 [21]: https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0
 [22]: https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0

--- a/samples/csharp_dotnetcore/13.basic-bot/README.md
+++ b/samples/csharp_dotnetcore/13.basic-bot/README.md
@@ -1,6 +1,6 @@
 # basic-bot
 This bot has been created using [Microsoft Bot Framework](https://dev.botframework.com),
-- - Use [LUIS](https://luis.ai) to implement core AI capabilities
+- - Use [LUIS](https://www.luis.ai) to implement core AI capabilities
 - Implement a multi-turn conversation using Dialogs
 - Handle user interruptions for such things as `Help` or `Cancel`
 - Prompt for and validate requests for information from the user
@@ -127,7 +127,7 @@ msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-loc
 - [Bot Framework Documentation](https://docs.botframework.com)
 - [Bot basics](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-basics?view=azure-bot-service-4.0)
 - [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
-- [LUIS](https://luis.ai)
+- [LUIS](https://www.luis.ai)
 - [Prompt Types](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-prompts?view=azure-bot-service-4.0&tabs=javascript)
 - [Azure Bot Service Introduction](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 - [Channels and Bot Connector Service](https://docs.microsoft.com/en-us/azure/bot-service/bot-concepts?view=azure-bot-service-4.0)

--- a/samples/csharp_dotnetcore/43.basic-bot-appinsights/README.md
+++ b/samples/csharp_dotnetcore/43.basic-bot-appinsights/README.md
@@ -1,6 +1,6 @@
 # basic-bot
 This bot has been created using [Microsoft Bot Framework](https://dev.botframework.com),
-- - Use [LUIS](https://luis.ai) to implement core AI capabilities
+- - Use [LUIS](https://www.luis.ai) to implement core AI capabilities
 - Implement a multi-turn conversation using Dialogs
 - Handle user interruptions for such things as `Help` or `Cancel`
 - Prompt for and validate requests for information from the user
@@ -120,7 +120,7 @@ msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-loc
 - [Bot Framework Documentation](https://docs.botframework.com)
 - [Bot basics](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-basics?view=azure-bot-service-4.0)
 - [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
-- [LUIS](https://luis.ai)
+- [LUIS](https://www.luis.ai)
 - [Prompt Types](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-prompts?view=azure-bot-service-4.0&tabs=javascript)
 - [Azure Bot Service Introduction](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 - [Channels and Bot Connector Service](https://docs.microsoft.com/en-us/azure/bot-service/bot-concepts?view=azure-bot-service-4.0)

--- a/samples/javascript_nodejs/02.a.echobot/README.md
+++ b/samples/javascript_nodejs/02.a.echobot/README.md
@@ -106,7 +106,7 @@ Would you like to perform this operation? [y/n]
 [8]: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest
 [9]: https://github.com/Microsoft/botbuilder-tools/tree/master/packages/MSBot
 [10]: https://portal.azure.com
-[11]: https://luis.ai
+[11]: https://www.luis.ai
 [20]: https://docs.botframework.com
 [21]: https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0
 [22]: https://docs.microsoft.com/en-us/azure/bot-service/?view=azure-bot-service-4.0

--- a/samples/javascript_nodejs/09.message-routing/README.md
+++ b/samples/javascript_nodejs/09.message-routing/README.md
@@ -68,7 +68,7 @@ Your project may be configured to rely on this secret and you should update it a
 - [Bot Framework Documentation](https://docs.botframework.com)
 - [Bot basics](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-basics?view=azure-bot-service-4.0)
 - [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
-- [LUIS](https://luis.ai)
+- [LUIS](https://www.luis.ai)
 - [Prompt Types](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-prompts?view=azure-bot-service-4.0&tabs=javascript)
 - [Azure Bot Service](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 - [Channels and Bot Connector Service](https://docs.microsoft.com/en-us/azure/bot-service/bot-concepts?view=azure-bot-service-4.0)

--- a/samples/javascript_nodejs/13.basic-bot/README.md
+++ b/samples/javascript_nodejs/13.basic-bot/README.md
@@ -2,7 +2,7 @@
 Bot Framework v4 basic bot sample
 
 This samples shows how to:
-- Use [LUIS](https://luis.ai) to implement core AI capabilities
+- Use [LUIS](https://www.luis.ai) to implement core AI capabilities
 - Implement a multi-turn conversation using Dialogs
 - Handle user interruptions for such things as Help or Cancel
 - Prompt for and validate requests for information from the user
@@ -44,7 +44,7 @@ See [here](./deploymentScripts/DEPLOY.md) to learn more about deploying this bot
 - [Bot Framework Documentation](https://docs.botframework.com)
 - [Bot basics](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-basics?view=azure-bot-service-4.0)
 - [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
-- [LUIS](https://luis.ai)
+- [LUIS](https://www.luis.ai)
 - [Prompt Types](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-prompts?view=azure-bot-service-4.0&tabs=javascript)
 - [Azure Bot Service Introduction](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 - [Channels and Bot Connector Service](https://docs.microsoft.com/en-us/azure/bot-service/bot-concepts?view=azure-bot-service-4.0)
@@ -74,7 +74,7 @@ Update `.env` with the appropriate keys botFilePath and botFileSecret.
 [7]: https://docs.microsoft.com/cli/azure/?view=azure-cli-latest
 [8]: https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest
 [10]: https://portal.azure.com
-[11]: https://luis.ai
+[11]: https://www.luis.ai
 [20]: https://docs.botframework.com
 [21]: https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0
 [22]: https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0

--- a/samples/javascript_nodejs/14.nlp-with-dispatch/README.md
+++ b/samples/javascript_nodejs/14.nlp-with-dispatch/README.md
@@ -1,7 +1,7 @@
 # NLP with Dispatch
 Bot Framework v4 NLP with Dispatch bot sample
 
-This sample shows how to create a bot that relies on multiple [LUIS.ai](https://luis.ai) and [QnAMaker.ai](https://qnamaker.ai) models for natural language processing (NLP).
+This sample shows how to create a bot that relies on multiple [LUIS.ai](https://www.luis.ai) and [QnAMaker.ai](https://qnamaker.ai) models for natural language processing (NLP).
 
 ## Prerequisites
 - [Node.js][4] version 8.5 or higher
@@ -110,7 +110,7 @@ Update the following line to add a prefix with the name of your bot (plus unders
 ## Manually configure required services
 ### Configure the LUIS service
 To create required LUIS applications for this sample bot,
-- Create an account with [LUIS](https://luis.ai). If you already have an account, login to your account.
+- Create an account with [LUIS](https://www.luis.ai). If you already have an account, login to your account.
 - Click on your name on top right corner of the screen -> settings and grab your authoring key.
 
 To create the LUIS application this bot needs and update the .bot file configuration, in a terminal,

--- a/samples/javascript_nodejs/51.cafe-bot/README.md
+++ b/samples/javascript_nodejs/51.cafe-bot/README.md
@@ -4,7 +4,7 @@ Bot Framework v4 cafe bot sample
 Contoso cafe bot is a complete and fairly sophisticated sample that demonstrates various parts of the [BotBuilder V4 SDK](https://github.com/microsoft/botbuilder-js) and [BotBuilder CLI tools](https://github.com/microsoft/botbuilder-tools) in action.
 
 This sample relies on prior knowledge/ familiarity with the following tools and services
-- [LUIS](https://luis.ai)
+- [LUIS](https://www.luis.ai)
 - [QnA Maker](https://qnamaker.ai)
 - [Ludown CLI tool](https://github.com/Microsoft/botbuilder-tools/tree/master/packages/Ludown)
 - [LUIS CLI tool](https://github.com/Microsoft/botbuilder-tools/tree/master/packages/LUIS)
@@ -34,7 +34,7 @@ Contoso cafe bot is a fairly sophisticated bot sample that uses the following co
 - Managing user and conversation state
 
 ## Services and tools demonstrated
-- Using [LUIS](https://luis.ai) for Natural Language Processing
+- Using [LUIS](https://www.luis.ai) for Natural Language Processing
 - Using [QnA Maker](https://qnamaker.ai) for FAQ, chit-chat, getting help and other single-turn conversations
 - Using [BotBuilder CLI tools](https://github.com/microsoft/botbuilder-tools) to create, configure and manage all required services.
 

--- a/samples/javascript_typescript/02.a.echobot/README.md
+++ b/samples/javascript_typescript/02.a.echobot/README.md
@@ -112,7 +112,7 @@ Would you like to perform this operation? [y/n]
 [8]: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest
 [9]: https://github.com/Microsoft/botbuilder-tools/tree/master/packages/MSBot
 [10]: https://portal.azure.com
-[11]: https://luis.ai
+[11]: https://www.luis.ai
 [20]: https://docs.botframework.com
 [21]: https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0
 [22]: https://docs.microsoft.com/en-us/azure/bot-service/?view=azure-bot-service-4.0

--- a/samples/javascript_typescript/12.nlp-with-luis/README.md
+++ b/samples/javascript_typescript/12.nlp-with-luis/README.md
@@ -120,7 +120,7 @@ const LUIS_CONFIGURATION = '<NAME>_nlp-with-luis-LUIS';
 ## Manually configure required services
 ### Configure the LUIS service
 To create required LUIS applications for this sample bot,
-- Create an account with [LUIS](https://luis.ai). If you already have an account, login to your account.
+- Create an account with [LUIS](https://www.luis.ai). If you already have an account, login to your account.
 - Click on your name on top right corner of the screen -> settings and grab your authoring key.
 
 To create the LUIS application this bot needs and update the `.bot` file configuration, in a terminal,

--- a/samples/javascript_typescript/13.basic-bot/README.md
+++ b/samples/javascript_typescript/13.basic-bot/README.md
@@ -4,7 +4,7 @@ Bot Builder v4 basic bot sample
 This bot has been created using [Microsoft Bot Framework](https://dev.botframework.com),
 
 This samples shows how to:
-- Use [LUIS](https://luis.ai) to implement core AI capabilities
+- Use [LUIS](https://www.luis.ai) to implement core AI capabilities
 - Implement a multi-turn conversation using Dialogs
 - Handle user interruptions for such things as 'Help' or 'Cancel'
 - Prompt for and validate requests for information from the user
@@ -50,7 +50,7 @@ See [here](./deploymentScripts/DEPLOY.md) to learn more about deploying this bot
 - [Bot Framework Documentation](https://docs.botframework.com)
 - [Bot basics](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-basics?view=azure-bot-service-4.0)
 - [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
-- [LUIS](https://luis.ai)
+- [LUIS](https://www.luis.ai)
 - [Prompt Types](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-prompts?view=azure-bot-service-4.0&tabs=javascript)
 - [Azure Bot Service Introduction](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 - [Channels and Bot Connector Service](https://docs.microsoft.com/en-us/azure/bot-service/bot-concepts?view=azure-bot-service-4.0)


### PR DESCRIPTION
The https://luis.ai link doesn't resolve to the luis website. This PR changes all of our https://luis.ai links to https://www.luis.ai, which resolves properly. 

The LUIS team has been notified, but hasn't yet provided an ETA. 

Note: The list of files to change was done using:
`grep -r -H 'https://luis.ai' .`