### PR TITLE
Removing instrumentation key check

### DIFF
--- a/samples/javascript_nodejs/20.qna-with-appinsights/middleware/myAppInsightsMiddleware.js
+++ b/samples/javascript_nodejs/20.qna-with-appinsights/middleware/myAppInsightsMiddleware.js
@@ -18,9 +18,6 @@ class MyAppInsightsMiddleware {
         if (!settings) {
             throw new Error('The settings parameter is required.');
         }
-        if (!settings.instrumentationKey) {
-            throw new Error('The settings.instrumentationKey parameter is required.');
-        }
         if (settings.logUserName) {
             this.logUserName = settings.logUserName;
         }


### PR DESCRIPTION
The check for instrumentation key is deprecated, and is causing issues with running the sample. It has been removed.