### PR TITLE
[netcore] Update Microsoft.Bot.Builder packages references to 4.1.5

### DIFF
--- a/samples/csharp_dotnetcore/12.nlp-with-luis/LuisBot.csproj
+++ b/samples/csharp_dotnetcore/12.nlp-with-luis/LuisBot.csproj
@@ -13,10 +13,10 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.0.7" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.0.7" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>

--- a/samples/csharp_dotnetcore/43.basic-bot-appinsights/BasicBot.csproj
+++ b/samples/csharp_dotnetcore/43.basic-bot-appinsights/BasicBot.csproj
@@ -11,14 +11,14 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="0.12.1-preview" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.0.7" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.0.7" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.0.7" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.0.7" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.1.5" />
     <PackageReference Include="Microsoft.Graph" Version="1.10.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Proposed Changes
  - Update `Microsoft.Bot.Builder` packages outdated dependencies in samples `12.nlp-with-luis` and `43.basic-bot-appinsights` from `4.0.7` to `4.1.5`