### PR TITLE
Bump internal VSIX Version to 4.3, so publishing and updates work correctly

### DIFF
--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/source.extension.vsixmanifest
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="BotBuilderV4.fbe0fc50-a6f1-4500-82a2-189314b7bea2" Version="4.2" Language="en-US" Publisher="Microsoft" />
+        <Identity Id="BotBuilderV4.fbe0fc50-a6f1-4500-82a2-189314b7bea2" Version="4.3" Language="en-US" Publisher="Microsoft" />
         <DisplayName>Bot Builder V4 SDK Template for Visual Studio</DisplayName>
         <Description xml:space="preserve">Templates for Microsoft Bot Framework v4. Will let you quickly set up a conversational AI bot using core AI capabilities.</Description>
         <MoreInfo>https://aka.ms/BotBuilderOverview</MoreInfo>
@@ -17,7 +17,7 @@
     </Dependencies>
     <Assets>
         <!--<Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="ProjectTemplates\BotFramework.zip" />-->
-      <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" />
+        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" />
     </Assets>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
When publishing to VS Marketplace, the VSIX version should be bumped each time. 