### PR TITLE
[JS Sample 15] Fix for image attachments

### DIFF
--- a/samples/javascript_nodejs/15.handling-attachments/bot.js
+++ b/samples/javascript_nodejs/15.handling-attachments/bot.js
@@ -84,7 +84,16 @@ class AttachmentsBot {
         const localFileName = path.join(__dirname, attachment.name);
 
         try {
-            const response = await axios.get(url);
+            // arraybuffer is necessary for images
+            const response = await axios.get(url, { responseType: 'arraybuffer' });
+            // If user uploads JSON file, this prevents it from being written as "{"type":"Buffer","data":[123,13,10,32,32,34,108..."
+            if (response.headers['content-type'] === 'application/json') {
+                response.data = JSON.parse(response.data, (key, value) => {
+                    return value && value.type === 'Buffer' ?
+                      Buffer.from(value.data) :
+                      value;
+                    });
+            }
             fs.writeFile(localFileName, response.data, (fsError) => {
                 if (fsError) {
                     throw fsError;


### PR DESCRIPTION
Fixes #1293 

Per issue, without this change, an attached/uploaded image or PDF (likely some other file formats, too) would corrupt while saving locally. @Zerryth and I found that this fixes it.

## Proposed Changes
When calling `downloadAttachmentAndWrite(attachment)`:

* Gets the attachment response as an 'arraybuffer' (instead of default ?blob?)
* If content-type is `application/json`, converts before saving to prevent `.json` file content being something like: "{"type":"Buffer","data":[123,13,10,32,32,34,108..."


## Testing
Tested with the following filetypes:

* jpg
* msi
* txt
* json
* js
* ts
* png
* mp4
* pdf

They all work.