### PR TITLE
Generating a consistent story to BotServices between LUIS and QnAMaker Samples

### DIFF
--- a/samples/csharp_dotnetcore/11.qnamaker/QnAMaker/BotServices.cs
+++ b/samples/csharp_dotnetcore/11.qnamaker/QnAMaker/BotServices.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Bot.Builder.AI.QnA;
+using Microsoft.Bot.Configuration;
 
 namespace Microsoft.BotBuilderSamples
 {
@@ -19,10 +20,51 @@ namespace Microsoft.BotBuilderSamples
         /// <summary>
         /// Initializes a new instance of the <see cref="BotServices"/> class.
         /// </summary>
-        /// <param name="qnaServices">A dictionary of named <see cref="QnAMaker"/> instances for usage within the bot.</param>
-        public BotServices(Dictionary<string, QnAMaker> qnaServices)
+        /// <param name="botConfiguration">A dictionary of named <see cref="BotConfiguration"/> instances for usage within the bot.</param>
+        public BotServices(BotConfiguration botConfiguration)
         {
-            QnAServices = qnaServices ?? throw new ArgumentNullException(nameof(qnaServices));
+            foreach (var service in botConfiguration.Services)
+            {
+                switch (service.Type)
+                {
+                    case ServiceTypes.QnA:
+                        {
+                            // Create a QnA Maker that is initialized and suitable for passing
+                            // into the IBot-derived class (QnABot).
+                            var qna = (QnAMakerService)service;
+                            if (qna == null)
+                            {
+                                throw new InvalidOperationException("The QnA service is not configured correctly in your '.bot' file.");
+                            }
+
+                            if (string.IsNullOrWhiteSpace(qna.KbId))
+                            {
+                                throw new InvalidOperationException("The QnA KnowledgeBaseId ('kbId') is required to run this sample. Please update your '.bot' file.");
+                            }
+
+                            if (string.IsNullOrWhiteSpace(qna.EndpointKey))
+                            {
+                                throw new InvalidOperationException("The QnA EndpointKey ('endpointKey') is required to run this sample. Please update your '.bot' file.");
+                            }
+
+                            if (string.IsNullOrWhiteSpace(qna.Hostname))
+                            {
+                                throw new InvalidOperationException("The QnA Host ('hostname') is required to run this sample. Please update your '.bot' file.");
+                            }
+
+                            var qnaEndpoint = new QnAMakerEndpoint()
+                            {
+                                KnowledgeBaseId = qna.KbId,
+                                EndpointKey = qna.EndpointKey,
+                                Host = qna.Hostname,
+                            };
+
+                            var qnaMaker = new QnAMaker(qnaEndpoint);
+                            QnAServices.Add(qna.Name, qnaMaker);
+                            break;
+                        }
+                }
+            }
         }
 
         /// <summary>

--- a/samples/csharp_dotnetcore/11.qnamaker/QnAMaker/BotServices.cs
+++ b/samples/csharp_dotnetcore/11.qnamaker/QnAMaker/BotServices.cs
@@ -31,7 +31,7 @@ namespace Microsoft.BotBuilderSamples
                         {
                             // Create a QnA Maker that is initialized and suitable for passing
                             // into the IBot-derived class (QnABot).
-                            var qna = (QnAMakerService)service;
+                            var qna = service as QnAMakerService;
                             if (qna == null)
                             {
                                 throw new InvalidOperationException("The QnA service is not configured correctly in your '.bot' file.");

--- a/samples/csharp_dotnetcore/11.qnamaker/Startup.cs
+++ b/samples/csharp_dotnetcore/11.qnamaker/Startup.cs
@@ -65,7 +65,7 @@ namespace Microsoft.BotBuilderSamples
             var botConfig = BotConfiguration.Load(botFilePath ?? @".\qnamaker.bot", secretKey);
 
             // Initialize Bot Connected Services clients.
-            var connectedServices = InitBotServices(botConfig);
+            var connectedServices = new BotServices(botConfig);
             services.AddSingleton(sp => connectedServices);
 
             services.AddSingleton(sp => botConfig);
@@ -131,67 +131,6 @@ namespace Microsoft.BotBuilderSamples
             app.UseDefaultFiles()
                 .UseStaticFiles()
                 .UseBotFramework();
-        }
-
-        /// <summary>
-        /// Initialize the bot's references to external services.
-        /// For example, the QnA Maker instance is created here. This external service is configured
-        /// using the <see cref="BotConfiguration"/> class (based on the contents of your ".bot" file).
-        /// </summary>
-        /// <param name="config">The <see cref="BotConfiguration"/> object based on your ".bot" file.</param>
-        /// <returns>A <see cref="BotConfiguration"/> representing client objects to access external services the bot uses.</returns>
-        /// <seealso cref="BotConfiguration"/>
-        /// <seealso cref="QnAMaker"/>
-        private static BotServices InitBotServices(BotConfiguration config)
-        {
-            var qnaServices = new Dictionary<string, QnAMaker>();
-
-            foreach (var service in config.Services)
-            {
-                switch (service.Type)
-                {
-                    case ServiceTypes.QnA:
-                        {
-                            // Create a QnA Maker that is initialized and suitable for passing
-                            // into the IBot-derived class (QnABot).
-                            var qna = (QnAMakerService)service;
-                            if (qna == null)
-                            {
-                                throw new InvalidOperationException("The QnA service is not configured correctly in your '.bot' file.");
-                            }
-
-                            if (string.IsNullOrWhiteSpace(qna.KbId))
-                            {
-                                throw new InvalidOperationException("The QnA KnowledgeBaseId ('kbId') is required to run this sample. Please update your '.bot' file.");
-                            }
-
-                            if (string.IsNullOrWhiteSpace(qna.EndpointKey))
-                            {
-                                throw new InvalidOperationException("The QnA EndpointKey ('endpointKey') is required to run this sample. Please update your '.bot' file.");
-                            }
-
-                            if (string.IsNullOrWhiteSpace(qna.Hostname))
-                            {
-                                throw new InvalidOperationException("The QnA Host ('hostname') is required to run this sample. Please update your '.bot' file.");
-                            }
-
-                            var qnaEndpoint = new QnAMakerEndpoint()
-                            {
-                                KnowledgeBaseId = qna.KbId,
-                                EndpointKey = qna.EndpointKey,
-                                Host = qna.Hostname,
-                            };
-
-                            var qnaMaker = new QnAMaker(qnaEndpoint);
-                            qnaServices.Add(qna.Name, qnaMaker);
-
-                            break;
-                        }
-                }
-            }
-
-            var connectedServices = new BotServices(qnaServices);
-            return connectedServices;
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/MicrosoftDocs/bot-docs/issues/777

## Proposed Changes
LUIS uses BotServices with:

    A constructor that takes BotConfiguration and initializes a Dictionary

QnAMaker uses BotServices:

    With a static method that initializes the QnAMaker instances on a Dictionary
    Then the result is being passed to BotServices just as a container

It's a little confusing if you are working on a project with both LUIS and QnAMaker to reconcile both approaches on the same base code. Additionally, the BotServices abstraction seems like a recommended approach, which I don't know if it's the case.
