### PR TITLE
Fixes 1218: Welcome Card does not display on non-Windows environments

### DIFF
--- a/samples/csharp_dotnetcore/13.basic-bot/BasicBot.cs
+++ b/samples/csharp_dotnetcore/13.basic-bot/BasicBot.cs
@@ -210,7 +210,9 @@ namespace Microsoft.BotBuilderSamples
         // Load attachment from file.
         private Attachment CreateAdaptiveCardAttachment()
         {
-            var adaptiveCard = File.ReadAllText(@".\Dialogs\Welcome\Resources\welcomeCard.json");
+            string[] paths = {".", "Dialogs", "Welcome", "Resources", "welcomeCard.json"};
+            string fullPath = Path.Combine(paths);
+            var adaptiveCard = File.ReadAllText(fullPath);
             return new Attachment()
             {
                 ContentType = "application/vnd.microsoft.card.adaptive",


### PR DESCRIPTION
Fixes #1218  

## Proposed Changes
- use Path.Combine to build file path to welcomeCard.json

## Testing
Build and run on macOS
Should see a welcome card as soon as Emulator connects to the Bot