### PR TITLE
yeoman - add support for TypeScript deploys to Azure

### DIFF
--- a/generators/generator-botbuilder/components/basicTemplateWriter.js
+++ b/generators/generator-botbuilder/components/basicTemplateWriter.js
@@ -95,6 +95,16 @@ const writeBasicTemplateFiles = (gen, templatePath) => {
     path.join(destinationPath, 'basicBot.luis')
   );
 
+  // if we're writing out TypeScript, then we need to add a webConfigPrep.js
+  if(_.toLower(gen.props.language) === LANG_TS) {
+    sourcePath = path.join(templatePath, srcFolders[DEPLOYMENT_SCRIPTS]);
+    destinationPath = path.join(gen.destinationPath(), destFolders[DEPLOYMENT_SCRIPTS]);
+    gen.fs.copy(
+      path.join(sourcePath, 'webConfigPrep.js'),
+      path.join(destinationPath, 'webConfigPrep.js')
+    );
+  }
+
   // write out deployment resources
   sourcePath = path.join(templatePath, srcFolders[DEPLOYMENT_MSBOT]);
   destinationPath = path.join(gen.destinationPath(), destFolders[DEPLOYMENT_MSBOT]);

--- a/generators/generator-botbuilder/components/echoTemplateWriter.js
+++ b/generators/generator-botbuilder/components/echoTemplateWriter.js
@@ -43,9 +43,20 @@ const writeEchoTemplateFiles = (gen, templatePath) => {
     mkdirp.sync(TS_SRC_FOLDER);
   }
 
+  let sourcePath = path.join(templatePath, folders[DEPLOYMENT_SCRIPTS]);
+  let destinationPath = path.join(gen.destinationPath(), folders[DEPLOYMENT_SCRIPTS]);
+
+   // if we're writing out TypeScript, then we need to add a webConfigPrep.js
+   if(_.toLower(gen.props.language) === LANG_TS) {
+     gen.fs.copy(
+       path.join(sourcePath, 'webConfigPrep.js'),
+       path.join(destinationPath, 'webConfigPrep.js')
+     );
+   }
+
   // write out deployment resources
-  let sourcePath = path.join(templatePath, folders[DEPLOYMENT_MSBOT]);
-  let destinationPath = path.join(gen.destinationPath(), folders[DEPLOYMENT_MSBOT]);
+  sourcePath = path.join(templatePath, folders[DEPLOYMENT_MSBOT]);
+  destinationPath = path.join(gen.destinationPath(), folders[DEPLOYMENT_MSBOT]);
   gen.fs.copyTpl(
     path.join(sourcePath, 'bot.recipe'),
     path.join(destinationPath, 'bot.recipe'),

--- a/generators/generator-botbuilder/components/emptyTemplateWriter.js
+++ b/generators/generator-botbuilder/components/emptyTemplateWriter.js
@@ -41,9 +41,20 @@ const writeEmptyTemplateFiles = (gen, templatePath) => {
     mkdirp.sync(TS_SRC_FOLDER);
   }
 
+  let sourcePath = path.join(templatePath, folders[DEPLOYMENT_SCRIPTS]);
+  let destinationPath = path.join(gen.destinationPath(), folders[DEPLOYMENT_SCRIPTS]);
+
+  // if we're writing out TypeScript, then we need to add a webConfigPrep.js
+  if(_.toLower(gen.props.language) === LANG_TS) {
+    gen.fs.copy(
+      path.join(sourcePath, 'webConfigPrep.js'),
+      path.join(destinationPath, 'webConfigPrep.js')
+    );
+  }
+
   // write out deployment resources
-  let sourcePath = path.join(templatePath, folders[DEPLOYMENT_MSBOT]);
-  let destinationPath = path.join(gen.destinationPath(), folders[DEPLOYMENT_MSBOT]);
+  sourcePath = path.join(templatePath, folders[DEPLOYMENT_MSBOT]);
+  destinationPath = path.join(gen.destinationPath(), folders[DEPLOYMENT_MSBOT]);
   gen.fs.copyTpl(
     path.join(sourcePath, 'bot.recipe'),
     path.join(destinationPath, 'bot.recipe'),

--- a/generators/generator-botbuilder/generators/app/templates/basic/deploymentScripts/webConfigPrep.js
+++ b/generators/generator-botbuilder/generators/app/templates/basic/deploymentScripts/webConfigPrep.js
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// DO NOT MODIFY THIS CODE
+// This script is run as part of the Post Deploy step when
+// deploying the bot to Azure.  It ensures the Azure Web App
+// is configured correctly to host a TypeScript authored bot.
+const fs = require('fs');
+const path = require('path');
+const replace = require('replace');
+const WEB_CONFIG_FILE = './web.config';
+
+if (fs.existsSync(path.resolve(WEB_CONFIG_FILE))) {
+    replace({
+        regex: "url=\"index.js\"",
+        replacement: "url=\"lib/index.js\"",
+        paths: ['./web.config'],
+        recursive: false,
+        silent: true,
+    })
+}

--- a/generators/generator-botbuilder/generators/app/templates/basic/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/basic/package.json.ts
@@ -8,6 +8,7 @@
     "scripts": {
         "build": "node_modules/.bin/tsc --build",
         "lint": "node_modules/.bin/tslint -c tslint.json 'src/**/*.ts'",
+        "postinstall": "npm run build && node ./deploymentScripts/webConfigPrep.js",
         "start": "node_modules/.bin/tsc --build && node ./lib/index.js",
         "test": "echo \"Error: no test specified\" && exit 1",
         "watch": "node_modules/.bin/nodemon --watch ./src -e ts --exec \"npm run start\""
@@ -25,6 +26,7 @@
         "botframework-connector": "^4.1.5",
         "botframework-schema": "^4.1.5",
         "dotenv": "^6.1.0",
+        "replace": "^1.0.0",
         "restify": "^7.2.3"
     },
     "devDependencies": {

--- a/generators/generator-botbuilder/generators/app/templates/echo/deploymentScripts/webConfigPrep.js
+++ b/generators/generator-botbuilder/generators/app/templates/echo/deploymentScripts/webConfigPrep.js
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// DO NOT MODIFY THIS CODE
+// This script is run as part of the Post Deploy step when
+// deploying the bot to Azure.  It ensures the Azure Web App
+// is configured correctly to host a TypeScript authored bot.
+const fs = require('fs');
+const path = require('path');
+const replace = require('replace');
+const WEB_CONFIG_FILE = './web.config';
+
+if (fs.existsSync(path.resolve(WEB_CONFIG_FILE))) {
+    replace({
+        regex: "url=\"index.js\"",
+        replacement: "url=\"lib/index.js\"",
+        paths: ['./web.config'],
+        recursive: false,
+        silent: true,
+    })
+}

--- a/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
@@ -8,6 +8,7 @@
     "scripts": {
         "build": "node_modules/.bin/tsc --build",
         "lint": "node_modules/.bin/tslint -c tslint.json 'src/**/*.ts'",
+        "postinstall": "npm run build && node ./deploymentScripts/webConfigPrep.js",
         "start": "node_modules/.bin/tsc --build && node ./lib/index.js",
         "test": "echo \"Error: no test specified\" && exit 1",
         "watch": "node_modules/.bin/nodemon --watch ./src -e ts --exec \"npm run start\""
@@ -20,6 +21,7 @@
         "botbuilder": "^4.1.5",
         "botframework-config": "^4.1.5",
         "dotenv": "^6.1.0",
+        "replace": "^1.0.0",
         "restify": "^7.2.3"
     },
     "devDependencies": {

--- a/generators/generator-botbuilder/generators/app/templates/empty/deploymentScripts/webConfigPrep.js
+++ b/generators/generator-botbuilder/generators/app/templates/empty/deploymentScripts/webConfigPrep.js
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// DO NOT MODIFY THIS CODE
+// This script is run as part of the Post Deploy step when
+// deploying the bot to Azure.  It ensures the Azure Web App
+// is configured correctly to host a TypeScript authored bot.
+const fs = require('fs');
+const path = require('path');
+const replace = require('replace');
+const WEB_CONFIG_FILE = './web.config';
+
+if (fs.existsSync(path.resolve(WEB_CONFIG_FILE))) {
+    replace({
+        regex: "url=\"index.js\"",
+        replacement: "url=\"lib/index.js\"",
+        paths: ['./web.config'],
+        recursive: false,
+        silent: true,
+    })
+}

--- a/generators/generator-botbuilder/generators/app/templates/empty/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/empty/package.json.ts
@@ -8,6 +8,7 @@
     "scripts": {
         "build": "node_modules/.bin/tsc --build",
         "lint": "node_modules/.bin/tslint -c tslint.json 'src/**/*.ts'",
+        "postinstall": "npm run build && node ./deploymentScripts/webConfigPrep.js",
         "start": "node_modules/.bin/tsc --build && node ./lib/index.js",
         "test": "echo \"Error: no test specified\" && exit 1",
         "watch": "node_modules/.bin/nodemon --watch ./src -e ts --exec \"npm run start\""
@@ -18,6 +19,7 @@
     },
     "dependencies": {
         "botbuilder": "^4.1.5",
+        "replace": "^1.0.0",
         "restify": "^7.2.3"
     },
     "devDependencies": {

--- a/generators/generator-botbuilder/package-lock.json
+++ b/generators/generator-botbuilder/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "generator-botbuilder",
-    "version": "4.1.22",
+    "version": "4.1.23",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/generators/generator-botbuilder/package.json
+++ b/generators/generator-botbuilder/package.json
@@ -1,6 +1,6 @@
 {
     "name": "generator-botbuilder",
-    "version": "4.1.22",
+    "version": "4.1.23",
     "description": "A yeoman generator for creating bots using Microsoft Bot Framework",
     "homepage": "https://github.com/Microsoft/BotBuilder-Samples/tree/master/generators/generator-botbuilder",
     "author": {


### PR DESCRIPTION
- add webConfigPrep.js to rewrite base node URL
- have each TS template write webConfigPrep.js to the deploymentScripts folder
- add a postinstall script command to TS generated package.json files
- bump the generator patch version to 4.1.23
