### PR TITLE
remove production endpoints from recipe files

### DIFF
--- a/samples/javascript_nodejs/02.a.echobot/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/02.a.echobot/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "echobot-abs"

--- a/samples/javascript_nodejs/02.b.echobot-with-counter/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/02.b.echobot-with-counter/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "echo-Bot"

--- a/samples/javascript_nodejs/03.welcome-users/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/03.welcome-users/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "welcome-Bot"

--- a/samples/javascript_nodejs/03.welcome-users/package.json
+++ b/samples/javascript_nodejs/03.welcome-users/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "echobot-with-counter",
+    "name": "welcome-users",
     "version": "1.0.0",
     "description": "Bot Builder v4 welcome user sample",
     "author": "Microsoft",

--- a/samples/javascript_nodejs/04.simple-prompt/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/04.simple-prompt/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "prompt-Bot"

--- a/samples/javascript_nodejs/05.multi-turn-prompt/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "prompts-Bot"

--- a/samples/javascript_nodejs/06.using-cards/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/06.using-cards/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "using-cards-Bot"

--- a/samples/javascript_nodejs/07.using-adaptive-cards/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "adaptive-cards-Bot"

--- a/samples/javascript_nodejs/08.suggested-actions/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/08.suggested-actions/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "suggested-actions-Bot"

--- a/samples/javascript_nodejs/09.message-routing/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/09.message-routing/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "message-routing-Bot"

--- a/samples/javascript_nodejs/10.prompt-validations/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/10.prompt-validations/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "prompt-validations-Bot"

--- a/samples/javascript_nodejs/11.qnamaker/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/11.qnamaker/deploymentScripts/msbotClone/bot.recipe
@@ -13,12 +13,6 @@
       "name": "qnamaker-QnAMaker"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "qnamaker-abs"

--- a/samples/javascript_nodejs/12.nlp-with-luis/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/12.nlp-with-luis/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "nlp-with-luis-abs"

--- a/samples/javascript_nodejs/13.basic-bot/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/13.basic-bot/deploymentScripts/msbotClone/bot.recipe
@@ -13,12 +13,6 @@
       "name": "basic-bot-LUIS"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "basic-Bot"

--- a/samples/javascript_nodejs/14.nlp-with-dispatch/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/14.nlp-with-dispatch/deploymentScripts/msbotClone/bot.recipe
@@ -33,12 +33,6 @@
       ]
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "Dispatch-Bot"

--- a/samples/javascript_nodejs/15.handling-attachments/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/15.handling-attachments/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "attachments-Bot"

--- a/samples/javascript_nodejs/16.proactive-messages/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/16.proactive-messages/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "proactive-Bot"

--- a/samples/javascript_nodejs/17.multilingual-conversations/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/17.multilingual-conversations/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "multi-lingual-Bot"

--- a/samples/javascript_nodejs/18.bot-authentication/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/18.bot-authentication/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "bot-authentication-Bot"

--- a/samples/javascript_nodejs/18.bot-authentication/package.json
+++ b/samples/javascript_nodejs/18.bot-authentication/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "19.bot-authentication",
+    "name": "bot-authentication",
     "version": "1.0.0",
     "description": "Bot Builder v4 Bot Authentication sample",
     "author": "Microsoft",

--- a/samples/javascript_nodejs/19.custom-dialogs/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/19.custom-dialogs/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "custom-dialogs-Bot"

--- a/samples/javascript_nodejs/20.qna-with-appinsights/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/20.qna-with-appinsights/deploymentScripts/msbotClone/bot.recipe
@@ -13,12 +13,6 @@
       "name": "qna-with-appinsights-qna"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "qna-with-appinsights-abs"

--- a/samples/javascript_nodejs/21.luis-with-appinsights/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/21.luis-with-appinsights/deploymentScripts/msbotClone/bot.recipe
@@ -13,12 +13,6 @@
       "name": "luis-with-appinsights-luis"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "luis-with-appinsights-abs"

--- a/samples/javascript_nodejs/23.facebook-events/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/23.facebook-events/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "facebook-Bot"

--- a/samples/javascript_nodejs/23.facebook-events/package.json
+++ b/samples/javascript_nodejs/23.facebook-events/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "81.facebook.events",
+    "name": "facebook.events",
     "version": "1.0.0",
     "description": "Bot Builder v4 facebook events sample",
     "author": "Microsoft",

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "both-auth-msgraph-Bot"

--- a/samples/javascript_nodejs/25.logger/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/25.logger/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "loggerBot-abs"

--- a/samples/javascript_nodejs/25.logger/logger.bot
+++ b/samples/javascript_nodejs/25.logger/logger.bot
@@ -1,5 +1,5 @@
 {
-    "name": "loggerBot",
+    "name": "logger-bot",
     "services": [
         {
             "type": "endpoint",

--- a/samples/javascript_nodejs/26.transcript-logger/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/26.transcript-logger/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "loggerBot-abs"

--- a/samples/javascript_nodejs/50.diceroller-skill/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/50.diceroller-skill/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3988/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "diceroller-Bot"

--- a/samples/javascript_nodejs/51.cafe-bot/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_nodejs/51.cafe-bot/deploymentScripts/msbotClone/bot.recipe
@@ -28,12 +28,6 @@
       "name": "cafeFaqChitChat"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "cafe-bot-abs"

--- a/samples/javascript_typescript/02.a.echobot/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_typescript/02.a.echobot/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "echobot-abs"

--- a/samples/javascript_typescript/02.b.echobot-with-counter/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_typescript/02.b.echobot-with-counter/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "echo-Bot"

--- a/samples/javascript_typescript/02.b.echobot-with-counter/package.json
+++ b/samples/javascript_typescript/02.b.echobot-with-counter/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "echobot-with-counter-ts",
+    "name": "echobot-with-counter",
     "version": "1.0.0",
     "description": "Bot Builder v4 echo bot with counter sample",
     "author": "Microsoft",

--- a/samples/javascript_typescript/11.qnamaker/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_typescript/11.qnamaker/deploymentScripts/msbotClone/bot.recipe
@@ -13,12 +13,6 @@
       "name": "qnamaker-QNA"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "qna-abs"

--- a/samples/javascript_typescript/12.nlp-with-luis/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_typescript/12.nlp-with-luis/deploymentScripts/msbotClone/bot.recipe
@@ -8,12 +8,6 @@
       "url": "http://localhost:3978/api/messages"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "nlp-with-luis-abs"

--- a/samples/javascript_typescript/13.basic-bot/deploymentScripts/msbotClone/bot.recipe
+++ b/samples/javascript_typescript/13.basic-bot/deploymentScripts/msbotClone/bot.recipe
@@ -13,12 +13,6 @@
       "name": "basic-bot-LUIS"
     },
     {
-      "type": "endpoint",
-      "id": "2",
-      "name": "production",
-      "url": "https://your-bot-url.azurewebsites.net/api/messages"
-    },
-    {
       "type": "abs",
       "id": "3",
       "name": "basic-Bot"


### PR DESCRIPTION
- production endpoint in recipe files causes msbot to produce two production endpoint when it does a clone services operation
- also updated package.json name attributes where they were inconsistent or in error
