### PR TITLE
[NodeJS][TypeScript][60.multilingual-luis-bot] Add links to readme

### DIFF
--- a/experimental/README.md
+++ b/experimental/README.md
@@ -25,15 +25,15 @@ Experimental samples are organized per platform.
 
 | Sample Name           | Description                                                                    | .NET CORE   | NodeJS      | .NET Web API | Typescript  |
 |-----------------------|--------------------------------------------------------------------------------|-------------|-------------|--------------|-------------|
-|bot translation library| The sample shows how to use the library through Middleware to support multilingual interaction with bots in general and LUIS bots in particular.                                                                                                 |[View][cs#1] |  |  |  |
+|bot translation library| The sample shows how to use the library through Middleware to support multilingual interaction with bots in general and LUIS bots in particular.                                                                                                 |[View][cs#1] | [View][js#1] |  | [View][ts#1] |
 
 
 [cs#1]:csharp_dotnetcore/MultilingualLuisBot
 
 [wa#2]:csharp_webapi/#
 
-[ts#1]:javascript_typescript/#
+[ts#1]:javascript_typescript/javascript_typescript
 
-[js#1]:samples/javascript_nodejs/#
+[js#1]:samples/javascript_nodejs/javascript_typescript
 
 

--- a/experimental/README.md
+++ b/experimental/README.md
@@ -32,8 +32,8 @@ Experimental samples are organized per platform.
 
 [wa#2]:csharp_webapi/#
 
-[ts#1]:javascript_typescript/javascript_typescript
+[ts#1]:javascript_typescript/60.multilingual-luis-bot
 
-[js#1]:samples/javascript_nodejs/javascript_typescript
+[js#1]:javascript_typescript/60.multilingual-luis-bot
 
 

--- a/experimental/README.md
+++ b/experimental/README.md
@@ -25,7 +25,7 @@ Experimental samples are organized per platform.
 
 | Sample Name           | Description                                                                    | .NET CORE   | NodeJS      | .NET Web API | Typescript  |
 |-----------------------|--------------------------------------------------------------------------------|-------------|-------------|--------------|-------------|
-|bot translation library| The sample shows how to use the library through Middleware to support multilingual interaction with bots in general and LUIS bots in particular.                                                                                                 |[View][cs#1] | [View][js#1] |  | [View][ts#1] |
+|bot translation library| The sample shows how to use the library through Middleware to support multilingual interaction with bots in general and LUIS bots in particular.                                                                                                 |[View][cs#1] |  |  | [View][ts#1] |
 
 
 [cs#1]:csharp_dotnetcore/MultilingualLuisBot
@@ -34,6 +34,4 @@ Experimental samples are organized per platform.
 
 [ts#1]:javascript_typescript/60.multilingual-luis-bot
 
-[js#1]:javascript_typescript/60.multilingual-luis-bot
-
-
+[js#1]:samples/javascript_nodejs/#


### PR DESCRIPTION
## Proposed Changes
Add the links for the experimental project [60.multilingual-luis-bot](https://github.com/Microsoft/BotBuilder-Samples/tree/master/experimental/javascript_typescript/60.multilingual-luis-bot).
## Testing
The readme file should include the missing link to the JavaScript version of `60.multilingual-luis-bot`.