### PR TITLE
Cleanup dotnet-template VS Code config files

### DIFF
--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/.vscode/launch.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/.vscode/launch.json
@@ -42,43 +42,5 @@
             "request": "attach",
             "processId": "${command:pickProcess}"
         }
-    ,
-        {
-            "name": ".NET Core Launch (web)",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceFolder}/bin/Debug/netcoreapp2.2/CoreBot.dll",
-            "args": [],
-            "cwd": "${workspaceFolder}",
-            "stopAtEntry": false,
-            "internalConsoleOptions": "openOnSessionStart",
-            "launchBrowser": {
-                "enabled": true,
-                "args": "${auto-detect-url}",
-                "windows": {
-                    "command": "cmd.exe",
-                    "args": "/C start ${auto-detect-url}"
-                },
-                "osx": {
-                    "command": "open"
-                },
-                "linux": {
-                    "command": "xdg-open"
-                }
-            },
-            "env": {
-                "ASPNETCORE_ENVIRONMENT": "Development"
-            },
-            "sourceFileMap": {
-                "/Views": "${workspaceFolder}/Views"
-            }
-        },
-        {
-            "name": ".NET Core Attach",
-            "type": "coreclr",
-            "request": "attach",
-            "processId": "${command:pickProcess}"
-        }
     ]
 }

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/.vscode/tasks.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/.vscode/tasks.json
@@ -3,16 +3,10 @@
     "tasks": [
         {
             "label": "build",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "build",
-                "${workspaceFolder}/CoreBot.csproj"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "build",
+            "group": {
+              "kind": "build",
+              "isDefault": true
+            },
             "command": "dotnet",
             "type": "process",
             "args": [

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/.vscode/launch.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/.vscode/launch.json
@@ -41,43 +41,6 @@
             "type": "coreclr",
             "request": "attach",
             "processId": "${command:pickProcess}"
-        },
-        {
-            "name": ".NET Core Launch (web)",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceFolder}/bin/Debug/netcoreapp2.2/EchoBot.dll",
-            "args": [],
-            "cwd": "${workspaceFolder}",
-            "stopAtEntry": false,
-            "internalConsoleOptions": "openOnSessionStart",
-            "launchBrowser": {
-                "enabled": true,
-                "args": "${auto-detect-url}",
-                "windows": {
-                    "command": "cmd.exe",
-                    "args": "/C start ${auto-detect-url}"
-                },
-                "osx": {
-                    "command": "open"
-                },
-                "linux": {
-                    "command": "xdg-open"
-                }
-            },
-            "env": {
-                "ASPNETCORE_ENVIRONMENT": "Development"
-            },
-            "sourceFileMap": {
-                "/Views": "${workspaceFolder}/Views"
-            }
-        },
-        {
-            "name": ".NET Core Attach",
-            "type": "coreclr",
-            "request": "attach",
-            "processId": "${command:pickProcess}"
         }
     ]
 }

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/.vscode/tasks.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/.vscode/tasks.json
@@ -3,16 +3,10 @@
     "tasks": [
         {
             "label": "build",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "build",
-                "${workspaceFolder}/EchoBot.csproj"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "build",
+            "group": {
+              "kind": "build",
+              "isDefault": true
+            },
             "command": "dotnet",
             "type": "process",
             "args": [

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/.vscode/tasks.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/.vscode/tasks.json
@@ -3,6 +3,10 @@
     "tasks": [
         {
             "label": "build",
+            "group": {
+              "kind": "build",
+              "isDefault": true
+            },
             "command": "dotnet",
             "type": "process",
             "args": [


### PR DESCRIPTION

 * Remove duplicate entries in launch/tasks.json
 * Update the "build" task  in tasks.json to use the newer (2.x)
grouping mechanism and make it the default since
it's the only task there right now