### PR TITLE
Fixes 1246, EmptyBot missing adapter contractor credentials

### DIFF
--- a/generators/generator-botbuilder/generators/app/templates/empty/index.js
+++ b/generators/generator-botbuilder/generators/app/templates/empty/index.js
@@ -18,7 +18,10 @@ server.listen(process.env.port || process.env.PORT || 3978, () => {
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about .bot file its use and bot configuration.
-const adapter = new BotFrameworkAdapter();
+const adapter = new BotFrameworkAdapter({
+    appId: process.env.microsoftAppID,
+    appPassword: process.env.microsoftAppPassword
+});
 
 // Catch-all for errors.
 adapter.onTurnError = async (context, error) => {

--- a/generators/generator-botbuilder/generators/app/templates/empty/index.ts
+++ b/generators/generator-botbuilder/generators/app/templates/empty/index.ts
@@ -18,7 +18,10 @@ server.listen(process.env.port || process.env.PORT || 3978, () => {
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about .bot file its use and bot configuration.
-const adapter = new BotFrameworkAdapter();
+const adapter = new BotFrameworkAdapter({
+    appId: process.env.microsoftAppID,
+    appPassword: process.env.microsoftAppPassword
+});
 
 // Catch-all for errors.
 adapter.onTurnError = async (context, error) => {

--- a/generators/generator-botbuilder/package.json
+++ b/generators/generator-botbuilder/package.json
@@ -1,6 +1,6 @@
 {
     "name": "generator-botbuilder",
-    "version": "4.2.5",
+    "version": "4.2.6",
     "description": "A yeoman generator for creating bots using Bot Framework v4",
     "homepage": "https://github.com/Microsoft/BotBuilder-Samples/tree/master/generators/generator-botbuilder",
     "author": {


### PR DESCRIPTION
Fixes #1246 

## Proposed Changes
- add appId and appPassword pulling from process.env
- update JavaScript
- update TypeScript
- bump version patch number

## Testing
1. run `yo botbuilder -N "my-empty-bot-js" -D "An empty bot in js" -L "JavaScript" -T "empty" --noprompt`
2. verify changes were added in index.js
3. run `yo botbuilder -N "my-empty-bot-ts" -D "An empty bot in ts" -L "TypeScript" -T "empty" --noprompt`
4. verify changes were added in src\index.ts