### PR TITLE
Add MessageBack Card Action to Sample Bots

### DIFF
--- a/samples/csharp_dotnetcore/06.using-cards/CardsBot.cs
+++ b/samples/csharp_dotnetcore/06.using-cards/CardsBot.cs
@@ -280,7 +280,8 @@ namespace Microsoft.BotBuilderSamples
                 Text = "Build and connect intelligent bots to interact with your users naturally wherever they are," +
                        " from text/sms to Skype, Slack, Office 365 mail and other popular services.",
                 Images = new List<CardImage> { new CardImage("https://sec.ch9.ms/ch9/7ff5/e07cfef0-aa3b-40bb-9baa-7c9ef8ff7ff5/buildreactionbotframework_960.jpg") },
-                Buttons = new List<CardAction> {
+                Buttons = new List<CardAction>
+                {
                     new CardAction(ActionTypes.OpenUrl, "Get Started", value: "https://docs.microsoft.com/bot-framework"),
                     new CardAction(ActionTypes.ImBack, "I am ImBack", value: "I am ImBack CardAction Value"),
                     new CardAction(ActionTypes.MessageBack, "I am MessageBack", text: "I am MessageBack CardAction Text", value: "I am MessageBack CardAction Value", displayText: "I am MessageBack displayText"),

--- a/samples/csharp_dotnetcore/06.using-cards/CardsBot.cs
+++ b/samples/csharp_dotnetcore/06.using-cards/CardsBot.cs
@@ -280,7 +280,11 @@ namespace Microsoft.BotBuilderSamples
                 Text = "Build and connect intelligent bots to interact with your users naturally wherever they are," +
                        " from text/sms to Skype, Slack, Office 365 mail and other popular services.",
                 Images = new List<CardImage> { new CardImage("https://sec.ch9.ms/ch9/7ff5/e07cfef0-aa3b-40bb-9baa-7c9ef8ff7ff5/buildreactionbotframework_960.jpg") },
-                Buttons = new List<CardAction> { new CardAction(ActionTypes.OpenUrl, "Get Started", value: "https://docs.microsoft.com/bot-framework") },
+                Buttons = new List<CardAction> {
+                    new CardAction(ActionTypes.OpenUrl, "Get Started", value: "https://docs.microsoft.com/bot-framework"),
+                    new CardAction(ActionTypes.ImBack, "I am ImBack", value: "I am ImBack CardAction Value"),
+                    new CardAction(ActionTypes.MessageBack, "I am MessageBack", text: "I am MessageBack CardAction Text", value: "I am MessageBack CardAction Value", displayText: "I am MessageBack displayText"),
+                },
             };
 
             return heroCard;

--- a/samples/csharp_dotnetcore/08.suggested-actions/SuggestedActionsBot.cs
+++ b/samples/csharp_dotnetcore/08.suggested-actions/SuggestedActionsBot.cs
@@ -145,7 +145,9 @@ namespace Microsoft.BotBuilderSamples
         /// Creates and sends an activity with suggested actions to the user. When the user
         /// clicks one of the buttons the text value from the <see cref="CardAction"/> will be
         /// displayed in the channel just as if the user entered the text. There are multiple
-        /// <see cref="ActionTypes"/> that may be used for different situations.
+        /// <see cref="ActionTypes"/> that may be used for different situations. For this sample we have only used two.
+        /// Note that the button with MessageBack ActionType initializes Text instead of Value.
+        /// However, Value can be initialized as an additional property.
         /// </summary>
         /// <param name="turnContext">Provides the <see cref="ITurnContext"/> for the turn of the bot.</param>
         /// <param name="cancellationToken" >(Optional) A <see cref="CancellationToken"/> that can be used by other objects
@@ -158,9 +160,9 @@ namespace Microsoft.BotBuilderSamples
             {
                 Actions = new List<CardAction>()
                 {
-                    new CardAction() { Title = "Red", Type = ActionTypes.ImBack, Value = "Red" },
-                    new CardAction() { Title = "Yellow", Type = ActionTypes.ImBack, Value = "Yellow" },
-                    new CardAction() { Title = "Blue", Type = ActionTypes.ImBack, Value = "Blue" },
+                    new CardAction() { Title = "Red", Type = ActionTypes.ImBack, Value = "Red: ImBack ActionType" },
+                    new CardAction() { Title = "Yellow", Type = ActionTypes.ImBack, Value = "Yellow: ImBack ActionType" },
+                    new CardAction() { Title = "Blue", Type = ActionTypes.MessageBack, Text = "Blue: MessageBack ActionType" },
                 },
             };
             await turnContext.SendActivityAsync(reply, cancellationToken);

--- a/samples/csharp_dotnetcore/08.suggested-actions/SuggestedActionsBot.cs
+++ b/samples/csharp_dotnetcore/08.suggested-actions/SuggestedActionsBot.cs
@@ -146,8 +146,8 @@ namespace Microsoft.BotBuilderSamples
         /// clicks one of the buttons the text value from the <see cref="CardAction"/> will be
         /// displayed in the channel just as if the user entered the text. There are multiple
         /// <see cref="ActionTypes"/> that may be used for different situations. For this sample we have only used two.
-        /// Note that the button with MessageBack ActionType initializes Text instead of Value.
-        /// However, Value can be initialized as an additional property.
+        /// Developers are encouraged to use MessageBack because it is supported across all channels and most clients.
+        /// PostBack is not supported by MSTeams. MessageBack can be used instead of PostBack and ImBack.
         /// </summary>
         /// <param name="turnContext">Provides the <see cref="ITurnContext"/> for the turn of the bot.</param>
         /// <param name="cancellationToken" >(Optional) A <see cref="CancellationToken"/> that can be used by other objects
@@ -160,6 +160,7 @@ namespace Microsoft.BotBuilderSamples
             {
                 Actions = new List<CardAction>()
                 {
+                    // Note that the button with MessageBack ActionType initializes Text instead of Value. Value is optional.
                     new CardAction() { Title = "Red", Type = ActionTypes.ImBack, Value = "Red: ImBack ActionType" },
                     new CardAction() { Title = "Yellow", Type = ActionTypes.ImBack, Value = "Yellow: ImBack ActionType" },
                     new CardAction() { Title = "Blue", Type = ActionTypes.MessageBack, Text = "Blue: MessageBack ActionType" },

--- a/samples/javascript_nodejs/06.using-cards/bot.js
+++ b/samples/javascript_nodejs/06.using-cards/bot.js
@@ -216,6 +216,18 @@ class RichCardsBot {
                     type: 'openUrl',
                     title: 'Get started',
                     value: 'https://docs.microsoft.com/en-us/azure/bot-service/'
+                },
+                {
+                    type: 'imBack',
+                    title: 'I am ImBack',
+                    value: 'I am ImBack CardAction Value'
+                },
+                {
+                    type: 'messageBack',
+                    title: 'I am MessageBack',
+                    text: 'I am MessageBack CardAction Text',
+                    displayText: 'I am MessageBack displayText',
+                    value: 'I am MessageBack CardAction Value'
                 }
             ])
         );


### PR DESCRIPTION
### NOTE: To be merged after MessageBack is implemented in WebChat and Emulator

Fixes # [Work Item](https://fuselabs.visualstudio.com/BotFramework/_queries/edit/17913)

## Proposed Changes
The purpose of this change is to add MessageBack card actions to bot samples. In sample 08 - suggested-actions, only ImBack ActionType was being used. Bot Framework now supports MessageBack ActionType. Also sample 06 - CardsBot was modified to add MessageBack card actions in Hero cards. Once MessageBack implementation is complete in the Emulator and WebChat bot developers will be encourage to use MessageBack instead of ImBack and PostBack. Therefore it is important that our samples demostrate how to use MessageBack ActionType.