### PR TITLE
Remove superfluous comma in bot file and include hard-coded luis name…

### DIFF
--- a/samples/javascript_nodejs/21.luis-with-appinsights/luis-with-appinsights.bot
+++ b/samples/javascript_nodejs/21.luis-with-appinsights/luis-with-appinsights.bot
@@ -12,7 +12,7 @@
         },        
         {
             "type": "luis",
-            "name": "",
+            "name": "luis-with-appinsights-luis",
             "appId": "",
             "authoringKey": "",
             "subscriptionKey": "",
@@ -31,7 +31,7 @@
             "applicationId": "",
             "apiKeys": {},
             "id": "4"
-        },
+        }
     ],
     "padlock": "",
     "version": "2.0"


### PR DESCRIPTION
Remove superfluous comma in bot file and include hard-coded luis name from index

Fixes #1089 

## Proposed Changes
Removing the comma makes the json parse cleanly so that the application does not complain about a missing botfile.

Including the name that the index.js file expects to be set in the botfile means that only user provided configuration needs to be added to it.  This makes it more clear what needs to be added.

## Testing
N/A