### PR TITLE
[netcore][12.nlp-with-luis] Add sample's project to 'csharp_dotnetcore.sln'

### DIFF
--- a/samples/csharp_dotnetcore/csharp_dotnetcore.sln
+++ b/samples/csharp_dotnetcore/csharp_dotnetcore.sln
@@ -59,6 +59,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ScaleoutBot", "42.scaleout\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EmptyBot", "00.empty-bot\EmptyBot.csproj", "{53C3CFFC-BCBE-4551-8FCD-A23FBC0716BB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LuisBot", "12.nlp-with-luis\LuisBot.csproj", "{A3ED8ED5-B90D-4BA2-BF8B-526A16BDD750}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -177,6 +179,10 @@ Global
 		{53C3CFFC-BCBE-4551-8FCD-A23FBC0716BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{53C3CFFC-BCBE-4551-8FCD-A23FBC0716BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{53C3CFFC-BCBE-4551-8FCD-A23FBC0716BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A3ED8ED5-B90D-4BA2-BF8B-526A16BDD750}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A3ED8ED5-B90D-4BA2-BF8B-526A16BDD750}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A3ED8ED5-B90D-4BA2-BF8B-526A16BDD750}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A3ED8ED5-B90D-4BA2-BF8B-526A16BDD750}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/csharp_dotnetcore/csharp_dotnetcore.sln
+++ b/samples/csharp_dotnetcore/csharp_dotnetcore.sln
@@ -25,6 +25,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PromptValidationsBot", "10.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QnABot", "11.qnamaker\QnABot.csproj", "{E8A19507-8EB5-4B37-B592-AB8316283A6F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LuisBot", "12.nlp-with-luis\LuisBot.csproj", "{A3ED8ED5-B90D-4BA2-BF8B-526A16BDD750}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BasicBot", "13.basic-bot\BasicBot.csproj", "{8FAE502C-68A1-47E8-9761-BCEA491BA4AA}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLP-With-Dispatch-Bot", "14.nlp-with-dispatch\NLP-With-Dispatch-Bot.csproj", "{2D9935A3-7F48-47DE-9C8A-1270CF125949}"
@@ -58,8 +60,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ScaleoutBot", "42.scaleout\ScaleoutBot.csproj", "{F0C62727-49E2-4DAB-984A-1038A9A9990A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EmptyBot", "00.empty-bot\EmptyBot.csproj", "{53C3CFFC-BCBE-4551-8FCD-A23FBC0716BB}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LuisBot", "12.nlp-with-luis\LuisBot.csproj", "{A3ED8ED5-B90D-4BA2-BF8B-526A16BDD750}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Fixes #840
## Proposed Changes
- Include [12.nlp-with-luis](https://github.com/Microsoft/BotBuilder-Samples/tree/master/samples/csharp_dotnetcore/12.nlp-with-luis) in [csharp_dotnetcore.sln](https://github.com/Microsoft/BotBuilder-Samples/blob/master/samples/csharp_dotnetcore/csharp_dotnetcore.sln).

## Testing
When opening the netcore samples solution in Visual Studio, the sample `12.nlp-with-luis` should appear in the list of projects.