### PR TITLE
v3dotnet sample fixes

### DIFF
--- a/CSharp/intelligence-SpeechToText/README.md
+++ b/CSharp/intelligence-SpeechToText/README.md
@@ -1,6 +1,6 @@
 ﻿# Speech To Text Bot Sample
 
-A sample bot that illustrates how to use the Microsoft Cognitive Services Bing Speech API to analyze an audio file and convert the audio stream to text.
+A sample bot that illustrates how to use the Microsoft Cognitive Services Speech API to analyze an audio file and convert the audio stream to text.
 
 [![Deploy to Azure][Deploy Button]][Deploy CSharp/SpeechToText]
 
@@ -12,11 +12,12 @@ A sample bot that illustrates how to use the Microsoft Cognitive Services Bing S
 The minimum prerequisites to run this sample are:
 * The latest update of Visual Studio 2015. You can download the community version [here](http://www.visualstudio.com) for free.
 * The Bot Framework Emulator. To install the Bot Framework Emulator, download it from [here](https://emulator.botframework.com/). Please refer to [this documentation article](https://github.com/microsoft/botframework-emulator/wiki/Getting-Started) to know more about the Bot Framework Emulator.
-* Subscribe to Bing Speech API services [here](https://azure.microsoft.com/en-us/services/cognitive-services/speech/) to obtain a Trial API Key and update the `MicrosoftSpeechApiKey` key in key in [Web.config](Web.config) file to try it out further.
+* Subscribe to Congnitive Speech API services [here](https://azure.microsoft.com/en-us/services/cognitive-services/speech/) to obtain a Trial API Key and update the `MicrosoftSpeechApiKey` and `MicrosoftSpeechServiceRegion` keys in [Web.config](Web.config).
 
 ````XML
   <appSettings>
     <add key="MicrosoftSpeechApiKey" value="PUT-YOUR-OWN-API-KEY-HERE" />
+	<add key="MicrosoftSpeechServiceRegion" value="PUT-YOUR-OWN-API-REGION-HERE" />
   </appSettings>
 ````
 
@@ -26,55 +27,71 @@ Attach an audio file (wav format).
 
 ### Code Highlights
 
-Microsoft Cognitive Services provides a Speech Recognition API to convert audio into text. Check out [Bing Speech API](https://www.microsoft.com/cognitive-services/en-us/speech-api) for a complete reference of Speech APIs available. In this sample we are using the Speech Recognition API using the [REST API](https://www.microsoft.com/cognitive-services/en-us/Speech-api/documentation/API-Reference-REST/BingVoiceRecognition).
+Microsoft Cognitive Services provides a Speech Recognition API to convert audio into text. Check out [Speech Services](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/rest-apis) more information. In this sample we are using the Microsoft.CognitiveServices.Speech library [Nuget](https://www.nuget.org/packages/Microsoft.CognitiveServices.Speech).
 
-In this sample we are using the API to get the text and send it back to the user. Check out the use of the `MicrosoftCognitiveSpeechService.GetTextFromAudioAsync()` method in the [Controllers/MessagesController](Controllers/MessagesController.cs) class.
+In this sample we are using the API to get the text and send it back to the user. Check out the use of the `MicrosoftCognitiveSpeechService.GetTextFromActivity()` method in the [Controllers/MessagesController](Controllers/MessagesController.cs) class.
 ````C#
-var audioAttachment = activity.Attachments?.FirstOrDefault(a => a.ContentType.Equals("audio/wav"));
+var audioAttachment = activity.Attachments?.FirstOrDefault(a => a.ContentType.Equals("audio/wav") || a.ContentType.Equals("application/octet-stream"));
 if (audioAttachment != null)
 {
-    using (var client = new HttpClient())
-    {
-        var stream = await client.GetStreamAsync(audioAttachment.ContentUrl);
-        var text = await this.speechService.GetTextFromAudioAsync(stream);
-        message = ProcessText(activity.Text, text);
-    }
+    var stream = await GetAudioStream(connector, audioAttachment);
+    string text = await MicrosoftCognitiveSpeechService.GetTextFromAudioAsync(stream);
+    message = ProcessText(text);
+}
+else
+{
+    message = "Did you upload an audio file? I'm more of an audible person. Try sending me a wav file";
 }
 ````
 
-and here is the implementation of `MicrosoftCognitiveSpeechService.GetTextFromAudioAsync()` in [Services/MicrosoftCognitiveSpeechService.cs](Services/MicrosoftCognitiveSpeechService.cs)
+and here is the relevant pieces from the implementation of `MicrosoftCognitiveSpeechService.GetTextFromAudioAsync()` in [Services/MicrosoftCognitiveSpeechService.cs](Services/MicrosoftCognitiveSpeechService.cs)
 ````C#
 /// <summary>
 /// Gets text from an audio stream.
 /// </summary>
-/// <param name="audiostream"></param>
-/// <returns>Transcribed text. </returns>
-public async Task<string> GetTextFromAudioAsync(Stream audiostream)
+/// <param name="audiostream">Audio stream</param>
+/// <returns>Transcribed text</returns>
+public static async Task<string> GetTextFromAudioAsync(Stream audiostream)
 {
-    var requestUri = @"https://speech.platform.bing.com/recognize?scenarios=smd&appid=D4D52672-91D7-4C74-8AD8-42B1D98141A5&locale=en-US&device.os=bot&version=3.0&format=json&instanceid=565D69FF-E928-4B7E-87DA-9A750B96D9E3&requestid=" + Guid.NewGuid();
+    string recognizedText = string.Empty;
+            
+    // Creates an instance of a speech config with specified subscription key and service region.
+    // Replace with your own subscription key and service region (e.g., "westus").
+    var config = SpeechConfig.FromSubscription(WebConfigurationManager.AppSettings["MicrosoftSpeechApiKey"], WebConfigurationManager.AppSettings["MicrosoftSpeechServiceRegion"]);
 
-    using (var client = new HttpClient())
+    var stopRecognition = new TaskCompletionSource<int>();
+
+    // Creates a speech recognizer using file as audio input.
+    // Replace with your own audio file name.
+    using (var audioInput = Helper.OpenWavStream(audiostream))
     {
-        var token = Authentication.Instance.GetAccessToken();
-        client.DefaultRequestHeaders.Add("Authorization", "Bearer " + token.access_token);
-
-        using (var binaryContent = new ByteArrayContent(StreamToBytes(audiostream)))
+        using (var recognizer = new SpeechRecognizer(config, audioInput))
         {
-            binaryContent.Headers.TryAddWithoutValidation("content-type", "audio/wav; codec=\"audio/pcm\"; samplerate=16000");
+            recognizer.Recognized += (s, e) =>
+            {
+                if (e.Result.Reason == ResultReason.RecognizedSpeech)
+                {
+                    recognizedText = e.Result.Text;
+                }
+                else if (e.Result.Reason == ResultReason.NoMatch)
+                {
+                    recognizedText = "NOMATCH: Speech could not be recognized.";
+                }
+            };
 
-            var response = await client.PostAsync(requestUri, binaryContent);
-            var responseString = await response.Content.ReadAsStringAsync();
-            try
-            {
-                dynamic data = JsonConvert.DeserializeObject(responseString);
-                return data.header.name;
-            }
-            catch (JsonReaderException ex)
-            {
-                throw new Exception(responseString, ex);
-            }
+            // Starts continuous recognition. Uses StopContinuousRecognitionAsync() to stop recognition.
+            await recognizer.StartContinuousRecognitionAsync().ConfigureAwait(false);
+
+            // Waits for completion.
+            // Use Task.WaitAny to keep the task rooted.
+            Task.WaitAny(new[] { stopRecognition.Task });
+
+            // Stops recognition.
+            await recognizer.StopContinuousRecognitionAsync().ConfigureAwait(false);
         }
     }
+
+    return recognizedText;
 }
 ````
 
@@ -92,6 +109,6 @@ Output:
 
 ### More Information
 
-To get more information about how to get started in Bot Builder for .NET and Microsoft Cognitive Services Bing Speech API please review the following resources:
+To get more information about how to get started in Bot Builder for .NET and Microsoft Cognitive Services Speech API please review the following resources:
 * [Bot Builder for .NET](https://docs.microsoft.com/en-us/bot-framework/dotnet/)
-* [Microsoft Cognitive Services Bing Speech API](https://www.microsoft.com/cognitive-services/en-us/speech-api)
+* [Microsoft Cognitive Speech Services](https://www.microsoft.com/cognitive-services/en-us/speech-api)

--- a/CSharp/intelligence-SpeechToText/Services/Authentication.cs
+++ b/CSharp/intelligence-SpeechToText/Services/Authentication.cs
@@ -8,7 +8,7 @@
 
     public sealed class Authentication
     {
-        // The token has an expiry time of 10 minutes https://www.microsoft.com/cognitive-services/en-us/Speech-api/documentation/API-Reference-REST/BingVoiceRecognition
+        // The token has an expiry time of 10 minutes
         private const int TokenExpiryInSeconds = 600;
 
         private static readonly object LockObject;

--- a/CSharp/intelligence-SpeechToText/Services/BinaryAudioStreamReader.cs
+++ b/CSharp/intelligence-SpeechToText/Services/BinaryAudioStreamReader.cs
@@ -1,0 +1,131 @@
+﻿using Microsoft.CognitiveServices.Speech.Audio;
+using System.Diagnostics;
+using System.IO;
+
+namespace SpeechToText.Services
+{
+    //from: https://github.com/Azure-Samples/cognitive-services-speech-sdk/blob/master/samples/csharp/sharedcontent/console/helper.cs
+    public class Helper
+    {
+        public static AudioConfig OpenWavStream(Stream stream)
+        {
+            BinaryReader reader = new BinaryReader(stream);
+            return OpenWavStream(reader);
+        }
+
+        public static AudioConfig OpenWavStream(BinaryReader reader)
+        {
+            AudioStreamFormat format = readWaveHeader(reader);
+            return AudioConfig.FromStreamInput(new BinaryAudioStreamReader(reader), format);
+        }
+
+        public static AudioStreamFormat readWaveHeader(BinaryReader reader)
+        {
+            // Tag "RIFF"
+            char[] data = new char[4];
+            reader.Read(data, 0, 4);
+            Trace.Assert((data[0] == 'R') && (data[1] == 'I') && (data[2] == 'F') && (data[3] == 'F'), "Wrong wav header");
+
+            // Chunk size
+            long fileSize = reader.ReadInt32();
+
+            // Subchunk, Wave Header
+            // Subchunk, Format
+            // Tag: "WAVE"
+            reader.Read(data, 0, 4);
+            Trace.Assert((data[0] == 'W') && (data[1] == 'A') && (data[2] == 'V') && (data[3] == 'E'), "Wrong wav tag in wav header");
+
+            // Tag: "fmt"
+            reader.Read(data, 0, 4);
+            Trace.Assert((data[0] == 'f') && (data[1] == 'm') && (data[2] == 't') && (data[3] == ' '), "Wrong format tag in wav header");
+
+            // chunk format size
+            var formatSize = reader.ReadInt32();
+            var formatTag = reader.ReadUInt16();
+            var channels = reader.ReadUInt16();
+            var samplesPerSecond = reader.ReadUInt32();
+            var avgBytesPerSec = reader.ReadUInt32();
+            var blockAlign = reader.ReadUInt16();
+            var bitsPerSample = reader.ReadUInt16();
+
+            // Until now we have read 16 bytes in format, the rest is cbSize and is ignored for now.
+            if (formatSize > 16)
+                reader.ReadBytes((int)(formatSize - 16));
+
+            // Second Chunk, data
+            // tag: data.
+            reader.Read(data, 0, 4);
+            Trace.Assert((data[0] == 'd') && (data[1] == 'a') && (data[2] == 't') && (data[3] == 'a'), "Wrong data tag in wav");
+            // data chunk size
+            int dataSize = reader.ReadInt32();
+
+            // now, we have the format in the format parameter and the
+            // reader set to the start of the body, i.e., the raw sample data
+            return AudioStreamFormat.GetWaveFormatPCM(samplesPerSecond, (byte)bitsPerSample, (byte)channels);
+        }
+    }
+
+    /// <summary>
+    /// Adapter class to the native stream api.
+    /// </summary>
+    public sealed class BinaryAudioStreamReader : PullAudioInputStreamCallback
+    {
+        private System.IO.BinaryReader _reader;
+
+        /// <summary>
+        /// Creates and initializes an instance of BinaryAudioStreamReader.
+        /// </summary>
+        /// <param name="reader">The underlying stream to read the audio data from. Note: The stream contains the bare sample data, not the container (like wave header data, etc).</param>
+        public BinaryAudioStreamReader(System.IO.BinaryReader reader)
+        {
+            _reader = reader;
+        }
+
+        /// <summary>
+        /// Creates and initializes an instance of BinaryAudioStreamReader.
+        /// </summary>
+        /// <param name="stream">The underlying stream to read the audio data from. Note: The stream contains the bare sample data, not the container (like wave header data, etc).</param>
+        public BinaryAudioStreamReader(System.IO.Stream stream)
+            : this(new System.IO.BinaryReader(stream))
+        {
+        }
+
+        /// <summary>
+        /// Reads binary data from the stream.
+        /// </summary>
+        /// <param name="dataBuffer">The buffer to fill</param>
+        /// <param name="size">The size of data in the buffer.</param>
+        /// <returns>The number of bytes filled, or 0 in case the stream hits its end and there is no more data available.
+        /// If there is no data immediate available, Read() blocks until the next data becomes available.</returns>
+        public override int Read(byte[] dataBuffer, uint size)
+        {
+            return _reader.Read(dataBuffer, 0, (int)size);
+        }
+
+        /// <summary>
+        /// This method performs cleanup of resources.
+        /// The Boolean parameter <paramref name="disposing"/> indicates whether the method is called from <see cref="IDisposable.Dispose"/> (if <paramref name="disposing"/> is true) or from the finalizer (if <paramref name="disposing"/> is false).
+        /// Derived classes should override this method to dispose resource if needed.
+        /// </summary>
+        /// <param name="disposing">Flag to request disposal.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                _reader.Dispose();
+            }
+
+            disposed = true;
+            base.Dispose(disposing);
+        }
+
+
+        private bool disposed = false;
+    }
+
+}

--- a/CSharp/intelligence-SpeechToText/SpeechToText.csproj
+++ b/CSharp/intelligence-SpeechToText/SpeechToText.csproj
@@ -2,6 +2,9 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <LangVersion>7.1</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>
@@ -13,7 +16,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SpeechToText</RootNamespace>
     <AssemblyName>SpeechToText</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />
@@ -23,23 +26,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <Use64BitIISExpress />
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Autofac, Version=4.2.1.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
@@ -82,6 +69,9 @@
     </Reference>
     <Reference Include="Microsoft.Bot.Connector, Version=3.12.2.4, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.Bot.Connector.3.12.2.4\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CognitiveServices.Speech.csharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=d2e6dcccb609e663, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.CognitiveServices.Speech.1.2.0\lib\net461\Microsoft.CognitiveServices.Speech.csharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -150,9 +140,9 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
       <Private>True</Private>
@@ -182,10 +172,13 @@
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\Authentication.cs" />
+    <Compile Include="Services\BinaryAudioStreamReader.cs" />
     <Compile Include="Services\MicrosoftCognitiveSpeechService.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="packages.config" />
+    <Content Include="packages.config">
+      <SubType>Designer</SubType>
+    </Content>
   </ItemGroup>
   <ItemGroup />
   <PropertyGroup>
@@ -194,6 +187,26 @@
   </PropertyGroup>
   <PropertyGroup>
     <EnableMSDeployAppOffline>true</EnableMSDeployAppOffline>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <LangVersion>7.1</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <LangVersion>7.1</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
@@ -222,7 +235,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('packages\Microsoft.Azure.DocumentDB.1.11.0\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Azure.DocumentDB.1.11.0\build\Microsoft.Azure.DocumentDB.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.CognitiveServices.Speech.1.2.0\build\net461\Microsoft.CognitiveServices.Speech.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.CognitiveServices.Speech.1.2.0\build\net461\Microsoft.CognitiveServices.Speech.targets'))" />
   </Target>
+  <Import Project="packages\Microsoft.CognitiveServices.Speech.1.2.0\build\net461\Microsoft.CognitiveServices.Speech.targets" Condition="Exists('packages\Microsoft.CognitiveServices.Speech.1.2.0\build\net461\Microsoft.CognitiveServices.Speech.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/CSharp/intelligence-SpeechToText/SpeechToText.sln
+++ b/CSharp/intelligence-SpeechToText/SpeechToText.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpeechToText", "SpeechToText.csproj", "{A8BA1066-5695-4D71-ABB4-65E5A5E0C3D4}"
 EndProject
@@ -12,16 +12,19 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "README", "README", "{D52A8E
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{A8BA1066-5695-4D71-ABB4-65E5A5E0C3D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A8BA1066-5695-4D71-ABB4-65E5A5E0C3D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A8BA1066-5695-4D71-ABB4-65E5A5E0C3D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A8BA1066-5695-4D71-ABB4-65E5A5E0C3D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A8BA1066-5695-4D71-ABB4-65E5A5E0C3D4}.Debug|x86.ActiveCfg = Debug|x86
+		{A8BA1066-5695-4D71-ABB4-65E5A5E0C3D4}.Debug|x86.Build.0 = Debug|x86
+		{A8BA1066-5695-4D71-ABB4-65E5A5E0C3D4}.Release|x86.ActiveCfg = Release|x86
+		{A8BA1066-5695-4D71-ABB4-65E5A5E0C3D4}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7D33C8AA-3D4D-4703-95CE-DC987EFADEA2}
 	EndGlobalSection
 EndGlobal

--- a/CSharp/intelligence-SpeechToText/Web.config
+++ b/CSharp/intelligence-SpeechToText/Web.config
@@ -7,7 +7,8 @@
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-  <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 --></configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+  </configSections>
   <appSettings>
     <!-- update these with your BotId, Microsoft App Id, your Microsoft App Password, and Microsoft Speech API Key-->
     <add key="BotId" value="YourBotId" />
@@ -15,10 +16,11 @@
     <add key="MicrosoftAppPassword" value="" />
     <!-- 
     This is a free trial Microsoft Cognitive service key with limited QPS.
-    Please subscribe to Bing Speech API to try it out further.
+    Please subscribe to Speech Services API to try it out further.
     Subscription URL: https://www.microsoft.com/cognitive-services/en-us/subscriptions
     -->
     <add key="MicrosoftSpeechApiKey" value="PUT-YOUR-OWN-API-KEY-HERE" />
+    <add key="MicrosoftSpeechServiceRegion" value="PUT-YOUR-OWN-API-REGION-HERE"/>
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
@@ -30,7 +32,7 @@
   -->
   <system.web>
     <customErrors mode="Off" />
-    <compilation debug="true" targetFramework="4.6" />
+    <compilation debug="true" targetFramework="4.6.1" />
     <httpRuntime targetFramework="4.6" />
   </system.web>
   <system.webServer>

--- a/CSharp/intelligence-SpeechToText/packages.config
+++ b/CSharp/intelligence-SpeechToText/packages.config
@@ -13,6 +13,7 @@
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
   <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.CognitiveServices.Speech" version="1.2.0" targetFramework="net461" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/intelligence-Zummer/Controllers/MessagesController.cs
+++ b/CSharp/intelligence-Zummer/Controllers/MessagesController.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http;
 using Autofac;
+using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Internals;
 using Microsoft.Bot.Builder.Internals.Fibers;
 using Microsoft.Bot.Connector;
@@ -29,6 +30,7 @@ namespace Zummer.Controllers
                     case ActivityTypes.Message:
                         using (var beginLifetimeScope = DialogModule.BeginLifetimeScope(this.scope, activity))
                         {
+                            DialogModule_MakeRoot.Register(beginLifetimeScope, () => beginLifetimeScope.Resolve<IDialog<object>>());
                             var postToBot = beginLifetimeScope.Resolve<IPostToBot>();
                             await postToBot.PostAsync(activity, token);
                         }


### PR DESCRIPTION
Fixes #172
Fixes #185
Fixes #159

Partially fixes: https://github.com/Microsoft/BotBuilder-V3/issues/116

- Use Microsoft.CognitiveServices.Speech for https://github.com/Microsoft/BotBuilder-Samples/tree/v3-sdk-samples/CSharp/intelligence-SpeechToText (Bing Speech has been deprecated.  new keys cannot be created) also note: Microsoft.CognitiveServices.Speech does not support AnyCPU

- Add DialogModule_MakeRoot autofac registration to fix https://github.com/Microsoft/BotBuilder-Samples/tree/v3-sdk-samples/CSharp/intelligence-Zummer


