### PR TITLE
Fix broken instructions in README.md’s

### DIFF
--- a/experimental/csharp_dotnetcore/multilingual-luis-bot/README.md
+++ b/experimental/csharp_dotnetcore/multilingual-luis-bot/README.md
@@ -7,7 +7,7 @@ This sample shows how to translate incoming and outgoing text using a custom mid
 
 ## Overview
 
-In this sample, we create a simple hotel reservation bot that uses LUIS and Microsoft Translator to provide multilingual abilities to bots without the need to train different models for LUIS, 
+In this sample, we create a simple hotel reservation bot that uses LUIS and Microsoft Translator to provide multilingual abilities to bots without the need to train different models for LUIS,
 the sample intoduces a wrapper around the raw translation API that can provide some customizations to the sample like :
 - no-translate-list of patterns that the user doesn't want to translate
 - a custom configured language vocab dictionary that is used to override the raw translation for some vocab with a predfined user translations.
@@ -16,25 +16,25 @@ We also use two middlewares to intercept and handle the requests for the bot, Lu
 ## To try this sample
 - Clone the repository
 ```bash
-git clone https://github.com/Microsoft/botbuilder-dotnet.git
+    git clone https://github.com/Microsoft/botbuilder-samples.git
 ```
 ### [Required] Getting set up with LUIS.ai model
 - Navigate to [LUIS Portal](http://luis.ai)
 - Click the `Sign in` button
 - Click on `My apps` button
 - Click on `Import new app`
-- Click on the `Choose File` and select [HotelReservation.json](HotelReservation.json) from the `botbuilder-samples\samples\csharp_dotnetcore\60.multilingual-luis-bot\Dialogs\HotelReservation\` folder.
-- Update [BotConfiguration.bot](BotConfiguration.bot) file with your AppId, SubscriptionKey, Region and Version. 
+- Click on the `Choose File` and select [HotelReservation.json](HotelReservation.json) from the `botbuilder-samples\experimental\csharp_dotnetcore\multilingual-luis-bot\Dialogs\HotelReservation\` folder.
+- Update [BotConfiguration.bot](BotConfiguration.bot) file with your AppId, SubscriptionKey, Region and Version.
     You can find this information under "Manage" tab for your LUIS application at [LUIS portal](https://www.luis.ai).
     - The `AppID` can be found in "Application Information"
     - The `SubscriptionKey` can be found in "Keys and Endpoints", under the `Key 1` column
     - The `region` can be found in "Keys and Endpoints", under the `Region` column
 ### [Required] Getting set up with translator service
--To consume the Microsoft Translator Text API, first obtain a key following the instructions in the [Microsoft Translator Text API documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/translator-text-how-to-signup). 
+-To consume the Microsoft Translator Text API, first obtain a key following the instructions in the [Microsoft Translator Text API documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/translator-text-how-to-signup).
 Paste the key in the ```translationKey``` placeholder within the appsettings.json file.
 
 ### (Optional) edit in customizable no-translate-patterns and language dictionary to give your bot translations more customization according to your scenario
-- File -> Open bot and navigate to `botbuilder-samples\samples\csharp_dotnetcore\60.multilingual-luis-bot\Dialogs\HotelReservation\` folder
+- File -> Open bot and navigate to `botbuilder-samples\experimental\csharp_dotnetcore\multilingual-luis-bot\Dialogs\HotelReservation\` folder
 - Modify in patterns.json and/or dictionary.json to enrich your customizations.
 
 ### (Optional) Install LUDown
@@ -44,12 +44,12 @@ Paste the key in the ```translationKey``` placeholder within the appsettings.jso
 - (Optional) Install the Chatdown [here](https://github.com/Microsoft/botbuilder-tools/tree/master/packages/Chatdown) to generate a .transcript file from a .chat file to generate mock transcripts.
 
 ### Visual studio
-- Navigate to the `botbuilder-samples\samples\csharp_dotnetcore\60.multilingual-luis-bot\` and open MultilingualLuisBot.csproj in visual studio
+- Navigate to the `botbuilder-samples\experimental\csharp_dotnetcore\multilingual-luis-bot\` and open MultilingualLuisBot.csproj in visual studio
 - Hit F5
 
 ## Visual Studio Code
-- Open `botbuilder-samples\samples\csharp_dotnetcore\60.multilingual-luis-bot\` sample folder.
-- Bring up a terminal, navigate to BotBuilder-Samples\60.multilingual-luis-bot folder
+- Open `botbuilder-samples\experimental\csharp_dotnetcore\multilingual-luis-bot\` sample folder.
+- Bring up a terminal, navigate to multilingual-luis-bot folder
 - type 'dotnet run'
 
 ## Testing the bot using Bot Framework Emulator
@@ -59,13 +59,13 @@ Paste the key in the ```translationKey``` placeholder within the appsettings.jso
 
 ### Connect to bot using Bot Framework Emulator **V4**
 - Launch the Bot Framework Emulator
-- File -> Open bot and navigate to `botbuilder-samples\samples\csharp_dotnetcore\60.multilingual-luis-bot\` folder
+- File -> Open bot and navigate to `botbuilder-samples\experimental\csharp_dotnetcore\multilingual-luis-bot\` folder
 - Select [BotConfiguration.bot](BotConfiguration.bot) file
 
 # Deploy this bot to Azure
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. 
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on.
 
-To install all Bot Builder tools - 
+To install all Bot Builder tools -
 
 Ensure you have [Node.js](https://nodejs.org/) version 8.5 or higher
 
@@ -84,7 +84,6 @@ Language Understanding service (LUIS) allows your application to understand what
 Bot translator allows your application to support multiple languages without an explicit need to train different language understanding models for each language.
 
 # Further reading
-
 - [Azure Bot Service Introduction](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 - [Bot State](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-storage-concept?view=azure-bot-service-4.0)
 - [LUIS documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/LUIS/)

--- a/experimental/javascript_typescript/multilingual-luis-bot/README.md
+++ b/experimental/javascript_typescript/multilingual-luis-bot/README.md
@@ -7,11 +7,11 @@ This sample shows how to translate incoming and outgoing text using a custom mid
     ```bash
     git clone https://github.com/Microsoft/botbuilder-samples.git
     ```
-- In a terminal, navigate to samples/javascript_typescript/60.multilingual-luis-bot
+- In a terminal, navigate to experimental/javascript_typescript/multilingual-luis-bot
     ```bash
-    cd samples/javascript_typescript/60.multilingual-luis-bot
+    cd experimental/javascript_typescript/multilingual-luis-bot
     ```
-- [Optional] Update the .env file under samples/javascript_typescript/60.multilingual-luis-bot with your botFileSecret
+- [Optional] Update the .env file under experimental/javascript_typescript/multilingual-luis-bot with your botFileSecret
     For Azure Bot Service bots, you can find the botFileSecret under application settings.
 - Install modules and start the bot
     ```bash
@@ -23,7 +23,7 @@ This sample shows how to translate incoming and outgoing text using a custom mid
     ```
 ## Microsoft Translator Text API
 
-To consume the Microsoft Translator Text API, first obtain a key following the instructions in the [Microsoft Translator Text API documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/translator-text-how-to-signup). 
+To consume the Microsoft Translator Text API, first obtain a key following the instructions in the [Microsoft Translator Text API documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/translator-text-how-to-signup).
 Paste the key in the `translationKey` setting in the .env file, or use your preferred configuration and update the following line in index.js with your translation key:
 
 ```js
@@ -37,7 +37,7 @@ Install the Bot Framework Emulator from [here](https://aka.ms/botframework-emula
 
 ## Connect to bot using Bot Framework Emulator V4
 - Launch Bot Framework Emulator
-- File -> Open Bot Configuration and navigate to samples/javascript_typescript/60.multilingual-luis-bot folder
+- File -> Open Bot Configuration and navigate to `experimental/javascript_typescript/multilingual-luis-bot` folder
 - Select luis-translator-bot.bot file
 
 ## Prerequisite
@@ -52,7 +52,7 @@ In order to run this sample, you must have TypeScript installed.  To install Typ
 - Click the `Sign in` button.
 - Click on `My Apps`.
 - Click on the `Import new app` button.
-- Click on the `Choose File` and select [hoterReservation.json](cognitiveModels/hoterReservation.json) from the `BotBuilder-Samples/samples/javascript_typescript/60.multilingual-luis-bot/cognitiveModels` folder.
+- Click on the `Choose File` and select [hoterReservation.json](cognitiveModels/hoterReservation.json) from the `BotBuilder-Samples/experimental/javascript_typescript/multilingual-luis-bot/cognitiveModels` folder.
 - Update [luis-translator-bot.bot](luis-translator-bot.bot) file with your AppId, SubscriptionKey, Endpoint and Version.
     You can find this information under "Publish" tab for your LUIS application at [LUIS portal](https://www.luis.ai).  For example, for
 	https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/XXXXXXXXXXXXX?subscription-key=YYYYYYYYYYYY&verbose=true&timezoneOffset=0&q=
@@ -61,10 +61,10 @@ In order to run this sample, you must have TypeScript installed.  To install Typ
     - SubscriptionKey = YYYYYYYYYYYY
     - Endpoint = https://westus.api.cognitive.microsoft.com/
 
-    The Version is listed on the page. [See an example .bot service configuration for using LUIS here](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-luis?view=azure-bot-service-4.0&tabs=js#configure-your-bot-to-use-your-luis-app).    
+    The Version is listed on the page. [See an example .bot service configuration for using LUIS here](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-luis?view=azure-bot-service-4.0&tabs=js#configure-your-bot-to-use-your-luis-app).
 - Update [luis-translator-bot.bot](luis-translator-bot.bot) file with your Authoring Key.
     You can find this under your user settings at [luis.ai](https://www.luis.ai).  Click on your name in the upper right hand corner of the portal, and click on the "Settings" menu option. Add this to your .bot file's service configuration as `authoringKey`.
-    
+
     NOTE: Once you publish your app on LUIS portal for the first time, it may take some time to go live.
 - Your .bot file should now include an item in the services array that looks like this:
 
@@ -85,19 +85,19 @@ In order to run this sample, you must have TypeScript installed.  To install Typ
 
 ## Creating a custom middleware
 
-Translation Middleware: We create a translation middleware than can translate text from from user to bot and apply some customizations like using a custon no-translate patterns or a custom vocab dictionary, allowing the creation of multilingual bots. 
+Translation Middleware: We create a translation middleware than can translate text from from user to bot and apply some customizations like using a custon no-translate patterns or a custom vocab dictionary, allowing the creation of multilingual bots.
 
 ## LUIS
 Language Understanding service (LUIS) allows your application to understand what a person wants in their own words. LUIS uses machine learning to allow developers to build applications that can receive user input in natural language and extract meaning from it.
 
 ## Microsoft Translator Text API
-The [Microsoft Translator Text API](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/), Microsoft Translator Text API is a cloud-based machine translation service. With this API you can translate text in near real-time from any app or service through a simple REST API call. 
+The [Microsoft Translator Text API](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/), Microsoft Translator Text API is a cloud-based machine translation service. With this API you can translate text in near real-time from any app or service through a simple REST API call.
 The API uses the most modern neural machine translation technology, as well as offering statistical machine translation technology.
 
 # Deploy this bot to Azure
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. 
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on.
 
-To install all Bot Builder tools - 
+To install all Bot Builder tools -
 
 Ensure you have [Node.js](https://nodejs.org/) version 8.5 or higher
 


### PR DESCRIPTION
Fixes
- Fix incorrect git clone repo instructions in C#
- Fix incorrect path and sample names in C#
- Fix incorrect path names in TS
- Update folder names to reflect recent name change where we dropped the numerical value of the sample
