### PR TITLE
*DO NOT MERGE*: Application Insights 4.2 updates for Node JS

### DIFF
--- a/samples/javascript_nodejs/20.qna-with-appinsights/index.js
+++ b/samples/javascript_nodejs/20.qna-with-appinsights/index.js
@@ -4,7 +4,7 @@
 const path = require('path');
 const restify = require('restify');
 const { BotFrameworkAdapter } = require('botbuilder');
-const { ApplicationInsightsTelemetryClient, ApplicationInsightsWebserverMiddleware } = require('applicationinsights');
+const { ApplicationInsightsTelemetryClient, ApplicationInsightsWebserverMiddleware } = require('botbuilder-applicationinsights');
 const { BotConfiguration } = require('botframework-config');
 const { QnAMakerBot } = require('./bot');
 const { MyAppInsightsMiddleware } = require('./middleware');

--- a/samples/javascript_nodejs/20.qna-with-appinsights/index.js
+++ b/samples/javascript_nodejs/20.qna-with-appinsights/index.js
@@ -4,6 +4,7 @@
 const path = require('path');
 const restify = require('restify');
 const { BotFrameworkAdapter } = require('botbuilder');
+const { ApplicationInsightsTelemetryClient, ApplicationInsightsWebserverMiddleware } = require('applicationinsights');
 const { BotConfiguration } = require('botframework-config');
 const { QnAMakerBot } = require('./bot');
 const { MyAppInsightsMiddleware } = require('./middleware');
@@ -57,10 +58,12 @@ const logName = true;
 
 // Map the contents of appInsightsConfig to a consumable format for MyAppInsightsMiddleware.
 const appInsightsSettings = {
-    instrumentationKey: appInsightsConfig.instrumentationKey,
     logOriginalMessage: logMessage,
     logUserName: logName
 };
+
+// Create an Application Insights telemetry client.
+const appInsightsClient = new ApplicationInsightsTelemetryClient(appInsightsConfig.instrumentationKey);
 
 // Create adapter. See https://aka.ms/about-bot-adapter to learn more adapters.
 const adapter = new BotFrameworkAdapter({
@@ -72,12 +75,12 @@ const adapter = new BotFrameworkAdapter({
 // This will send to Application Insights all incoming Message-type activities.
 // It also stores in TurnContext.TurnState an `applicationinsights` TelemetryClient instance.
 // This cached TelemetryClient is used by the custom class MyAppInsightsQnAMaker.
-adapter.use(new MyAppInsightsMiddleware(appInsightsSettings));
+adapter.use(new MyAppInsightsMiddleware(appInsightsClient, appInsightsSettings));
 
 // Catch-all for errors.
-adapter.onTurnError = async (turnContext, error) => {
+adapter.onTurnError = async (context, error) => {
     console.error(`\n [onTurnError]: ${ error }`);
-    await turnContext.sendActivity(`Oops. Something went wrong!`);
+    await context.sendActivity(`Oops. Something went wrong!`);
 };
 
 // Create the SuggestedActionsBot.
@@ -91,6 +94,11 @@ try {
 
 // Create HTTP server.
 let server = restify.createServer();
+
+// Enable the Application Insights middleware, which helps correlate all activity
+// based on the incoming request.
+server.use(ApplicationInsightsWebserverMiddleware);
+
 server.listen(process.env.port || process.env.PORT || 3978, function() {
     console.log(`\n${ server.name } listening to ${ server.url }.`);
     console.log(`\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator.`);

--- a/samples/javascript_nodejs/20.qna-with-appinsights/middleware/myAppInsightsMiddleware.js
+++ b/samples/javascript_nodejs/20.qna-with-appinsights/middleware/myAppInsightsMiddleware.js
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-const { TelemetryClient } = require('applicationinsights');
-
 /**
  * Middleware for logging incoming activities into Application Insights.
  * In addition, registers a service so other components can log telemetry.
  * If this component is not registered, visibility within the Bot is not logged.
  */
 class MyAppInsightsMiddleware {
-    constructor(settings) {
+    constructor(telemetryClient, settings) {
         // Indicates whether or not to log the user name into the BotMessageReceived event. Defaults to false.
         this.logUserName = false;
 
@@ -29,7 +27,19 @@ class MyAppInsightsMiddleware {
         if (settings.logOriginalMessage) {
             this.logOriginalMessage = settings.logOriginalMessage;
         }
-        this._telemetryClient = new TelemetryClient(settings.instrumentationKey);
+        this._telemetryClient = telemetryClient;
+
+        // Application Insights Custom Event name, logged when new message is received from the user.
+        this.botMsgReceivedEvent = 'BotMessageReceived';
+
+        // Application Insights Custom Event name, logged when a message is sent out from the bot.
+        this.botMsgSendEvent = 'BotMessageSend';
+
+        // Application Insights Custom Event name, logged when a message is updated by the bot (rare case).
+        this.botMsgUpdateEvent = 'BotMessageUpdate';
+
+        // Application Insights Custom Event name, logged when a message is deleted by the bot (rare case).
+        this.botMsgDeleteEvent = 'BotMessageDelete';
     }
 
     /**
@@ -42,14 +52,6 @@ class MyAppInsightsMiddleware {
             // Store the TelemetryClient on the TurnContext's turnState so MyAppInsightsQnAMaker can use it.
             turnContext.turnState.set(this.appInsightsServiceKey, this._telemetryClient);
 
-            const activity = turnContext.activity;
-            // Set userId and sessionId tag values for the Application Insights Context object.
-            if (activity.from && activity.from.id) {
-                this._telemetryClient.context.keys.userId = activity.from.id;
-            }
-            if (activity.conversation && activity.conversation.id) {
-                this._telemetryClient.context.keys.sessionId = activity.conversation.id;
-            }
             // Construct the EventTelemetry object.
             const msgReceivedEvent = { name: this.botMsgReceivedEvent };
             // Add activity specific information, e.g. user ID, conversation ID, to the Event's properties.
@@ -107,11 +109,12 @@ class MyAppInsightsMiddleware {
         const properties = Object.assign({}, this.createBasicProperties(activity), { Locale: activity.locale });
         // For some customers, logging user name within Application Insights might be an issue so we have provided a config setting to enable this feature
         if (this.logUserName && activity.from.name) {
-            properties.FromName = activity.from.name;
+            properties.fromId = activity.from.id;
+            properties.fromName = activity.from.name;
         }
         // For some customers, logging the utterances within Application Insights might be an issue so we have provided a config setting to enable this feature
         if (this.logOriginalMessage && activity.text) {
-            properties.TextProperty = activity.text;
+            properties.text = activity.text;
         }
         return properties;
     }
@@ -126,11 +129,11 @@ class MyAppInsightsMiddleware {
         const properties = Object.assign({}, this.createBasicProperties(activity), { Locale: activity.locale });
         // For some customers, logging user name within Application Insights might be an issue so have provided a config setting to enable this feature.
         if (this.logUserName && !!activity.recipient.name) {
-            properties.RecipientName = activity.recipient.name;
+            properties.recipientName = activity.recipient.name;
         }
         // For some customers, logging the utterances within Application Insights might be an issue so have provided a config setting to enable this feature.
         if (this.logOriginalMessage && !!activity.text) {
-            properties.Text = activity.text;
+            properties.text = activity.text;
         }
         return properties;
     }
@@ -147,7 +150,7 @@ class MyAppInsightsMiddleware {
         const properties = Object.assign({}, this.createBasicProperties(activity), { Locale: activity.locale });
         // For some customers, logging the utterances within Application Insights might be an issue so have provided a config setting to enable this feature.
         if (this.logOriginalMessage && !!activity.text) {
-            properties.Text = activity.text;
+            properties.text = activity.text;
         }
         return properties;
     }
@@ -163,11 +166,11 @@ class MyAppInsightsMiddleware {
      */
     createBasicProperties(activity) {
         const properties = {
-            ActivityId: activity.id,
-            Channel: activity.channelId,
-            ConversationId: activity.conversation.id,
-            ConversationName: activity.conversation.name,
-            RecipientId: activity.recipient
+            activityId: activity.id,
+            channel: activity.channelId,
+            conversationId: activity.conversation.id,
+            conversationName: activity.conversation.name,
+            recipientId: activity.recipient
         };
         return properties;
     }

--- a/samples/javascript_nodejs/20.qna-with-appinsights/myAppInsightsQnAMaker.js
+++ b/samples/javascript_nodejs/20.qna-with-appinsights/myAppInsightsQnAMaker.js
@@ -32,12 +32,6 @@ class MyAppInsightsQnAMaker extends QnAMaker {
         const telemetryMetrics = {};
         const activity = turnContext.activity;
 
-        // Make it so we can correlate our reports with Activity or Conversation.
-        telemetryProperties.ActivityId = activity.id;
-        if (activity.conversation.id) {
-            telemetryProperties.ConversationId = activity.conversation.id;
-        }
-
         // For some customers, logging original text name within Application Insights might be an issue.
         if (this.logOriginalMessage && !!activity.text) {
             telemetryProperties.OriginalQuestion = activity.text;

--- a/samples/javascript_nodejs/20.qna-with-appinsights/package.json
+++ b/samples/javascript_nodejs/20.qna-with-appinsights/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "applicationinsights": "^1.0.6",
+        "botbuilder-applicationinsights": "^4.2.0-preview.2408",
         "botbuilder": "^4.1.5",
         "botbuilder-ai": "^4.1.5",
         "botframework-config": "^4.1.5",

--- a/samples/javascript_nodejs/21.luis-with-appinsights/index.js
+++ b/samples/javascript_nodejs/21.luis-with-appinsights/index.js
@@ -4,6 +4,7 @@
 const path = require('path');
 const restify = require('restify');
 const { BotFrameworkAdapter } = require('botbuilder');
+const { ApplicationInsightsTelemetryClient, ApplicationInsightsWebserverMiddleware } = require('botbuilder-applicationinsights');
 const { BotConfiguration } = require('botframework-config');
 const { LuisBot } = require('./bot');
 const { MyAppInsightsMiddleware } = require('./middleware');
@@ -57,10 +58,12 @@ const logName = true;
 
 // Map the contents of appInsightsConfig to a consumable format for MyAppInsightsMiddleware.
 const appInsightsSettings = {
-    instrumentationKey: appInsightsConfig.instrumentationKey,
     logOriginalMessage: logMessage,
     logUserName: logName
 };
+
+// Create an Application Insights telemetry client.
+const appInsightsClient = new ApplicationInsightsTelemetryClient(appInsightsConfig.instrumentationKey);
 
 // Indicate that the base LuisRecognizer class should include the raw LUIS results.
 const includeApiResults = true;
@@ -75,12 +78,12 @@ const adapter = new BotFrameworkAdapter({
 // This will send to Application Insights all incoming Message-type activities.
 // It also stores in TurnContext.TurnState an `applicationinsights` TelemetryClient instance.
 // This cached TelemetryClient is used by the custom class MyAppInsightsLuisRecognizer.
-adapter.use(new MyAppInsightsMiddleware(appInsightsSettings));
+adapter.use(new MyAppInsightsMiddleware(appInsightsClient, appInsightsSettings));
 
 // Catch-all for errors.
-adapter.onTurnError = async (turnContext, error) => {
+adapter.onTurnError = async (context, error) => {
     console.error(`\n [onTurnError]: ${ error }`);
-    await turnContext.sendActivity(`Oops. Something went wrong!`);
+    await context.sendActivity(`Oops. Something went wrong!`);
 };
 
 // Create the LuisBot.
@@ -102,6 +105,11 @@ try {
 
 // Create HTTP server.
 let server = restify.createServer();
+
+// Enable the Application Insights middleware, which helps correlate all activity
+// based on the incoming request.
+server.use(ApplicationInsightsWebserverMiddleware);
+
 server.listen(process.env.port || process.env.PORT || 3978, function() {
     console.log(`\n${ server.name } listening to ${ server.url }.`);
     console.log(`\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator.`);

--- a/samples/javascript_nodejs/21.luis-with-appinsights/middleware/myAppInsightsMiddleware.js
+++ b/samples/javascript_nodejs/21.luis-with-appinsights/middleware/myAppInsightsMiddleware.js
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-const { TelemetryClient } = require('applicationinsights');
-
 /**
  * Middleware for logging incoming activities into Application Insights.
  * In addition, registers a service so other components can log telemetry.
  * If this component is not registered, visibility within the Bot is not logged.
  */
 class MyAppInsightsMiddleware {
-    constructor(settings) {
+    constructor(telemetryClient, settings) {
         // Indicates whether or not to log the user name into the BotMessageReceived event. Defaults to false.
         this.logUserName = false;
 
@@ -29,27 +27,31 @@ class MyAppInsightsMiddleware {
         if (settings.logOriginalMessage) {
             this.logOriginalMessage = settings.logOriginalMessage;
         }
-        this._telemetryClient = new TelemetryClient(settings.instrumentationKey);
+        this._telemetryClient = telemetryClient;
+
+        // Application Insights Custom Event name, logged when new message is received from the user.
+        this.botMsgReceivedEvent = 'BotMessageReceived';
+
+        // Application Insights Custom Event name, logged when a message is sent out from the bot.
+        this.botMsgSendEvent = 'BotMessageSend';
+
+        // Application Insights Custom Event name, logged when a message is updated by the bot (rare case).
+        this.botMsgUpdateEvent = 'BotMessageUpdate';
+
+        // Application Insights Custom Event name, logged when a message is deleted by the bot (rare case).
+        this.botMsgDeleteEvent = 'BotMessageDelete';
     }
 
     /**
      * Records incoming and outgoing activities to the Application Insights store.
-     * @param {TurnContext} turnContext for the current turn of conversation with the user.
+     * @param {TurnContext} turnContext Context for the current turn of conversation with the user.
      * @param {Promise<void>} next Function to invoke at the end of the middleware chain.
      */
     async onTurn(turnContext, next) {
         if (turnContext.activity) {
-            // Store the TelemetryClient on the TurnContext's turnState so MyAppInsightsLuisRecognizer can use it.
+            // Store the TelemetryClient on the TurnContext's turnState so MyAppInsightsQnAMaker can use it.
             turnContext.turnState.set(this.appInsightsServiceKey, this._telemetryClient);
 
-            const activity = turnContext.activity;
-            // Set userId and sessionId tag values for the Application Insights Context object.
-            if (activity.from && activity.from.id) {
-                this._telemetryClient.context.keys.userId = activity.from.id;
-            }
-            if (activity.conversation && activity.conversation.id) {
-                this._telemetryClient.context.keys.sessionId = activity.conversation.id;
-            }
             // Construct the EventTelemetry object.
             const msgReceivedEvent = { name: this.botMsgReceivedEvent };
             // Add activity specific information, e.g. user ID, conversation ID, to the Event's properties.
@@ -107,11 +109,12 @@ class MyAppInsightsMiddleware {
         const properties = Object.assign({}, this.createBasicProperties(activity), { Locale: activity.locale });
         // For some customers, logging user name within Application Insights might be an issue so we have provided a config setting to enable this feature
         if (this.logUserName && activity.from.name) {
-            properties.FromName = activity.from.name;
+            properties.fromId = activity.from.id;
+            properties.fromName = activity.from.name;
         }
         // For some customers, logging the utterances within Application Insights might be an issue so we have provided a config setting to enable this feature
         if (this.logOriginalMessage && activity.text) {
-            properties.TextProperty = activity.text;
+            properties.text = activity.text;
         }
         return properties;
     }
@@ -126,11 +129,11 @@ class MyAppInsightsMiddleware {
         const properties = Object.assign({}, this.createBasicProperties(activity), { Locale: activity.locale });
         // For some customers, logging user name within Application Insights might be an issue so have provided a config setting to enable this feature.
         if (this.logUserName && !!activity.recipient.name) {
-            properties.RecipientName = activity.recipient.name;
+            properties.recipientName = activity.recipient.name;
         }
         // For some customers, logging the utterances within Application Insights might be an issue so have provided a config setting to enable this feature.
         if (this.logOriginalMessage && !!activity.text) {
-            properties.Text = activity.text;
+            properties.text = activity.text;
         }
         return properties;
     }
@@ -147,7 +150,7 @@ class MyAppInsightsMiddleware {
         const properties = Object.assign({}, this.createBasicProperties(activity), { Locale: activity.locale });
         // For some customers, logging the utterances within Application Insights might be an issue so have provided a config setting to enable this feature.
         if (this.logOriginalMessage && !!activity.text) {
-            properties.Text = activity.text;
+            properties.text = activity.text;
         }
         return properties;
     }
@@ -163,11 +166,11 @@ class MyAppInsightsMiddleware {
      */
     createBasicProperties(activity) {
         const properties = {
-            ActivityId: activity.id,
-            Channel: activity.channelId,
-            ConversationId: activity.conversation.id,
-            ConversationName: activity.conversation.name,
-            RecipientId: activity.recipient
+            activityId: activity.id,
+            channel: activity.channelId,
+            conversationId: activity.conversation.id,
+            conversationName: activity.conversation.name,
+            recipientId: activity.recipient
         };
         return properties;
     }

--- a/samples/javascript_nodejs/21.luis-with-appinsights/myAppInsightsLuisRecognizer.js
+++ b/samples/javascript_nodejs/21.luis-with-appinsights/myAppInsightsLuisRecognizer.js
@@ -29,29 +29,28 @@ class MyAppInsightsLuisRecognizer extends LuisRecognizer {
         const telemetryClient = turnContext.turnState.get('AppInsightsLoggerMiddleware.AppInsightsContext');
         const telemetryProperties = {};
         const activity = turnContext.activity;
+
         const topLuisIntent = results.luisResult.topScoringIntent;
         const intentScore = topLuisIntent.score.toString();
 
         telemetryProperties.Intent = topLuisIntent.intent;
         telemetryProperties.Score = intentScore;
 
-        // Make it so we can correlate our reports with Activity or Conversation.
-        telemetryProperties.ActivityId = activity.id;
-        if (activity.conversation.id) {
-            telemetryProperties.ConversationId = activity.conversation.id;
-        }
         // For some customers, logging original text name within Application Insights might be an issue.
         if (this.logOriginalMessage && !!activity.text) {
             telemetryProperties.OriginalMessage = activity.text;
         }
+
         // For some customers, logging user name within Application Insights might be an issue.
         if (this.logUserName && !!activity.from.name) {
             telemetryProperties.Username = activity.from.name;
         }
+
         // Finish constructing the event.
         const luisMsgEvent = { name: `LuisMessage.${ topLuisIntent.intent }`,
             properties: telemetryProperties
         };
+
         // Track the event.
         telemetryClient.trackEvent(luisMsgEvent);
         return results;

--- a/samples/javascript_nodejs/21.luis-with-appinsights/package.json
+++ b/samples/javascript_nodejs/21.luis-with-appinsights/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "applicationinsights": "^1.0.6",
+        "botbuilder-applicationinsights": "^4.2.0-preview.2408",
         "botbuilder": "^4.1.5",
         "botbuilder-ai": "^4.1.5",
         "botframework-config": "^4.1.5",


### PR DESCRIPTION
This is a repeat of #996 which was merged too early and rolled back by #1054 

This uses the new botbuilder-applicationinsights telemetry client which automatically correlates additional information along with the luis and qnamaker events.  

NOTE: This is pointing at the nightly build of botbuilder-applicationinsights.  To test you must first point npm to our nightly build feed.  

ALSO NOTE: We will have to update the package.json file to point to the public 4.2 version once it is published.