### PR TITLE
Removing extra comma from bot to ensure valid JSON

### DIFF
--- a/samples/csharp_webapi/13.basic-bot/basic-bot.bot
+++ b/samples/csharp_webapi/13.basic-bot/basic-bot.bot
@@ -19,7 +19,7 @@
             "version": "0.1",
             "region": "",
             "id": "34"
-        },
+        }
     ],
     "padlock": "",
     "version": "2.0"


### PR DESCRIPTION
Bot file in basic bot webapi sample has extraneous comma that is making it invalid JSON and is causing msbot to fail when using connect or update.