### PR TITLE
Updated C# Samples to Include 4.2.0 SDK & Recognizers.Text 1.1.3

### DIFF
--- a/samples/csharp_dotnetcore/00.empty-bot/EmptyBot.csproj
+++ b/samples/csharp_dotnetcore/00.empty-bot/EmptyBot.csproj
@@ -15,11 +15,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.2.0" />
   </ItemGroup>
   
   <Target Name="ValidatePublish" BeforeTargets="BeforePublish">

--- a/samples/csharp_dotnetcore/01.console-echo/Console-EchoBot.csproj
+++ b/samples/csharp_dotnetcore/01.console-echo/Console-EchoBot.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>

--- a/samples/csharp_dotnetcore/02.b.echo-with-counter/EchoBotWithCounter.csproj
+++ b/samples/csharp_dotnetcore/02.b.echo-with-counter/EchoBotWithCounter.csproj
@@ -16,12 +16,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>

--- a/samples/csharp_dotnetcore/03.welcome-user/WelcomeUser.csproj
+++ b/samples/csharp_dotnetcore/03.welcome-user/WelcomeUser.csproj
@@ -10,11 +10,11 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
 

--- a/samples/csharp_dotnetcore/04.simple-prompt/SimplePromptBot.csproj
+++ b/samples/csharp_dotnetcore/04.simple-prompt/SimplePromptBot.csproj
@@ -13,11 +13,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
 

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/MultiTurnPromptsBot.csproj
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/MultiTurnPromptsBot.csproj
@@ -14,10 +14,10 @@
   <ItemGroup>
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
 

--- a/samples/csharp_dotnetcore/06.using-cards/CardsBot.csproj
+++ b/samples/csharp_dotnetcore/06.using-cards/CardsBot.csproj
@@ -14,11 +14,11 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
 

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/AdaptiveCardsBot.csproj
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/AdaptiveCardsBot.csproj
@@ -14,11 +14,11 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
 

--- a/samples/csharp_dotnetcore/08.suggested-actions/SuggestedActionsBot.csproj
+++ b/samples/csharp_dotnetcore/08.suggested-actions/SuggestedActionsBot.csproj
@@ -14,11 +14,11 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
 

--- a/samples/csharp_dotnetcore/09.message-routing/MessageRoutingBot.csproj
+++ b/samples/csharp_dotnetcore/09.message-routing/MessageRoutingBot.csproj
@@ -40,14 +40,14 @@
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="0.12.1-preview" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.2.0" />
     <PackageReference Include="Microsoft.Graph" Version="1.10.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/csharp_dotnetcore/10.prompt-validations/PromptValidationsBot.csproj
+++ b/samples/csharp_dotnetcore/10.prompt-validations/PromptValidationsBot.csproj
@@ -14,10 +14,10 @@
   <ItemGroup>
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
 

--- a/samples/csharp_dotnetcore/11.qnamaker/QnABot.csproj
+++ b/samples/csharp_dotnetcore/11.qnamaker/QnABot.csproj
@@ -14,10 +14,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>

--- a/samples/csharp_dotnetcore/12.nlp-with-luis/LuisBot.csproj
+++ b/samples/csharp_dotnetcore/12.nlp-with-luis/LuisBot.csproj
@@ -13,10 +13,10 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>

--- a/samples/csharp_dotnetcore/13.basic-bot/BasicBot.csproj
+++ b/samples/csharp_dotnetcore/13.basic-bot/BasicBot.csproj
@@ -10,14 +10,14 @@
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="0.12.1-preview" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.2.0" />
     <PackageReference Include="Microsoft.Graph" Version="1.10.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/csharp_dotnetcore/14.nlp-with-dispatch/NLP-With-Dispatch-Bot.csproj
+++ b/samples/csharp_dotnetcore/14.nlp-with-dispatch/NLP-With-Dispatch-Bot.csproj
@@ -16,11 +16,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder.Ai.LUIS" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder.Ai.LUIS" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="2.9.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />

--- a/samples/csharp_dotnetcore/15.handling-attachments/HandlingAttachmentsBot.csproj
+++ b/samples/csharp_dotnetcore/15.handling-attachments/HandlingAttachmentsBot.csproj
@@ -13,10 +13,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
 

--- a/samples/csharp_dotnetcore/16.proactive-messages/ProactiveBot.csproj
+++ b/samples/csharp_dotnetcore/16.proactive-messages/ProactiveBot.csproj
@@ -14,9 +14,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />

--- a/samples/csharp_dotnetcore/17.multilingual-bot/MultiLingualBot.csproj
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/MultiLingualBot.csproj
@@ -10,14 +10,14 @@
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="0.12.1-preview" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.TemplateManager" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.2.0" />
     <PackageReference Include="Microsoft.Graph" Version="1.10.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008">

--- a/samples/csharp_dotnetcore/18.bot-authentication/AuthenticationBot.csproj
+++ b/samples/csharp_dotnetcore/18.bot-authentication/AuthenticationBot.csproj
@@ -12,11 +12,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/samples/csharp_dotnetcore/19.custom-dialogs/Custom-Dialogs.csproj
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/Custom-Dialogs.csproj
@@ -13,11 +13,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
 

--- a/samples/csharp_dotnetcore/21.luis-with-appinsights/LuisBotAppInsights.csproj
+++ b/samples/csharp_dotnetcore/21.luis-with-appinsights/LuisBotAppInsights.csproj
@@ -26,15 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\..\daveta-appinsight-dialogset\botbuilder-dotnet\libraries\integration\Microsoft.Bot.Builder.ApplicationInsights.Core\Microsoft.Bot.Builder.ApplicationInsights.Core.csproj" />
-    <ProjectReference Include="..\..\..\..\..\daveta-appinsight-dialogset\botbuilder-dotnet\libraries\integration\Microsoft.Bot.Builder.Integration.AspNet.Core\Microsoft.Bot.Builder.Integration.AspNet.Core.csproj" />
-    <ProjectReference Include="..\..\..\..\..\daveta-appinsight-dialogset\botbuilder-dotnet\libraries\Microsoft.Bot.Builder.AI.LUIS\Microsoft.Bot.Builder.AI.LUIS.csproj" />
-    <ProjectReference Include="..\..\..\..\..\daveta-appinsight-dialogset\botbuilder-dotnet\libraries\Microsoft.Bot.Builder.ApplicationInsights\Microsoft.Bot.Builder.ApplicationInsights.csproj" />
-    <ProjectReference Include="..\..\..\..\..\daveta-appinsight-dialogset\botbuilder-dotnet\libraries\Microsoft.Bot.Builder\Microsoft.Bot.Builder.csproj" />
-    <ProjectReference Include="..\..\..\..\..\daveta-appinsight-dialogset\botbuilder-dotnet\libraries\Microsoft.Bot.Configuration\Microsoft.Bot.Configuration.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <WCFMetadata Include="Connected Services" />
   </ItemGroup>
 

--- a/samples/csharp_dotnetcore/22.conversation-history/ConversationHistory.csproj
+++ b/samples/csharp_dotnetcore/22.conversation-history/ConversationHistory.csproj
@@ -14,10 +14,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
 

--- a/samples/csharp_dotnetcore/23.facebook-events/Facebook-Events-Bot.csproj
+++ b/samples/csharp_dotnetcore/23.facebook-events/Facebook-Events-Bot.csproj
@@ -10,10 +10,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/BotAuthenticationMSGraph.csproj
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/BotAuthenticationMSGraph.csproj
@@ -7,10 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
     <PackageReference Include="Microsoft.Graph" Version="1.10.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />

--- a/samples/csharp_dotnetcore/30.asp-mvc-bot/Asp-Mvc-Bot.csproj
+++ b/samples/csharp_dotnetcore/30.asp-mvc-bot/Asp-Mvc-Bot.csproj
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />

--- a/samples/csharp_dotnetcore/40.timex-resolution/Timex-Resolution.csproj
+++ b/samples/csharp_dotnetcore/40.timex-resolution/Timex-Resolution.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.1.3" />
   </ItemGroup>
 
 </Project>

--- a/samples/csharp_dotnetcore/42.scaleout/ScaleoutBot.csproj
+++ b/samples/csharp_dotnetcore/42.scaleout/ScaleoutBot.csproj
@@ -13,9 +13,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.2" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />

--- a/samples/csharp_dotnetcore/51.cafe-bot/CafeBot.csproj
+++ b/samples/csharp_dotnetcore/51.cafe-bot/CafeBot.csproj
@@ -7,19 +7,19 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.1.5" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.1.5" />
-    <PackageReference Include="Microsoft.Recognizers.Text.Choice" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Recognizers.Text.Choice" Version="1.1.3" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.1.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #1120, #1140

## Proposed Changes


  - Updated C# samples to Include `4.2.0` SDK packages instead of older `4.1.5` version
  - Updated `Microsoft.Recognizers.Text` packages to `1.1.3` from `1.1.2`
  - Deleted ItemGroup that referenced `.csroj` specifically from `daveta-appinsight-dialogset`
