### PR TITLE
[Proactive Samples] Add code and docs for TrustServiceUrl - Prevents 401 Errors

### DIFF
--- a/samples/csharp_dotnetcore/16.proactive-messages/ProactiveBot.cs
+++ b/samples/csharp_dotnetcore/16.proactive-messages/ProactiveBot.cs
@@ -245,7 +245,8 @@ namespace Microsoft.BotBuilderSamples
                 //    fine without the TrustServiceUrl code below. However, if you remove the code below and your bot is restarted, a user
                 //    awaiting a proactive message cannot receive it unless they message the bot again after the restart. Basically, placing the TrustServiceUrl
                 //    right before sending the proactive message ensures that a user will always be able to receive the proactive message.
-                MicrosoftAppCredentials.TrustServiceUrl(turnContext.Activity.ServiceUrl);
+                // Note: This code is commented out because it will not work in Emulator without also setting appId and appPassword
+                // MicrosoftAppCredentials.TrustServiceUrl(turnContext.Activity.ServiceUrl);
 
                 // Send the user a proactive confirmation message.
                 await turnContext.SendActivityAsync($"Job {jobInfo.TimeStamp} is complete.");

--- a/samples/csharp_dotnetcore/16.proactive-messages/ProactiveBot.cs
+++ b/samples/csharp_dotnetcore/16.proactive-messages/ProactiveBot.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Configuration;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 
 namespace Microsoft.BotBuilderSamples
@@ -237,6 +238,14 @@ namespace Microsoft.BotBuilderSamples
 
                 // Now save it into the JobState
                 await _jobState.SaveChangesAsync(turnContext);
+
+                // Trust the serviceUrl of the recipient
+                // By default, the BotBuilder SDK adds a serviceUrl to the list of trusted host names if the incoming request is
+                //    authenticated by BotAuthentication. They are maintained in an in-memory cache. In most instances, your bot will work
+                //    fine without the TrustServiceUrl code below. However, if you remove the code below and your bot is restarted, a user
+                //    awaiting a proactive message cannot receive it unless they message the bot again after the restart. Basically, placing the TrustServiceUrl
+                //    right before sending the proactive message ensures that a user will always be able to receive the proactive message.
+                MicrosoftAppCredentials.TrustServiceUrl(turnContext.Activity.ServiceUrl);
 
                 // Send the user a proactive confirmation message.
                 await turnContext.SendActivityAsync($"Job {jobInfo.TimeStamp} is complete.");

--- a/samples/csharp_dotnetcore/16.proactive-messages/README.md
+++ b/samples/csharp_dotnetcore/16.proactive-messages/README.md
@@ -72,7 +72,7 @@ MicrosoftAppCredentials.TrustServiceUrl(serviceUrl);
 
 For proactive messaging, `serviceUrl` is the URL of the channel that the recipient of the proactive message is using and can be found in `Activity.ServiceUrl`.
 
-You'll want to add the above code just prior to the the code that sends the proactive message. This sample has it near the end of `CreateCallback()` in `ProactiveBot.cs`.
+You'll want to add the above code just prior to the the code that sends the proactive message. This sample has it near the end of `CreateCallback()` in `ProactiveBot.cs`, but it is commented out because it will not work in Emulator without an `appId` and `appPassword`.
 
 
 # Further reading

--- a/samples/csharp_dotnetcore/16.proactive-messages/README.md
+++ b/samples/csharp_dotnetcore/16.proactive-messages/README.md
@@ -60,5 +60,20 @@ msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-loc
 
 **NOTE**: You can obtain your `appId` and `appSecret` at the Microsoft's [Application Registration Portal](https://apps.dev.microsoft.com/)
 
+# Avoiding 401 "Unauthorized" Errors
+
+By default, the BotBuilder SDK adds a `serviceUrl` to the list of trusted host names if the incoming request is authenticated by BotAuthentication. They are maintained in an in-memory cache. If your bot is restarted, a user awaiting a proactive message cannot receive it unless they have messaged the bot again after it restarted.
+
+To avoid this, you must manually add the `serviceUrl` to the list of trusted host names by using:
+
+```csharp
+MicrosoftAppCredentials.TrustServiceUrl(serviceUrl);
+```
+
+For proactive messaging, `serviceUrl` is the URL of the channel that the recipient of the proactive message is using and can be found in `Activity.ServiceUrl`.
+
+You'll want to add the above code just prior to the the code that sends the proactive message. This sample has it near the end of `CreateCallback()` in `ProactiveBot.cs`.
+
+
 # Further reading
 - [Azure Bot Service Introduction](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)

--- a/samples/javascript_nodejs/16.proactive-messages/README.md
+++ b/samples/javascript_nodejs/16.proactive-messages/README.md
@@ -107,6 +107,20 @@ As you make changes to your bot running locally, and want to deploy those change
 ### Getting Additional Help Deploying to Azure
 To learn more about deploying a bot to Azure, see [Deploy your bot to Azure][40] for a complete list of deployment instructions.
 
+# Avoiding 401 "Unauthorized" Errors
+
+By default, the BotBuilder SDK adds a `serviceUrl` to the list of trusted host names if the incoming request is authenticated by BotAuthentication. They are maintained in an in-memory cache. If your bot is restarted, a user awaiting a proactive message cannot receive it unless they have messaged the bot again after it restarted.
+
+To avoid this, you must manually add the `serviceUrl` to the list of trusted host names by using:
+
+```js
+MicrosoftAppCredentials.trustServiceUrl(serviceUrl);
+```
+
+For proactive messaging, `serviceUrl` is the URL of the channel that the recipient of the proactive message is using and can be found in `activity.serviceUrl`.
+
+You'll want to add the above code just prior to the the code that sends the proactive message. This sample has it near the end of `completeJob()` in `bot.js`.
+
 # Further reading
 - [Bot Framework Documentation][20]
 - [Bot Basics][32]

--- a/samples/javascript_nodejs/16.proactive-messages/README.md
+++ b/samples/javascript_nodejs/16.proactive-messages/README.md
@@ -119,7 +119,7 @@ MicrosoftAppCredentials.trustServiceUrl(serviceUrl);
 
 For proactive messaging, `serviceUrl` is the URL of the channel that the recipient of the proactive message is using and can be found in `activity.serviceUrl`.
 
-You'll want to add the above code just prior to the the code that sends the proactive message. This sample has it near the end of `completeJob()` in `bot.js`.
+You'll want to add the above code just prior to the the code that sends the proactive message. This sample has it near the end of `completeJob()` in `bot.js`, but it is commented out because it will not work in Emulator without an `appId` and `appPassword`.
 
 # Further reading
 - [Bot Framework Documentation][20]

--- a/samples/javascript_nodejs/16.proactive-messages/bot.js
+++ b/samples/javascript_nodejs/16.proactive-messages/bot.js
@@ -132,7 +132,8 @@ class ProactiveBot {
                 //    fine without the trustServiceUrl code below. However, if you remove the code below and your bot is restarted, a user
                 //    awaiting a proactive message cannot receive it unless they message the bot again after the restart. Basically, placing the trustServiceUrl
                 //    right before sending the proactive message ensures that a user will always be able to receive the proactive message.
-                MicrosoftAppCredentials.trustServiceUrl(turnContext.activity.serviceUrl);
+                // Note: This code is commented out because it will not work in Emulator without also setting appId and appPassword
+                // MicrosoftAppCredentials.trustServiceUrl(turnContext.activity.serviceUrl);
 
                 // Send a message to the person who completed the job.
                 await turnContext.sendActivity('Job completed. Notification sent.');

--- a/samples/javascript_nodejs/16.proactive-messages/bot.js
+++ b/samples/javascript_nodejs/16.proactive-messages/bot.js
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 const { ActivityTypes, TurnContext } = require('botbuilder');
+const { MicrosoftAppCredentials } = require('botframework-connector');
 
 const JOBS_LIST = 'jobs';
 
@@ -124,6 +125,14 @@ class ProactiveBot {
                     // Notify the user that the job is complete.
                     await proactiveTurnContext.sendActivity(`Your queued job ${ jobIdNumber } just completed.`);
                 });
+
+                // Trust the serviceUrl of the recipient
+                // By default, the BotBuilder SDK adds a serviceUrl to the list of trusted host names if the incoming request is
+                //    authenticated by BotAuthentication. They are maintained in an in-memory cache. In most instances, your bot will work
+                //    fine without the trustServiceUrl code below. However, if you remove the code below and your bot is restarted, a user
+                //    awaiting a proactive message cannot receive it unless they message the bot again after the restart. Basically, placing the trustServiceUrl
+                //    right before sending the proactive message ensures that a user will always be able to receive the proactive message.
+                MicrosoftAppCredentials.trustServiceUrl(turnContext.activity.serviceUrl);
 
                 // Send a message to the person who completed the job.
                 await turnContext.sendActivity('Job completed. Notification sent.');

--- a/samples/javascript_nodejs/16.proactive-messages/package.json
+++ b/samples/javascript_nodejs/16.proactive-messages/package.json
@@ -19,6 +19,7 @@
         "botbuilder": "^4.2.0",
         "botbuilder-dialogs": "^4.2.0",
         "botframework-config": "^4.2.0",
+        "botframework-connector": "^4.2.0",
         "dotenv": "^6.1.0",
         "fetch-ponyfill": "^6.0.2",
         "moment": "^2.22.2",


### PR DESCRIPTION
## Proposed Changes

Adds code and documentation for implementing `MicrosoftAppCredentials.TrustServiceUrl(turnContext.Activity.ServiceUrl);`

There are [several.](https://www.google.com/search?q=site%3Astackoverflow.com+%22trustserviceurl%22+%22botframework%22&rlz=1C1CHBF_enUS830US830&oq=site%3Astackoverflow.com+%22trustserviceurl%22+%22botf&aqs=chrome.0.69i59j69i57j69i58.9602j0j7&sourceid=chrome&ie=UTF-8) [issues.](https://github.com/Microsoft/BotBuilder/issues?q=label%3A%22Trust+Service+URL%22+is%3Aclosed) relating to this. Basically, when developers want to send proactive messages, they often stop working because the URL is no longer trusted. Issues have and do pop up for this fairly frequently, so this PR adds code and docs to the most relevant place to 1) learn how to proactive message and, 2) look for help.

Note: I would be fine if the code is commented out, so long as the comment remains. Devs should still find it useful.

## Testing

I tested implementations of this for both the C# and JS sample.

Method:

**Normal**

1. Deploy sample without PR change
2. Test proactive message between Emulator connected to Production and "Test in Web Chat"
3. Bot successfully sends proactive message

**No Change, Restarted**

1. Deploy sample without PR change
2. Have Emulator user create proactive job
3. Restart bot service
4. Have Test in Web Chat user complete job
5. Bot gives 401 Unauthorized error since URL is no longer trusted. Emulator user does not receive message.

**PR implemented, Bot Restarted**

1. Deploy sample WITH PR change
2. Have Emulator user create proactive job
3. Restart bot service
4. Have Test in Web Chat user complete job
5. Emulator user successfully gets message that job was completed.