### PR TITLE
Fixes 1138 - msbot generated .env file was mistakenly merged

### DIFF
--- a/samples/javascript_nodejs/17.multilingual-conversations/.env
+++ b/samples/javascript_nodejs/17.multilingual-conversations/.env
@@ -1,3 +1,3 @@
-botFilePath="sjg-multilingual.bot"
-botFileSecret="B5Ng6+ztxpVBvx76a8JoSrPGsHCem7qOnwkDR5dhPqg="
-translatorKey="1460baff7a1345218c78088b529368e4"
+botFilePath="multilingual-conversations.bot"
+botFileSecret=""
+translatorKey=""


### PR DESCRIPTION
Fixes #1138

- remove msbot generated data from .env file

