### PR TITLE
[Various Samples] Added quotes around appSecret and appId for msbot cmd

### DIFF
--- a/samples/csharp_dotnetcore/02.b.echo-with-counter/README.md
+++ b/samples/csharp_dotnetcore/02.b.echo-with-counter/README.md
@@ -43,7 +43,7 @@ You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Build
 
 To clone this bot, run
 ```bash
-msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_dotnetcore/03.welcome-user/README.md
+++ b/samples/csharp_dotnetcore/03.welcome-user/README.md
@@ -24,7 +24,7 @@ You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Build
 To clone this bot, run
 
 ```bash
-msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_dotnetcore/04.simple-prompt/README.md
+++ b/samples/csharp_dotnetcore/04.simple-prompt/README.md
@@ -37,7 +37,7 @@ npm i -g msbot chatdown ludown qnamaker luis-apis botdispatch luisgen
 ```
 To clone this bot, run
 ```
-msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/README.md
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/README.md
@@ -33,7 +33,7 @@ You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Build
 To clone this bot, run
 
 ```bash
-msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_dotnetcore/06.using-cards/README.md
+++ b/samples/csharp_dotnetcore/06.using-cards/README.md
@@ -37,7 +37,7 @@ You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Build
 
 To clone this bot, run
 ```
-msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/README.md
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/README.md
@@ -35,7 +35,7 @@ You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Build
 
 To clone this bot, run
 ```bash
-msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_dotnetcore/08.suggested-actions/README.md
+++ b/samples/csharp_dotnetcore/08.suggested-actions/README.md
@@ -36,7 +36,7 @@ You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Build
 To clone this bot, run
 
 ```bash
-msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_dotnetcore/09.message-routing/README.md
+++ b/samples/csharp_dotnetcore/09.message-routing/README.md
@@ -31,7 +31,7 @@ You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Build
 To clone this bot, run
 
 ```bash
-msbot clone services -f DeploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services -f DeploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_dotnetcore/12.nlp-with-luis/README.md
+++ b/samples/csharp_dotnetcore/12.nlp-with-luis/README.md
@@ -76,7 +76,7 @@ You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Build
 To clone this bot, run
 
 ```bash
-msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_dotnetcore/13.basic-bot/README.md
+++ b/samples/csharp_dotnetcore/13.basic-bot/README.md
@@ -29,7 +29,7 @@ az account set --subscription "<azure-subscription>"
 
 4. Run the following command from the project directory:
 ```bash
-msbot clone services --name "<NAME>" --luisAuthoringKey "<YOUR AUTHORING KEY>" --folder "DeploymentScripts/MsbotClone" --location "westus" --verbose --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services --name "<NAME>" --luisAuthoringKey "<YOUR AUTHORING KEY>" --folder "DeploymentScripts/MsbotClone" --location "westus" --verbose --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_dotnetcore/14.nlp-with-dispatch/README.md
+++ b/samples/csharp_dotnetcore/14.nlp-with-dispatch/README.md
@@ -78,7 +78,7 @@ To clone this bot, perform the following:
 
 - Run the following command from the project directory:
 ```bash
-msbot clone services --name "<NAME>" --luisAuthoringKey "<YOUR AUTHORING KEY>" --folder "DeploymentScripts/MsbotClone" --location "ie, westus" --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services --name "<NAME>" --luisAuthoringKey "<YOUR AUTHORING KEY>" --folder "DeploymentScripts/MsbotClone" --location "ie, westus" --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_dotnetcore/15.handling-attachments/README.md
+++ b/samples/csharp_dotnetcore/15.handling-attachments/README.md
@@ -44,7 +44,7 @@ You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Build
 To clone this bot, run
 
 ```bash
-msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_dotnetcore/16.proactive-messages/README.md
+++ b/samples/csharp_dotnetcore/16.proactive-messages/README.md
@@ -55,7 +55,7 @@ You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Build
 
 To clone this bot, run
 ```bash
-msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_dotnetcore/17.multilingual-bot/README.md
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/README.md
@@ -56,7 +56,7 @@ You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Build
 
 To clone this bot, run
 ```bash
-msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_dotnetcore/18.bot-authentication/README.md
+++ b/samples/csharp_dotnetcore/18.bot-authentication/README.md
@@ -50,7 +50,7 @@ developers to test and debug their bots on localhost or running remotely through
 You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
 To clone this bot, run
 ```bash
-msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_dotnetcore/19.custom-dialogs/README.md
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/README.md
@@ -31,7 +31,7 @@ You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Build
 
 To clone this bot, run
 ```bash
-msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_dotnetcore/22.conversation-history/README.md
+++ b/samples/csharp_dotnetcore/22.conversation-history/README.md
@@ -38,7 +38,7 @@ You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Build
 
 To clone this bot, run
 ```bash
-msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_dotnetcore/23.facebook-events/README.md
+++ b/samples/csharp_dotnetcore/23.facebook-events/README.md
@@ -44,7 +44,7 @@ You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Build
 
 To clone this bot, run
 ```bash
-msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/README.md
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/README.md
@@ -59,7 +59,7 @@ You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Build
 
 To clone this bot, run
 ```bash
-msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_dotnetcore/51.cafe-bot/README.md
+++ b/samples/csharp_dotnetcore/51.cafe-bot/README.md
@@ -98,7 +98,7 @@ az account set --subscription "<YOUR SUBSCRIPTION>"
 - - Run MSbot Clone and pass in your LUIS authoring key and Azure subscription ID. This command will create required services for your bot and update the .bot file.
 
 ```bash
-msbot clone services --name <YOUR-BOT-NAME> --folder DeploymentScripts/msbotClone --location <Bot service location, ie "westus"> --luisAuthoringKey <YOUR LUIS AUTHORING KEY> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services --name <YOUR-BOT-NAME> --folder DeploymentScripts/msbotClone --location <Bot service location, ie "westus"> --luisAuthoringKey <YOUR LUIS AUTHORING KEY> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/csharp_webapi/02.b.echo-with-counter/README.md
+++ b/samples/csharp_webapi/02.b.echo-with-counter/README.md
@@ -38,7 +38,7 @@ You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Build
 
 To clone this bot, run
 ```bash
-msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/javascript_nodejs/23.facebook-events/README.md
+++ b/samples/javascript_nodejs/23.facebook-events/README.md
@@ -52,7 +52,7 @@ npm i -g msbot
 
 To clone this bot, run
 ```
-msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/javascript_nodejs/50.diceroller-skill/README.md
+++ b/samples/javascript_nodejs/50.diceroller-skill/README.md
@@ -56,7 +56,7 @@ You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Build
 
 To clone this bot, run
 ```
-msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
 ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)

--- a/samples/javascript_nodejs/51.cafe-bot/README.md
+++ b/samples/javascript_nodejs/51.cafe-bot/README.md
@@ -96,7 +96,7 @@ Ensure you have [Node.js](https://nodejs.org/) version 8.5 or higher
         ```
     - Run MSbot Clone and pass in your LUIS authoring key and Azure subscription ID. This command will create required services for your bot and update the .bot file.
         ```bash
-        msbot clone services -n <YOUR-BOT-NAME> -f deploymentScripts/msbotClone -l <Bot service location> --luisAuthoringKey <Key from step-2 above> --subscriptionId <Key from step-1 above> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>
+        msbot clone services -n <YOUR-BOT-NAME> -f deploymentScripts/msbotClone -l <Bot service location> --luisAuthoringKey <Key from step-2 above> --subscriptionId <Key from step-1 above> --appId "<YOUR APP ID>" --appSecret "<YOUR APP SECRET PASSWORD>"
         ```
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)


### PR DESCRIPTION
Fixes #1233 

## Proposed Changes
Added `""` around `appId` and `appSecret` for `msbot clone services ...` command in README.md for applicable samples. This is a rare issue, but seems to pop up occasionally due in large part to whether `appSecret` contains special characters and in small part to the console the user uses.