### PR TITLE
Update VSIX to use 4.2.0 SDK. Bump VSIX version to 4.4

### DIFF
--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/EchoBotWithCounter.csproj
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/EchoBotWithCounter.csproj
@@ -13,11 +13,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.1" />
   </ItemGroup>
 </Project>

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/EmptyBot.csproj
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/EmptyBot.csproj
@@ -13,10 +13,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.2.0" />
   </ItemGroup>
 </Project>

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/source.extension.vsixmanifest
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="BotBuilderV4.fbe0fc50-a6f1-4500-82a2-189314b7bea2" Version="4.3" Language="en-US" Publisher="Microsoft" />
+        <Identity Id="BotBuilderV4.fbe0fc50-a6f1-4500-82a2-189314b7bea2" Version="4.4" Language="en-US" Publisher="Microsoft" />
         <DisplayName>Bot Builder V4 SDK Template for Visual Studio</DisplayName>
         <Description xml:space="preserve">Templates for Microsoft Bot Framework v4. Will let you quickly set up a conversational AI bot using core AI capabilities.</Description>
         <MoreInfo>https://aka.ms/BotBuilderOverview</MoreInfo>


### PR DESCRIPTION
As part of the SDK 4.2.0 release, update the VSIX templates to use the latest Nuget packages. 

Bump the VSIX version to 4.4. 