### PR TITLE
Added note about matching LUIS key and config names for deployed bot

### DIFF
--- a/samples/csharp_dotnetcore/12.nlp-with-luis/README.md
+++ b/samples/csharp_dotnetcore/12.nlp-with-luis/README.md
@@ -81,6 +81,8 @@ msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-loc
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)
 
+**NOTE**: Since the `msbot clone services ...` command creates a new `.bot` file, you likely need to ensure that `LuisKey` in your deployed `LuisBot.cs` matches the `name` property of your LUIS endpoint in your deployed `.bot` file.
+
 
 # Further reading
 - [Azure Bot Service](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)

--- a/samples/csharp_dotnetcore/21.luis-with-appinsights/README.md
+++ b/samples/csharp_dotnetcore/21.luis-with-appinsights/README.md
@@ -64,6 +64,8 @@ This samples requires prerequisites in order to run.
 After creating the bot and testing it locally, you can deploy it to Azure to make it accessible from anywhere.
 To learn how, see [Deploy your bot to Azure][40] for a complete set of deployment instructions.
 
+**NOTE**: Since the `msbot clone services ...` command creates a new `.bot` file, you likely need to ensure that `LuisKey` in your deployed `LuisBot.cs` matches the `name` property of your LUIS endpoint in your deployed `.bot` file.
+
 # View metrics
 - Learn how to use [PowerBI, use Azure Monitor queries and Visual Studio][42] to view Application Insights data
 

--- a/samples/javascript_nodejs/21.luis-with-appinsights/README.md
+++ b/samples/javascript_nodejs/21.luis-with-appinsights/README.md
@@ -67,6 +67,8 @@ This samples requires prerequisites in order to run.
 After creating the bot and testing it locally, you can deploy it to Azure to make it accessible from anywhere.
 To learn how, see [Deploy your bot to Azure][40] for a complete set of deployment instructions.
 
+**NOTE**: Since the `msbot clone services ...` command creates a new `.bot` file, you likely need to ensure that the `name` property of your deployed LUIS service in your `.bot` file matches `LUIS_CONFIGURATIONS`  in your deployed `index.js`
+
 # View metrics
 - Learn how to use [PowerBI, use Azure Monitor queries and Visual Studio][42] to view Application Insights data.
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/BotBuilder-Samples/issues/1203

## Proposed Changes

After `msbot clone services ...` runs, it often renames the LUIS service in the `.bot` file. I just added note about making sure to match the LUIS key and config names for the deployed bot to the relevant LUIS bot samples.
