### PR TITLE
[Sample 30][.NetCore] Added bot.recipe and deployment instructions

### DIFF
--- a/samples/csharp_dotnetcore/30.asp-mvc-bot/DeploymentScripts/MSbotClone/bot.recipe
+++ b/samples/csharp_dotnetcore/30.asp-mvc-bot/DeploymentScripts/MSbotClone/bot.recipe
@@ -1,0 +1,51 @@
+{
+  "version": "1.0",
+  "resources": [
+    {
+      "type": "endpoint",
+      "id": "1",
+      "name": "bot1 development",
+      "url": "http://localhost:3978/bot1"
+    },
+    {
+      "type": "endpoint",
+      "id": "2",
+      "name": "bot2 development",
+      "url": "http://localhost:3978/bot2"
+    },
+    {
+      "type": "endpoint",
+      "id": "3",
+      "name": "bot3 development",
+      "url": "http://localhost:3978/bot3"
+    },
+    {
+      "type": "endpoint",
+      "id": "4",
+      "name": "bot1 production",
+      "url": "https://your-bot-url.azurewebsites.net/bot1"
+    },
+    {
+      "type": "endpoint",
+      "id": "5",
+      "name": "bot2 production",
+      "url": "https://your-bot-url.azurewebsites.net/bot2"
+    },
+    {
+      "type": "endpoint",
+      "id": "6",
+      "name": "bot3 production",
+      "url": "https://your-bot-url.azurewebsites.net/bot3"
+    },
+    {
+      "type": "abs",
+      "id": "7",
+      "name": "MVC-Bot"
+    },
+    {
+      "type": "appInsights",
+      "id": "8",
+      "name": "MVC-Insights"
+    }
+  ]
+}

--- a/samples/csharp_dotnetcore/30.asp-mvc-bot/README.md
+++ b/samples/csharp_dotnetcore/30.asp-mvc-bot/README.md
@@ -40,5 +40,16 @@ To clone this bot, run
 ```bash
 msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id>
 ```
+
+`msbot` will create an extra production endpoint in your `.bot` file with the "name", "production" (*not* "bot* production"). You can safely delete this extra endpoint.
+
+Tests with each endpoint will work in Emulator. Because the bot has three different endpoints, if you want to test in Web Chat, you need to change the endpoint:
+
+1. Open the Web App Bot resource in Azure
+2. Go to Settings
+3. Under Configuration, change the messaging endpoint to `https://<your-bot-url>.azurewebsites.net/bot<1|2|3>` with your bot's URL and the appropriate bot number.
+
+Ensure that you use the appropriate endpoint for any channel that you use to communicate with your bot.
+
 # Further reading
 - [Azure Bot Service Introduction](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)


### PR DESCRIPTION
Fixes #1235 

## Proposed Changes
Per issue, running the `msbot clone` command doesn't work because no `bot.recipe` file is present. I've added that as well as special deployment instructions for dealing with the 3 different endpoints specific to this sample.

## Testing
![image](https://user-images.githubusercontent.com/40401643/52808839-bb9bc200-3043-11e9-8eaa-95720a6bd7af.png)
