### PR TITLE
Typescript Basic Bot sample build will now put files in ./lib instead of ./lib/src

### DIFF
--- a/samples/javascript_typescript/13.basic-bot/tsconfig.json
+++ b/samples/javascript_typescript/13.basic-bot/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es2016",
     "module": "commonjs",
     "outDir": "./lib",
+    "rootDir": "./src",
     "resolveJsonModule": true,
     "rootDirs": ["./src", "./resources"],
     "sourceMap": true


### PR DESCRIPTION
Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

Typescript sample 13. Basic Bot won't start after building. It gives the error:

`Cannot find module 'C:\Users\v-micric\Documents\Code\Samples\Test Samples\13.basic-bot\lib\index.js'`

This is because the `tsconfig` file builds to `/lib/src/` instead of `/lib`

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
Build for Typescript Basic Bot sample will now put files in ./lib instead of ./lib/src
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->

Before:

![image](https://user-images.githubusercontent.com/40401643/51862481-9729b100-22f3-11e9-8fb0-4d4d34c2198c.png)

After:

![image](https://user-images.githubusercontent.com/40401643/51862523-ac9edb00-22f3-11e9-9f2c-d6b9b339c81a.png)

### Note:

This does NOT copy the `resources/welcomeCard.json` over into lib (it didn't before this, either). Since the `resources` dir gets pushed during deployment, it doesn't seem to make a difference.

Alternative solutions, that DO copy `welcomeCard.json`, if needed:

1. Remove "rootDir" and "rootDirs" from `tsconfig`.
2. Then change `"run"` in `package.json` to: `"start": "node_modules/.bin/tsc --build && node ./lib/index.js",`

or

1. Move the `resources` folder to `src/resources` and still use `"rootDir": "./src"`
2. Ensure all mappings to `welcomeCard.json` match.

This PR only required changing one line in one file, so it seemed to make the most sense.