### PR TITLE
add conversationUpdate activity to browser sample

### DIFF
--- a/samples/javascript_es6/01.a.browser-echo/src/app.js
+++ b/samples/javascript_es6/01.a.browser-echo/src/app.js
@@ -10,10 +10,15 @@ import { WebChatAdapter } from './webChatAdapter';
 // Create the custom WebChatAdapter.
 const webChatAdapter = new WebChatAdapter();
 
+// Create user and bot profiles.
+// These profiles fill out additional information on the incoming and outgoing Activities.
+export const USER_PROFILE = { id: 'Me!', name: 'Me!', role: 'user' };
+export const BOT_PROFILE = { id: 'bot', name: 'bot', role: 'bot' };
+
 // Connect our BotFramework-WebChat App instance with the DOM.
 App({
-    user: { id: 'Me!' },
-    bot: { id: 'bot' },
+    user: USER_PROFILE,
+    bot: BOT_PROFILE,
     botConnection: webChatAdapter.botConnection
 }, document.getElementById('bot'));
 
@@ -44,5 +49,14 @@ webChatAdapter.processActivity(async (turnContext) => {
 
 // Prevent Flash of Unstyled Content (FOUC): https://en.wikipedia.org/wiki/Flash_of_unstyled_content
 document.addEventListener('DOMContentLoaded', () => {
-    window.requestAnimationFrame(() => { document.body.style.visibility = 'visible'; });
+    window.requestAnimationFrame(() => {
+        document.body.style.visibility = 'visible';
+        // After the content has finished loading, send the bot a "conversationUpdate" Activity with the user's information.
+        // When the bot receives a "conversationUpdate" Activity, the developer can opt to send a welcome message to the user.
+        webChatAdapter.botConnection.postActivity({
+            recipient: BOT_PROFILE,
+            membersAdded: [ USER_PROFILE ],
+            type: ActivityTypes.ConversationUpdate
+        });
+    });
 });

--- a/samples/javascript_es6/01.a.browser-echo/src/webChatAdapter.js
+++ b/samples/javascript_es6/01.a.browser-echo/src/webChatAdapter.js
@@ -4,6 +4,7 @@
 import { ConnectionStatus } from 'botframework-webchat';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { BotAdapter, TurnContext } from 'botbuilder-core';
+import { BOT_PROFILE, USER_PROFILE } from './app';
 
 /**
  * Custom BotAdapter used for deploying a bot in a browser.
@@ -31,7 +32,8 @@ export class WebChatAdapter extends BotAdapter {
                         ...activity,
                         id,
                         conversation: { id: 'bot' },
-                        channelId: 'WebChat'
+                        channelId: 'WebChat',
+                        recipient: BOT_PROFILE
                     }).then(() => id)
                 );
             }
@@ -50,7 +52,8 @@ export class WebChatAdapter extends BotAdapter {
             id: Date.now().toString(),
             channelId: 'WebChat',
             conversation: { id: 'bot' },
-            from: { id: 'bot' },
+            from: BOT_PROFILE,
+            recipient: USER_PROFILE,
             timestamp: Date.now()
         }));
 


### PR DESCRIPTION
Fixes #945 

## Proposed Changes
  - The browser-echo sample now emits a conversationUpdate when the page is finished loading.
  - Changed the incoming and outgoing activities to have correct `from` and `recipient` fields.


![issue945](https://user-images.githubusercontent.com/14935595/50187549-3c07a600-02d3-11e9-8140-62ce0aa784f1.jpg)
