### PR TITLE
Fix "Oujia" typo in cafeFaqChitChat

### DIFF
--- a/samples/javascript_nodejs/51.cafe-bot/cognitiveModels/cafeFaqChitChat.qna
+++ b/samples/javascript_nodejs/51.cafe-bot/cognitiveModels/cafeFaqChitChat.qna
@@ -401,7 +401,7 @@
     },
     {
       "id": 0,
-      "answer": "With questions like this, I'm not much better than a Oujia board.\r\n",
+      "answer": "With questions like this, I'm not much better than a Ouija board.\r\n",
       "source": "custom editorial",
       "questions": [
         "How do you feel about working late?",


### PR DESCRIPTION
Note that this is only in the Node sample. The .NET cafeFaqChitChat KB is much smaller and does not contain this particular quip.