### PR TITLE
changed qnamaker sample to use getAnswers() instead of deprecated generateAnswer()

### DIFF
--- a/samples/javascript_nodejs/11.qnamaker/bot.js
+++ b/samples/javascript_nodejs/11.qnamaker/bot.js
@@ -28,7 +28,7 @@ class QnAMakerBot {
         // By checking the incoming Activity type, the bot only calls QnA Maker in appropriate cases.
         if (turnContext.activity.type === ActivityTypes.Message) {
             // Perform a call to the QnA Maker service to retrieve matching Question and Answer pairs.
-            const qnaResults = await this.qnaMaker.generateAnswer(turnContext.activity.text);
+            const qnaResults = await this.qnaMaker.getAnswers(turnContext);
 
             // If an answer was received from QnA Maker, send the answer back to the user.
             if (qnaResults[0]) {


### PR DESCRIPTION
Fixes #1021

## Proposed Changes
  - `onTurn` handler now makes call to qna with `.getAnswers()` instead of deprecated `generateAnswer()`
