### PR TITLE
Fixes #1215 - Core bot TypeScript generated code doesn’t compile

### DIFF
--- a/generators/generator-botbuilder/generators/app/templates/core/tsconfig.json
+++ b/generators/generator-botbuilder/generators/app/templates/core/tsconfig.json
@@ -6,7 +6,6 @@
       "sourceMap": true,
       "outDir": "./lib",
       "resolveJsonModule": true,
-      "rootDirs": ["./src", "./resources"],
-      "strict": true
+      "rootDirs": ["./src", "./resources"]
     }
 }

--- a/generators/generator-botbuilder/package.json
+++ b/generators/generator-botbuilder/package.json
@@ -1,6 +1,6 @@
 {
     "name": "generator-botbuilder",
-    "version": "4.2.4",
+    "version": "4.2.5",
     "description": "A yeoman generator for creating bots using Bot Framework v4",
     "homepage": "https://github.com/Microsoft/BotBuilder-Samples/tree/master/generators/generator-botbuilder",
     "author": {


### PR DESCRIPTION
Fixes #1215 

## Proposed Changes
- remove strict from tsconfig.json
- bump version to 2.4.5


## Testing
generate TypeScript version of CoreBot
compile