### PR TITLE
Fix port number and improve error handling in MultiLingual sample bot (C#)

### DIFF
--- a/samples/csharp_dotnetcore/17.multilingual-bot/MultiLingualBot.cs
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/MultiLingualBot.cs
@@ -25,8 +25,10 @@ namespace Microsoft.BotBuilderSamples
     /// <seealso cref="https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-2.1"/>
     public class MultiLingualBot : IBot
     {
-        private const string English = "en";
-        private const string Spanish = "es";
+        private const string EnglishEnglish = "en";
+        private const string EnglishSpanish = "es";
+        private const string SpanishEnglish = "in";
+        private const string SpanishSpanish = "it";
 
         private readonly MultiLingualBotAccessors _accessors;
 
@@ -67,13 +69,16 @@ namespace Microsoft.BotBuilderSamples
 
                 if (IsLanguageChangeRequested(turnContext.Activity.Text))
                 {
+                    var curentLang = turnContext.Activity.Text.ToLower();
+                    var lang = curentLang == EnglishEnglish || curentLang == SpanishEnglish ? EnglishEnglish : EnglishSpanish;
+
                     // If the user requested a language change through the suggested actions with values "es" or "en",
                     // simply change the user's language preference in the user state.
                     // The translation middleware will catch this setting and translate both ways to the user's
                     // selected language.
                     // If Spanish was selected by the user, the reply below will actually be shown in spanish to the user.
-                    await _accessors.LanguagePreference.SetAsync(turnContext, turnContext.Activity.Text);
-                    var reply = turnContext.Activity.CreateReply($"Your current language code is: {turnContext.Activity.Text}");
+                    await _accessors.LanguagePreference.SetAsync(turnContext, lang);
+                    var reply = turnContext.Activity.CreateReply($"Your current language code is: {lang}");
 
                     await turnContext.SendActivityAsync(reply, cancellationToken);
 
@@ -90,8 +95,8 @@ namespace Microsoft.BotBuilderSamples
                     {
                         Actions = new List<CardAction>()
                         {
-                            new CardAction() { Title = "Español", Type = ActionTypes.PostBack, Value = Spanish },
-                            new CardAction() { Title = "English", Type = ActionTypes.PostBack, Value = English },
+                            new CardAction() { Title = "Español", Type = ActionTypes.PostBack, Value = EnglishSpanish },
+                            new CardAction() { Title = "English", Type = ActionTypes.PostBack, Value = EnglishEnglish },
                         },
                     };
 
@@ -108,7 +113,8 @@ namespace Microsoft.BotBuilderSamples
             }
 
             utterance = utterance.ToLower().Trim();
-            return utterance == Spanish || utterance == English;
+            return utterance == EnglishSpanish || utterance == EnglishEnglish
+                || utterance == SpanishSpanish || utterance == SpanishEnglish;
         }
     }
 }

--- a/samples/csharp_dotnetcore/17.multilingual-bot/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:55375/",
+      "applicationUrl": "http://localhost:3978/",
       "sslPort": 0
     }
   },
@@ -21,7 +21,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:55377/"
+      "applicationUrl": "http://localhost:3978/"
     }
   }
 }

--- a/samples/csharp_dotnetcore/17.multilingual-bot/Startup.cs
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/Startup.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
@@ -82,10 +83,14 @@ namespace Microsoft.BotBuilderSamples
                 ILogger logger = _loggerFactory.CreateLogger<MultiLingualBot>();
 
                 // Catches any errors that occur during a conversation turn and logs them.
-                options.OnTurnError = async (context, exception) =>
+                options.OnTurnError = async (turnContext, exception) =>
                 {
                     logger.LogError($"Exception caught : {exception}");
-                    await context.SendActivityAsync("Sorry, it looks like something went wrong.");
+
+                    // By-pass the middleware by sending the Activity directly on the Adapter.
+                    var activity = MessageFactory.Text("Sorry, it looks like something went wrong.");
+                    activity.ApplyConversationReference(turnContext.Activity.GetConversationReference());
+                    await turnContext.Adapter.SendActivitiesAsync(turnContext, new[] { activity }, default(CancellationToken));
                 };
 
                 // The Memory Storage used here is for local bot debugging only. When the bot

--- a/samples/csharp_dotnetcore/17.multilingual-bot/Translation/MicrosoftTranslator.cs
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/Translation/MicrosoftTranslator.cs
@@ -43,6 +43,9 @@ namespace Microsoft.BotBuilderSamples.Translation
                 request.Headers.Add("Ocp-Apim-Subscription-Key", _key);
 
                 var response = await _client.SendAsync(request, cancellationToken);
+
+                response.EnsureSuccessStatusCode();
+
                 var responseBody = await response.Content.ReadAsStringAsync();
                 var result = JsonConvert.DeserializeObject<TranslatorResponse[]>(responseBody);
 


### PR DESCRIPTION
- fixes port number in launch json
- throws on http error from translation services
- error handler send activity via adapter to explicitly avoid middleware
- minor change to logic so you can switch back from Spanish to English
