### PR TITLE
Fix #1142 (cancellation confirmation in Cafe Bot)

### DIFF
--- a/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Shared/Prompts/GetLocationDateTimePartySizePrompt.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Shared/Prompts/GetLocationDateTimePartySizePrompt.cs
@@ -155,7 +155,7 @@ namespace Microsoft.BotBuilderSamples
 
         public async override Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (result != null && result is bool && (bool)result != false)
+            if (result is bool && (bool)result)
             {
                 // User said yes to cancel prompt.
                 await dc.Context.SendActivityAsync("Sure. I've canceled that!");

--- a/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Shared/Prompts/GetUserNamePrompt.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Shared/Prompts/GetUserNamePrompt.cs
@@ -175,7 +175,7 @@ namespace Microsoft.BotBuilderSamples
 
         public async override Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (result == null)
+            if (result is bool && (bool)result)
             {
                 // User said yes to cancel prompt.
                 await dc.Context.SendActivityAsync("Sure. I've canceled that!");

--- a/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Shared/Prompts/GetUserNamePrompt.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/Dialogs/Shared/Prompts/GetUserNamePrompt.cs
@@ -184,7 +184,7 @@ namespace Microsoft.BotBuilderSamples
             else
             {
                 // User said no to cancel.
-                return await base.ResumeDialogAsync(dc, reason, result);
+                return await base.ResumeDialogAsync(dc, reason, result, cancellationToken);
             }
         }
 


### PR DESCRIPTION
Fixes #1142 

While it was suggested I change `if (result == null)` to `if (result != null && (bool)result)`, I've used `result is bool` because that will return `false` if `result` is anything other than a `bool`, including `null`. If we only checked if it's `null`, the case `(bool)result` would throw an exception if `result` was a non-null object other than a `bool` (probably impossible in this case).

I've also modified another dialog where this pattern shows up, so they match.