### PR TITLE
Qnamaker support bot Sample

### DIFF
--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/BotConfiguration.bot
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/BotConfiguration.bot
@@ -1,0 +1,34 @@
+﻿{
+  "name": "SupportBot",
+  "services": [
+    {
+      "type": "endpoint",
+      "name": "development",
+      "endpoint": "http://localhost:54789/api/messages",
+      "appId": "",
+      "appPassword": "",
+      "id": "1"
+    },
+    {
+      "type": "qna",
+      "name": "QnABot",
+      "KbId": "<Your KBID>",
+      "Hostname": "<Your HostName>",
+      "EndpointKey": "<Your Endpoint Key>"
+    },
+       {
+      "type": "appInsights",
+      "tenantId": "",
+      "subscriptionId": "",
+      "resourceGroup": "",
+      "name": "appinsightsService",
+      "serviceName": "appinsightsService",
+      "instrumentationKey": "<Yourappinsights Instrumentation Key>",
+      "applicationId": "<Your Application insights App ID>",
+      "apiKeys": {},
+      "id": "4"
+    }
+  ],
+  "padlock": "",
+  "version": "2.0"
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Connected Services/Application Insights/ConnectedService.json
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Connected Services/Application Insights/ConnectedService.json
@@ -1,0 +1,7 @@
+﻿{
+  "ProviderId": "Microsoft.ApplicationInsights.ConnectedService.ConnectedServiceProvider",
+  "Version": "8.13.10627.1",
+  "GettingStartedDocument": {
+    "Uri": "https://go.microsoft.com/fwlink/?LinkID=798432"
+  }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/DeploymentScripts/MsbotClone/bot.recipe
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/DeploymentScripts/MsbotClone/bot.recipe
@@ -1,0 +1,32 @@
+{
+  "version": "1.0",
+  "resources": [
+    {
+      "type": "endpoint",
+      "id": "1",
+      "name": "development",
+      "url": "http://localhost:3978/api/messages"
+    },
+    {
+      "type": "luis",
+      "id": "34",
+      "name": "basic-bot-LUIS"
+    },
+    {
+      "type": "abs",
+      "id": "3",
+      "name": "Bot_Builder_Basic_Bot_V42-abs"
+    },
+    {
+      "type": "appInsights",
+      "id": "4",
+      "name": "Bot_Builder_Basic_Bot_V42-insights"
+    },
+    {
+      "type": "blob",
+      "id": "5",
+      "name": "Bot_Builder_Basic_Bot_V42-blob",
+      "container": "botstatestore"
+    }
+  ]
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Dialogs/ShowQnAResult/ShowQnAResultAccessor.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Dialogs/ShowQnAResult/ShowQnAResultAccessor.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Dialogs.ShowQnAResult
+{
+    using System;
+    using Microsoft.Bot.Builder;
+    using Microsoft.Bot.Builder.Dialogs;
+
+    public class ShowQnAResultAccessor
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ShowQnAResultAccessor"/> class.
+        /// Contains the <see cref="ConversationState"/> and associated <see cref="IStatePropertyAccessor{T}"/>.
+        /// </summary>
+        /// <param name="conversationState">The state object that stores the counter.</param>
+        public ShowQnAResultAccessor(ConversationState conversationState)
+        {
+            ConversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IStatePropertyAccessor{T}"/> name used for the <see cref="CounterState"/> accessor.
+        /// </summary>
+        /// <remarks>Accessors require a unique name.</remarks>
+        /// <value>The accessor name for the counter accessor.</value>
+        public static string QnAResultStateName { get; } = $"{nameof(ShowQnAResultAccessor)}.QnAResultState";
+
+        /// <summary>
+        /// Gets or sets the <see cref="IStatePropertyAccessor{T}"/> for CounterState.
+        /// </summary>
+        /// <value>
+        /// The accessor stores the turn count for the conversation.
+        /// </value>
+        public IStatePropertyAccessor<ShowQnAResultState> QnAResultState { get; set; }
+
+        public IStatePropertyAccessor<DialogState> ConversationDialogState { get; set; }
+
+        public IStatePropertyAccessor<UserState> UserProfile { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="ConversationState"/> object for the conversation.
+        /// </summary>
+        /// <value>The <see cref="ConversationState"/> object.</value>
+        public ConversationState ConversationState { get; }
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Dialogs/ShowQnAResult/ShowQnAResultState.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Dialogs/ShowQnAResult/ShowQnAResultState.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Dialogs.ShowQnAResult
+{
+    using SupportBot.Providers.QnAMaker;
+
+    /// <summary>TurnContext State.</summary>
+    public class ShowQnAResultState
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ShowQnAResultState"/> class.
+        /// </summary>
+        public ShowQnAResultState()
+        {
+            this.ConsiderState = false;
+            this.QnaAnswer = new QnAMakerAnswer();
+            this.NeuroconCount = 0;
+            this.IsFeedback = false;
+            this.ActiveLearningAnswer = false;
+        }
+
+        /// <summary>Gets or sets a value indicating whether context state needs to be considered.</summary>
+        public bool ConsiderState { get; set; }
+
+        /// <summary>Gets or sets QnAMaker answer.</summary>
+        public QnAMakerAnswer QnaAnswer { get; set; }
+
+        /// <summary>Gets or sets number of times personality chat or QnA chitchat answer is shown consequently.</summary>
+        public int NeuroconCount { get; set; }
+
+        /// <summary>Gets or sets a value indicating whether feedback flow is true.</summary>
+        public bool IsFeedback { get; set; }
+
+        /// <summary>Gets or sets a value indicating whether active learning is true.</summary>
+        public bool ActiveLearningAnswer { get; set; }
+
+        /// <summary>Gets or sets user question which invoked active learning.</summary>
+        public string ActiveLearningUserQuestion { get; set; }
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Middleware/Telemetry/QnATelemetryConstants.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Middleware/Telemetry/QnATelemetryConstants.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Middleware.Telemetry
+{
+    /// <summary>
+    /// The Application Insights property names to log.
+    /// </summary>
+    public class QnATelemetryConstants
+    {
+        public const string UsernameProperty = "username";
+        public const string OriginalQuestionProperty = "originalQuestion";
+        public const string OriginalMetadataProperty = "originalMetadata";
+        public const string QuestionProperty = "question";
+        public const string AnswerProperty = "answer";
+        public const string ScoreProperty = "score";
+        public const string MetadataProperty = "metadata";
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Middleware/Telemetry/TelemetryConstants.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Middleware/Telemetry/TelemetryConstants.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Middleware.Telemetry
+{
+    /// <summary>
+    /// The Application Insights Telemetry constants to log.
+    /// </summary>
+    public class TelemetryConstants
+    {
+        public const string ReplyActivityIDProperty = "replyActivityId";
+        public const string FromIdProperty = "FromId";
+        public const string FromNameProperty = "FromName";
+        public const string RecipientIdProperty = "recipientId";
+        public const string RecipientNameProperty = "recipientName";
+        public const string ConversationNameProperty = "conversationName";
+        public const string TextProperty = "text";
+        public const string LocaleProperty = "locale";
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Middleware/Telemetry/TelemetryLogger.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Middleware/Telemetry/TelemetryLogger.cs
@@ -1,0 +1,243 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Middleware.Telemetry
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Bot.Builder;
+    using Microsoft.Bot.Schema;
+
+    /// <summary>
+    /// Middleware for logging incoming, outgoing, updated or deleted Activity messages into Application Insights.
+    /// In addition, registers the telemetry client in the context so other Application Insights components can log
+    /// telemetry.
+    /// If this Middleware is removed, all the other sample components don't log (but still operate).
+    /// </summary>
+    public class TelemetryLoggerMiddleware : IMiddleware
+    {
+        public static readonly string AppInsightsServiceKey = $"{nameof(TelemetryLoggerMiddleware)}.AppInsightsContext";
+
+        // Application Insights Custom Event name, logged when new message is received from the user
+        public static readonly string BotMsgReceiveEvent = "BotMessageReceived";
+
+        // Application Insights Custom Event name, logged when a message is sent out from the bot
+        public static readonly string BotMsgSendEvent = "BotMessageSend";
+
+        // Application Insights Custom Event name, logged when a message is updated by the bot (rare case)
+        public static readonly string BotMsgUpdateEvent = "BotMessageUpdate";
+
+        // Application Insights Custom Event name, logged when a message is deleted by the bot (rare case)
+        public static readonly string BotMsgDeleteEvent = "BotMessageDelete";
+
+        private IBotTelemetryClient _telemetryClient;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TelemetryLoggerMiddleware"/> class.
+        /// </summary>
+        /// <param name="telemetryClient">The IBotTelemetryClient that logs to Application Insights.</param>
+        /// <param name="logUserName"> (Optional) Enable/Disable logging user name within Application Insights.</param>
+        /// <param name="logOriginalMessage"> (Optional) Enable/Disable logging original message name within Application Insights.</param>
+        /// <param name="config"> (Optional) TelemetryConfiguration to use for Application Insights.</param>
+        public TelemetryLoggerMiddleware(IBotTelemetryClient telemetryClient, bool logUserName = true, bool logOriginalMessage = true)
+        {
+            _telemetryClient = telemetryClient;
+            LogUserName = logUserName;
+            LogOriginalMessage = logOriginalMessage;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether indicates whether to log the user name into the BotMessageReceived event.
+        /// </summary>
+        /// <value>
+        /// A value indicating whether indicates whether to log the user name into the BotMessageReceived event.
+        /// </value>
+        public bool LogUserName { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether indicates whether to log the original message into the BotMessageReceived event.
+        /// </summary>
+        /// <value>
+        /// Indicates whether to log the original message into the BotMessageReceived event.
+        /// </value>
+        public bool LogOriginalMessage { get; }
+
+        /// <summary>
+        /// Records incoming and outgoing activities to the Application Insights store.
+        /// </summary>
+        /// <param name="context">The context object for this turn.</param>
+        /// <param name="nextTurn">The delegate to call to continue the bot middleware pipeline.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <seealso cref="ITurnContext"/>
+        /// <seealso cref="Bot.Schema.IActivity"/>
+        public async Task OnTurnAsync(ITurnContext context, NextDelegate nextTurn, CancellationToken cancellationToken)
+        {
+            BotAssert.ContextNotNull(context);
+
+            context.TurnState.Add(TelemetryLoggerMiddleware.AppInsightsServiceKey, _telemetryClient);
+
+            // log incoming activity at beginning of turn
+            if (context.Activity != null)
+            {
+                var activity = context.Activity;
+
+                // Log the Application Insights Bot Message Received
+                _telemetryClient.TrackEvent(BotMsgReceiveEvent, this.FillReceiveEventProperties(activity));
+            }
+
+            // hook up onSend pipeline
+            context.OnSendActivities(async (ctx, activities, nextSend) =>
+            {
+                // run full pipeline
+                var responses = await nextSend().ConfigureAwait(false);
+
+                foreach (var activity in activities)
+                {
+                    _telemetryClient.TrackEvent(BotMsgSendEvent, this.FillSendEventProperties(activity));
+                }
+
+                return responses;
+            });
+
+            // hook up update activity pipeline
+            context.OnUpdateActivity(async (ctx, activity, nextUpdate) =>
+            {
+                // run full pipeline
+                var response = await nextUpdate().ConfigureAwait(false);
+
+                _telemetryClient.TrackEvent(BotMsgUpdateEvent, this.FillUpdateEventProperties(activity));
+
+                return response;
+            });
+
+            // hook up delete activity pipeline
+            context.OnDeleteActivity(async (ctx, reference, nextDelete) =>
+            {
+                // run full pipeline
+                await nextDelete().ConfigureAwait(false);
+
+                var deleteActivity = new Activity
+                {
+                    Type = ActivityTypes.MessageDelete,
+                    Id = reference.ActivityId,
+                }
+                .ApplyConversationReference(reference, isIncoming: false)
+                .AsMessageDeleteActivity();
+
+                _telemetryClient.TrackEvent(BotMsgDeleteEvent, this.FillDeleteEventProperties(deleteActivity));
+            });
+
+            if (nextTurn != null)
+            {
+                await nextTurn(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Fills the Application Insights Custom Event properties for BotMessageReceived.
+        /// These properties are logged in the custom event when a new message is received from the user.
+        /// </summary>
+        /// <param name="activity">Last activity sent from user.</param>
+        /// <returns>A dictionary that is sent as "Properties" to Application Insights TrackEvent method for the BotMessageReceived Message.</returns>
+        private Dictionary<string, string> FillReceiveEventProperties(Activity activity)
+        {
+            var properties = new Dictionary<string, string>()
+                {
+                    { TelemetryConstants.FromIdProperty, activity.From.Id },
+                    { TelemetryConstants.ConversationNameProperty, activity.Conversation.Name },
+                    { TelemetryConstants.LocaleProperty, activity.Locale },
+                };
+
+            // For some customers, logging user name within Application Insights might be an issue so have provided a config setting to disable this feature
+            if (LogUserName && !string.IsNullOrWhiteSpace(activity.From.Name))
+            {
+                properties.Add(TelemetryConstants.FromNameProperty, activity.From.Name);
+            }
+
+            // For some customers, logging the utterances within Application Insights might be an so have provided a config setting to disable this feature
+            if (LogOriginalMessage && !string.IsNullOrWhiteSpace(activity.Text))
+            {
+                properties.Add(TelemetryConstants.TextProperty, activity.Text);
+            }
+
+            return properties;
+        }
+
+        /// <summary>
+        /// Fills the Application Insights Custom Event properties for BotMessageSend.
+        /// These properties are logged in the custom event when a response message is sent by the Bot to the user.
+        /// </summary>
+        /// <param name="activity">Last activity sent from user.</param>
+        /// <returns>A dictionary that is sent as "Properties" to Application Insights TrackEvent method for the BotMessageSend Message.</returns>
+        private Dictionary<string, string> FillSendEventProperties(Activity activity)
+        {
+            var properties = new Dictionary<string, string>()
+                {
+                    { TelemetryConstants.ReplyActivityIDProperty, activity.Id },
+                    { TelemetryConstants.RecipientIdProperty, activity.Recipient.Id },
+                    { TelemetryConstants.ConversationNameProperty, activity.Conversation.Name },
+                    { TelemetryConstants.LocaleProperty, activity.Locale },
+                };
+
+            // For some customers, logging user name within Application Insights might be an issue so have provided a config setting to disable this feature
+            if (LogUserName && !string.IsNullOrWhiteSpace(activity.Recipient.Name))
+            {
+                properties.Add(TelemetryConstants.RecipientNameProperty, activity.Recipient.Name);
+            }
+
+            // For some customers, logging the utterances within Application Insights might be an so have provided a config setting to disable this feature
+            if (LogOriginalMessage && !string.IsNullOrWhiteSpace(activity.Text))
+            {
+                properties.Add(TelemetryConstants.TextProperty, activity.Text);
+            }
+
+            return properties;
+        }
+
+        /// <summary>
+        /// Fills the Application Insights Custom Event properties for BotMessageUpdate.
+        /// These properties are logged in the custom event when an activity message is updated by the Bot.
+        /// For example, if a card is interacted with by the use, and the card needs to be updated to reflect
+        /// some interaction.
+        /// </summary>
+        /// <param name="activity">Last activity sent from user.</param>
+        /// <returns>A dictionary that is sent as "Properties" to Application Insights TrackEvent method for the BotMessageUpdate Message.</returns>
+        private Dictionary<string, string> FillUpdateEventProperties(Activity activity)
+        {
+            var properties = new Dictionary<string, string>()
+                {
+                    { TelemetryConstants.RecipientIdProperty, activity.Recipient.Id },
+                    { TelemetryConstants.ConversationNameProperty, activity.Conversation.Name },
+                    { TelemetryConstants.LocaleProperty, activity.Locale },
+                };
+
+            // For some customers, logging the utterances within Application Insights might be an so have provided a config setting to disable this feature
+            if (LogOriginalMessage && !string.IsNullOrWhiteSpace(activity.Text))
+            {
+                properties.Add(TelemetryConstants.TextProperty, activity.Text);
+            }
+
+            return properties;
+        }
+
+        /// <summary>
+        /// Fills the Application Insights Custom Event properties for BotMessageDelete.
+        /// These properties are logged in the custom event when an activity message is deleted by the Bot.  This is a relatively rare case.
+        /// </summary>
+        /// <param name="activity">Last activity sent from user.</param>
+        /// <returns>A dictionary that is sent as "Properties" to Application Insights TrackEvent method for the BotMessageDelete Message.</returns>
+        private Dictionary<string, string> FillDeleteEventProperties(IMessageDeleteActivity activity)
+        {
+            var properties = new Dictionary<string, string>()
+                {
+                    { TelemetryConstants.RecipientIdProperty, activity.Recipient.Id },
+                    { TelemetryConstants.ConversationNameProperty, activity.Conversation.Name },
+                };
+
+            return properties;
+        }
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Middleware/Telemetry/TelemetryQnAMaker.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Middleware/Telemetry/TelemetryQnAMaker.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Middleware.Telemetry
+{
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Microsoft.Bot.Builder;
+    using Microsoft.Bot.Builder.AI.QnA;
+
+    /// <summary>
+    /// MyAppInsightsQnARecognizer invokes the QnA Maker and logs some results into Application Insights.
+    /// Logs the score, and (optionally) question along with Conversation and ActivityID.
+    ///
+    /// Customize for specific reporting needs.
+    ///
+    /// The Custom Event name this logs is "QnAMessage"
+    /// See <seealso cref="QnAMaker"/> for additional information.
+    /// </summary>
+    public class TelemetryQnaMaker : QnAMaker
+    {
+        public static readonly string QnAMsgEvent = "QnAMessage";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TelemetryQnaMaker"/> class.
+        /// </summary>
+        /// <param name="endpoint">The endpoint of the knowledge base to query.</param>
+        /// <param name="options">The options for the QnA Maker knowledge base.</param>
+        /// <param name="logUserName">Option to log user name to Application Insights (PII consideration).</param>
+        /// <param name="logOriginalMessage">Option to log the original message to Application Insights (PII consideration).</param>
+        /// <param name="httpClient">An alternate client with which to talk to QnAMaker.
+        /// If null, a default client is used for this instance.</param>
+        public TelemetryQnaMaker(QnAMakerEndpoint endpoint, QnAMakerOptions options = null, bool logUserName = true, bool logOriginalMessage = true, HttpClient httpClient = null)
+            : base(endpoint, options, httpClient)
+        {
+            LogUserName = logUserName;
+            LogOriginalMessage = logOriginalMessage;
+            Endpoint = endpoint;
+        }
+
+        public bool LogUserName { get; }
+
+        public bool LogOriginalMessage { get; }
+
+        public QnAMakerEndpoint Endpoint { get; }
+
+        public new async Task<QueryResult[]> GetAnswersAsync(ITurnContext context, QnAMakerOptions options = null)
+        {
+            // Call QnA Maker
+            var queryResults = await base.GetAnswersAsync(context, options);
+
+            // Find the Bot Telemetry Client
+            if (queryResults != null && context.TurnState.TryGetValue(TelemetryLoggerMiddleware.AppInsightsServiceKey, out var telemetryClient))
+            {
+                var telemetryProperties = new Dictionary<string, string>();
+                var telemetryMetrics = new Dictionary<string, double>();
+
+                // For some customers, logging original text name within Application Insights might be an issue.
+                var text = context.Activity.Text;
+                if (LogOriginalMessage && !string.IsNullOrWhiteSpace(text))
+                {
+                    telemetryProperties.Add(QnATelemetryConstants.OriginalQuestionProperty, text);
+                }
+
+                if (LogOriginalMessage && options.StrictFilters.Length > 0)
+                {
+
+                    var metadata = this.GetMetadata(options.StrictFilters);
+                    telemetryProperties.Add(QnATelemetryConstants.OriginalMetadataProperty, metadata);
+                }
+
+                // For some customers, logging user name within Application Insights might be an issue.
+                var userName = context.Activity.From.Name;
+                if (LogUserName && !string.IsNullOrWhiteSpace(userName))
+                {
+                    telemetryProperties.Add(QnATelemetryConstants.UsernameProperty, userName);
+                }
+
+                // Fill in Qna Results (found or not)
+                if (queryResults.Length > 0)
+                {
+                    for (var i = 0; i < queryResults.Length; i++)
+                    {
+                        var queryResult = queryResults[i];
+                        telemetryProperties.Add(QnATelemetryConstants.QuestionProperty + i.ToString(), string.Join(",", queryResult.Questions));
+                        telemetryProperties.Add(QnATelemetryConstants.AnswerProperty + i.ToString(), queryResult.Answer);
+                        telemetryProperties.Add(QnATelemetryConstants.ScoreProperty + i.ToString(), queryResult.Score.ToString());
+                        if (queryResult.Metadata.Length > 0)
+                        {
+                            var metadata = this.GetMetadata(queryResult.Metadata);
+                            telemetryProperties.Add(QnATelemetryConstants.MetadataProperty + i.ToString(), metadata);
+                        }
+                    }
+                }
+                else
+                {
+                    telemetryProperties.Add(QnATelemetryConstants.QuestionProperty, "No Qna Question matched");
+                    telemetryProperties.Add(QnATelemetryConstants.AnswerProperty, "No Qna Question matched");
+                }
+
+                telemetryProperties.Add(TelemetryConstants.FromIdProperty, context.Activity.From.Id);
+                telemetryProperties.Add(TelemetryConstants.FromNameProperty, context.Activity.From.Name);
+                telemetryProperties.Add(SupportBot.Service.TelemetryConstants.ChannelId, context.Activity.ChannelId);
+                telemetryProperties.Add(SupportBot.Service.TelemetryConstants.ActivityId, context.Activity.Id);
+                if (context.Activity.ReplyToId != null)
+                {
+                    telemetryProperties.Add(SupportBot.Service.TelemetryConstants.ReplyToId, context.Activity.ReplyToId);
+                }
+
+                // Track the event
+                ((IBotTelemetryClient)telemetryClient).TrackEvent(QnAMsgEvent, telemetryProperties, telemetryMetrics);
+            }
+
+            return queryResults;
+        }
+
+        private string GetMetadata(Metadata[] metadatas)
+        {
+            var result = string.Empty;
+            foreach (var metadata in metadatas)
+            {
+                result = result + metadata.Name + ":" + metadata.Value + ";";
+            }
+
+            return result;
+        }
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Models/Constants.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Models/Constants.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Models
+{
+    /// <summary>
+    /// Constants for the project.
+    /// </summary>
+    public static class Constants
+    {
+        public static bool EnablePersonalityChat = false;
+        public static bool EnableLuis = false;
+        public static int TotalOptions = 6;
+        public static int ConsecutiveNeuroconAnswersAllowed = 3;
+        public static int MaxContinuousTextDialogs = 3;
+        public static string WelcomeQuestion = @"Hi there! I'm the QnA Maker support bot. What can I help you with today? Just so you know, you can enter MENU anytime you want to go back to the options below or just go ahead type your query.";
+        public static string[] WelcomeOptions = new string[] { "Learn more about QnA Maker", "I am having a problem", "Give feedback" };
+        public static string HeroCardTitle = string.Empty;
+        public static int DefaultTop = 1;
+        public static int ActiveLearningTop = 3;
+        public static float DefaultThreshold = 0.6F;
+        public static float ActiveLearningThreshold = 0.6F;
+        public static float MultiturnThreshold = 0.85F;
+        public static string NeuroconRedirectionQuestion = "redirection Neurocon";
+        public static string GuidedFlowRedirectionQuestion = "redirection GuidedFlow";
+        public static string PersonalityChatKey = string.Empty;
+        public static string EventWelcomeMessage = "EventWelcomeMessage";
+
+        public enum RedirectionType
+        {
+            Neurocon,
+            GuidedFlow,
+            RedirectionIntent
+        }
+
+        public struct MetadataValue
+        {
+            public static string ExcludeIsroot = "no";
+            public static string Welcome = "welcome message";
+            public static string Redirection = "multiturn end";
+            public static string Feedback = "feedback";
+            public static string ChitChat = "chitchat";
+        }
+
+        public struct MetadataName
+        {
+            public static string Requery = "requery";
+            public static string Option = "option";
+            public static string Parent = "parent";
+            public static string Name = "name";
+            public static string Isroot = "isroot";
+            public static string Intent = "intent";
+            public static string Flowtype = "flowtype";
+            public static string OptionRequery = "optionrequery";
+            public static string Editorial = "editorial";
+            public static string ActiveLearning = "suggestion";
+            public static string QnAId = "qnaid";
+        }
+
+        /// <summary>
+        /// This is for handling capitalization while showing options.
+        /// </summary>
+        public struct FormattedWord
+        {
+            public string Original;
+            public string ConvertTo;
+        }
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Models/HandleCaptitalization.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Models/HandleCaptitalization.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Models
+{
+    using System.Collections.Generic;
+    using static SupportBot.Models.Constants;
+
+    /// <summary>
+    /// Since metadata name is lower case only, handle captilalization here.
+    /// </summary>
+    public static class HandleCaptitalization
+    {
+        public static List<FormattedWord> formattedWords = new List<FormattedWord>()
+        {
+            { new FormattedWord { Original = "qna maker", ConvertTo = "QnAMaker" } },
+            { new FormattedWord { Original = "qnamaker", ConvertTo = "QnAMaker" } },
+            { new FormattedWord {Original = "qna", ConvertTo = "QnA" } },
+            { new FormattedWord {Original = "rest api", ConvertTo = "REST API" } },
+            { new FormattedWord {Original = "api", ConvertTo = "API" } },
+            { new FormattedWord {Original = "azure bot service", ConvertTo = "Azure Bot Service" } },
+            { new FormattedWord {Original = "curl", ConvertTo = "CURL" } },
+            { new FormattedWord {Original = "azure search", ConvertTo = "Azure Search" } },
+            { new FormattedWord {Original = @"java/C#/python/node.js/go", ConvertTo = @"Java/C#/Python/Node.js/Go" } },
+            { new FormattedWord {Original = "crud", ConvertTo = "CRUD" } },
+            { new FormattedWord {Original = "cors", ConvertTo = "CORS" } },
+            { new FormattedWord {Original = "luis", ConvertTo = "LUIS" } },
+        };
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Program.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Program.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot
+{
+    using Microsoft.AspNetCore;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Extensions.Logging;
+
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            BuildWebHost(args).Run();
+        }
+
+        public static IWebHost BuildWebHost(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseApplicationInsights()
+                .ConfigureLogging((hostingContext, logging) =>
+                {
+                    // Add Azure Logging
+                    logging.AddAzureWebAppDiagnostics();
+                })
+                .UseStartup<Startup>()
+                .Build();
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Properties/launchSettings.json
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:54789/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "SupportBot": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:54791/"
+    }
+  }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Providers/PersonalityChat/ChatReply.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Providers/PersonalityChat/ChatReply.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Providers.PersonalityChat
+{
+    /// <summary>
+    /// Personality chat reply.
+    /// </summary>
+    public class ChatReply
+    {
+        /// <summary>
+        /// Gets or sets answer from personality chat.
+        /// </summary>
+        public string Text { get; set; }
+
+        /// <summary>
+        /// Gets or sets score from personality chat.
+        /// </summary>
+        public double Score { get; set; }
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Providers/PersonalityChat/PersonalityChatProvider.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Providers/PersonalityChat/PersonalityChatProvider.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Providers.PersonalityChat
+{
+    using System.Net.Http;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Newtonsoft.Json;
+    using SupportBot.Models;
+
+    /// <summary>
+    /// Personality chat provider
+    /// </summary>
+    public class PersonalityChatProvider
+    {
+        /// <summary>
+        /// Gets response from personality chat.
+        /// </summary>
+        /// <param name="query">query.</param>
+        /// <returns>Personality chat response.</returns>
+        internal async Task<PersonalityChatResponse> GetResponse(string query)
+        {
+            var request = new PersonalityChatRequest { Query = query, PersonaName = "Friendly", ResponseCount = 1, Metadata = "{\"RestrictedIntentsEnabled\" : \"false\"} , {\"CheckChat\" : \"true\"}, {\"CheckAdult\" : \"true\"}" };
+            var content = new StringContent(JsonConvert.SerializeObject(request), Encoding.UTF8, "application/json");
+            using (var client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.Add("ocp-apim-subscription-key", Constants.PersonalityChatKey);
+                var result = await client.PostAsync("https://smarttalk.azure-api.net/pc/api/v1/personalitychat", content);
+                var resultContent = await result.Content.ReadAsStringAsync();
+                var response = JsonConvert.DeserializeObject<PersonalityChatResponse>(resultContent);
+                return response;
+            }
+        }
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Providers/PersonalityChat/PersonalityChatRequest.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Providers/PersonalityChat/PersonalityChatRequest.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Providers.PersonalityChat
+{
+    /// <summary>
+    /// Personality chat request.
+    /// </summary>
+    public class PersonalityChatRequest
+    {
+        public string PersonaName { get; set; }
+
+        public string Query { get; set; }
+
+        public int ResponseCount { get; set; }
+
+        public string Metadata { get; set; }
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Providers/PersonalityChat/PersonalityChatResponse.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Providers/PersonalityChat/PersonalityChatResponse.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Providers.PersonalityChat
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Personality chat response.
+    /// </summary>
+    public class PersonalityChatResponse
+    {
+        public List<ChatReply> Responses { get; set; }
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Providers/QnAMaker/ActiveLearning.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Providers/QnAMaker/ActiveLearning.cs
@@ -1,0 +1,175 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Providers.QnAMaker
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Bot.Builder.AI.QnA;
+    using Newtonsoft.Json;
+    using SupportBot.Models;
+
+    public class ActiveLearning
+    {
+        /// <summary>
+        /// Minimum Score For Low Score Variation
+        /// </summary>
+        private const double MinimumScoreForLowScoreVariation = 20.0;
+
+        /// <summary>
+        /// Previous Low Score Variation Multiplier
+        /// </summary>
+        private const double PreviousLowScoreVariationMultiplier = 1.4;
+
+        /// <summary>
+        /// Max Low Score Variation Multiplier
+        /// </summary>
+        private const double MaxLowScoreVariationMultiplier = 2.0;
+
+        /// <summary>
+        /// Maximum Score For Low Score Variation
+        /// </summary>
+        private const double MaximumScoreForLowScoreVariation = 95.0;
+
+        /// <summary>
+        /// Returns list of qnaSearch results which have low score variation
+        /// </summary>
+        /// <param name="qnaSearchResults">List of QnaSearch results</param>
+        /// <returns>List of filtered qnaSearch results</returns>
+        public static List<QueryResult> GetLowScoreVariation(List<QueryResult> qnaSearchResults)
+        {
+            var filteredQnaSearchResult = new List<QueryResult>();
+
+            if (qnaSearchResults == null || qnaSearchResults.Count == 0)
+            {
+                return filteredQnaSearchResult;
+            }
+
+            if (qnaSearchResults.Count == 1)
+            {
+                return qnaSearchResults;
+            }
+
+            var topAnswerScore = qnaSearchResults[0].Score * 100;
+            var prevScore = topAnswerScore;
+
+            if ((topAnswerScore > MinimumScoreForLowScoreVariation) && (topAnswerScore < MaximumScoreForLowScoreVariation))
+            {
+                filteredQnaSearchResult.Add(qnaSearchResults[0]);
+
+                for (var i = 1; i < qnaSearchResults.Count; i++)
+                {
+                    if (IncludeForClustering(prevScore, qnaSearchResults[i].Score * 100, PreviousLowScoreVariationMultiplier) && IncludeForClustering(topAnswerScore, qnaSearchResults[i].Score * 100, MaxLowScoreVariationMultiplier))
+                    {
+                        prevScore = qnaSearchResults[i].Score * 100;
+                        filteredQnaSearchResult.Add(qnaSearchResults[i]);
+                    }
+                }
+            }
+
+            return filteredQnaSearchResult;
+        }
+
+        /// <summary>
+        /// Call tarin API.
+        /// </summary>
+        /// <param name="activeLearningData">Active Learning Data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public async static void CallTrainApi(ActiveLearningDTO activeLearningData, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var records = new FeedbackRecord[]
+            {
+                 new FeedbackRecord()
+                {
+                    QnaId = activeLearningData.qnaId,
+                    UserQuestion = activeLearningData.userQuestion,
+                },
+            };
+            var feedbackRecords = new FeedbackRecords { Records = records };
+
+            var uri = activeLearningData.hostName + "/knowledgebases/" + activeLearningData.kbid + "/train/";
+
+            try
+            {
+                using (var client = new HttpClient())
+                {
+                    using (var request = new HttpRequestMessage())
+                    {
+                        request.Method = HttpMethod.Post;
+                        request.RequestUri = new Uri(uri);
+                        request.Content = new StringContent(JsonConvert.SerializeObject(feedbackRecords), Encoding.UTF8, "application/json");
+                        request.Headers.Add("Authorization", "EndpointKey " + activeLearningData.endpointKey);
+
+                        var response = await client.SendAsync(request, cancellationToken);
+                        await response.Content.ReadAsStringAsync();
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // TODO : Log exception
+            }
+        }
+
+        /// <summary>
+        /// Returns Active learning response
+        /// </summary>
+        /// <param name="responseCandidates">List of QnaSearch results</param>
+        /// <returns>Array of filtered qnaSearch results</returns>
+        public static QueryResult GenerateResponse(List<QueryResult> responseCandidates)
+        {
+            var finalResponse = new QueryResult();
+            var finalMetadatas = new List<Metadata>();
+            var count = 1;
+            foreach (var response in responseCandidates)
+            {
+                finalResponse.Answer = "Do you mean : ";
+                var optionPrompt = response.Metadata.Where(m => m.Name.Equals(Constants.MetadataName.ActiveLearning, StringComparison.OrdinalIgnoreCase));
+                string question = null;
+                if (optionPrompt != null && optionPrompt.Count() != 0 && optionPrompt.First().Value != null)
+                {
+                    question = optionPrompt.First().Value;
+                }
+
+                var metadataOption = new Metadata()
+                {
+                    Name = Constants.MetadataName.Option + count.ToString(),
+                    Value = string.IsNullOrEmpty(question) ? response.Questions[0] : question,
+                };
+                finalMetadatas.Add(metadataOption);
+                var requeryMetadata = response.Metadata.Where(m => m.Name.Equals(Constants.MetadataName.Requery + count.ToString(), StringComparison.OrdinalIgnoreCase));
+                if (requeryMetadata != null && requeryMetadata.Count() != 0 && requeryMetadata.First().Value != null)
+                {
+                    var metadataRequery = new Metadata()
+                    {
+                        Name = Constants.MetadataName.Requery + count.ToString(),
+                        Value = requeryMetadata.First().Value,
+                    };
+                    finalMetadatas.Add(metadataRequery);
+                }
+
+                var metadataQnAId = new Metadata()
+                {
+                    Name = Constants.MetadataName.QnAId + count.ToString(),
+                    Value = response.Id.ToString(),
+                };
+                finalMetadatas.Add(metadataQnAId);
+
+                count++;
+            }
+
+            finalResponse.Metadata = finalMetadatas.ToArray();
+            return finalResponse;
+        }
+
+        private static bool IncludeForClustering(double prevScore, double currentScore, double multiplier)
+        {
+            return (prevScore - currentScore) < (multiplier * Math.Sqrt(prevScore));
+        }
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Providers/QnAMaker/ActiveLearningDTO.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Providers/QnAMaker/ActiveLearningDTO.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Providers.QnAMaker
+{
+    /// <summary>
+    /// DTO for Active Learning.
+    /// </summary>
+    public class ActiveLearningDTO
+    {
+        public string userQuestion { get; set; }
+
+        public int qnaId { get; set; }
+
+        public string hostName { get; set; }
+
+        public string kbid { get; set; }
+
+        public string endpointKey { get; set; }
+
+        public string userId { get; set; }
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Providers/QnAMaker/FeedbackRecord.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Providers/QnAMaker/FeedbackRecord.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Providers.QnAMaker
+{
+    /// <summary>
+    /// Active learning feedback record.
+    /// </summary>
+        public class FeedbackRecord
+    {
+        /// <summary>
+        /// Gets or sets User id.
+        /// </summary>
+        public string UserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets User question.
+        /// </summary>
+        public string UserQuestion { get; set; }
+
+        /// <summary>
+        /// Gets or sets QnA Id.
+        /// </summary>
+        public int QnaId { get; set; }
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Providers/QnAMaker/FeedbackRecords.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Providers/QnAMaker/FeedbackRecords.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Providers.QnAMaker
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Active learning feedback records.
+    /// </summary>
+    public class FeedbackRecords
+    {
+        /// <summary>
+        /// Gets or sets List of feedback records.
+        /// </summary>
+        [JsonProperty("feedbackRecords")]
+        public FeedbackRecord[] Records { get; set; }
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Providers/QnAMaker/PromptOption.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Providers/QnAMaker/PromptOption.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Providers.QnAMaker
+{
+    /// <summary>
+    /// Prompt option.
+    /// </summary>
+    public class PromptOption
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PromptOption"/> class.
+        /// </summary>
+        public PromptOption()
+        {
+            Option = null;
+            Requery = null;
+            QnAId = 0;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PromptOption"/> class.
+        /// </summary>
+        /// <param name="option">option text.</param>
+        /// <param name="requery">requesry text.</param>
+        /// <param name="qnaId">qna ID.</param>
+        public PromptOption(string option, string requery = null, int qnaId = 0)
+        {
+            Option = option;
+            Requery = requery;
+            QnAId = qnaId;
+        }
+
+        /// <summary>
+        /// Gets or sets Option text.
+        /// </summary>
+        public string Option { get; set; }
+
+        /// <summary>
+        /// Gets or sets Requery text.
+        /// </summary>
+        public string Requery { get; set; }
+
+        /// <summary>
+        /// Gets or sets QnA Id - required for train api call.
+        /// </summary>
+        public int QnAId { get; set; }
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Providers/QnAMaker/QnAMakerAnswer.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Providers/QnAMaker/QnAMakerAnswer.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Providers.QnAMaker
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Holds all relevant information for QnaMaker Answer.
+    /// </summary>
+    public class QnAMakerAnswer
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QnAMakerAnswer"/> class.
+        /// </summary>
+        public QnAMakerAnswer()
+        {
+            Text = null;
+            Requery = null;
+            Options = new List<PromptOption>();
+            IsRoot = "yes";
+            Parent = null;
+            Name = null;
+            Flowtype = null;
+            IsChitChat = false;
+            QnAId = 0;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QnAMakerAnswer"/> class.
+        /// </summary>
+        /// <param name="text">Answeer text.</param>
+        /// <param name="requery">Requery text.</param>
+        /// <param name="options">Options.</param>
+        public QnAMakerAnswer(string text, string requery = null, List<PromptOption> options = null)
+        {
+            Text = text;
+            Requery = requery;
+            Options = options ?? new List<PromptOption>();
+            IsChitChat = false;
+        }
+
+        /// <summary>
+        /// Gets or sets Answer text.
+        /// </summary>
+        public string Text { get; set; }
+
+        /// <summary>
+        /// Gets or sets requery text.
+        /// </summary>
+        public string Requery { get; set; }
+
+        /// <summary>
+        /// Gets or sets list of prompt options.
+        /// </summary>
+        public List<PromptOption> Options { get; set; }
+
+        /// <summary>
+        /// Gets or sets Parent metadata value.
+        /// </summary>
+        public string Parent { get; set; }
+
+        /// <summary>
+        /// Gets or sets Name metadata value.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets IsRoot metadata value.
+        /// </summary>
+        public string IsRoot { get; set; }
+
+        /// <summary>
+        /// Gets or sets Flowtype metadata value.
+        /// </summary>
+        public string Flowtype { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether chitchat is triggered.
+        /// </summary>
+        public bool IsChitChat { get; set; }
+
+        /// <summary>
+        /// Gets or sets QnAId.
+        /// </summary>
+        public int QnAId { get; set; }
+
+        /// <summary>
+        /// Compares if answers are equal.
+        /// </summary>
+        /// <param name="answer">QnAMaker answer.</param>
+        /// <returns>true if equal.</returns>
+        public bool IsEqual(QnAMakerAnswer answer)
+        {
+            var isEqual = true;
+            if (!answer.Text.Equals(this.Text))
+            {
+                isEqual = false;
+            }
+
+            foreach (var currentoption in answer.Options)
+            {
+                if (!this.Options.Exists(s => s.Option.Equals(currentoption.Option)))
+                {
+                    isEqual = false;
+                }
+            }
+
+            return isEqual;
+        }
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/README.md
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/README.md
@@ -1,0 +1,74 @@
+﻿# Active learning in QnA Maker
+This sample shows how to integrate Active Learning in a QnA Maker bot with ASP.Net Core 2.
+
+#Concepts introduced in this sample
+The [QnA Maker Service][7] enables you to build, train and publish a simple question and answer bot based on FAQ URLs, structured documents or editorial content in minutes.
+In this sample, we demonstrate how to use the Active Learning to generate suggestions for knowledge base.
+
+#To try this sample
+- Clone the samples repository
+- [Optional] Update the appsettings.json file under BotBuilder-Samples/experimental/csharp_dotnetcore/qnamaker-activelearning-bot/ with your botFileSecret. For Azure Bot Service bots, you can find the botFileSecret under application settings.
+
+# Prerequisites
+- Follow instructions [here](https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/how-to/set-up-qnamaker-service-azure)
+to create a QnA Maker service.
+- Follow instructions [here](https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/quickstarts/create-publish-knowledge-base) to
+import and publish the [ActiveLearningSampleFAQ.tsv](CognitiveModels/ActiveLearningSampleFAQ.tsv) to your newly created QnA Maker service.
+- Update [qnamaker-activelearning.bot](qnamaker-activelearning.bot) with your kbid (KnowledgeBase Id) and endpointKey in the "qna" services section. You can find this
+information under "Settings" tab for your QnA Maker Knowledge Base at [QnAMaker.ai](https://www.qnamaker.ai)
+- (Optional) Follow instructions [here](https://github.com/Microsoft/botbuilder-tools/tree/master/packages/QnAMaker) to set up the
+QnA Maker CLI to deploy the model.
+
+# Running Locally
+
+## Visual Studio
+- Open qnamaker-activelearning-bot.sln in Visual Studio.
+- Run the project (press `F5` key).
+
+## Testing the bot using Bot Framework Emulator
+[Microsoft Bot Framework Emulator][5] is a desktop application that allows bot 
+developers to test and debug their bots on localhost or running remotely through a tunnel.
+- Install the [Bot Framework emulator][6].
+
+## Connect to bot using Bot Framework Emulator **V4**
+- Launch the Bot Framework Emulator.
+- File -> Open bot and open [qnamaker-activelearning.bot](qnamaker-activelearning.bot).
+
+# Try Active Learning
+- Once your QnA Maker service is up and you have published the sample KB, try the following queries to trigger the Train API on the bot.
+- Sample queries: "surface pro 4", "apps on your surface pro"
+
+# Deploy the bot to Azure
+See [Deploy your C# bot to Azure][50] for instructions.
+
+The deployment process assumes you have an account on Microsoft Azure and are able to log into the [Microsoft Azure Portal][60].
+
+If you are new to Microsoft Azure, please refer to [Getting started with Azure][70] for guidance on how to get started on Azure.
+
+# Further reading
+* [Bot Framework Documentation][80]
+* [Bot Basics][90]
+* [Azure Bot Service Introduction][100]
+* [Azure Bot Service Documentation][110]
+* [msbot CLI][130]
+* [Azure Portal][140]
+
+[1]: https://dev.botframework.com
+[2]: https://docs.microsoft.com/en-us/visualstudio/releasenotes/vs2017-relnotes
+[3]: https://dotnet.microsoft.com/download/dotnet-core/2.1
+[4]: https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0
+[5]: https://github.com/microsoft/botframework-emulator
+[6]: https://aka.ms/botframeworkemulator
+[7]: https://www.qnamaker.ai
+
+[50]: https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-deploy-azure?view=azure-bot-service-4.0
+[60]: https://portal.azure.com
+[70]: https://azure.microsoft.com/get-started/
+[80]: https://docs.botframework.com
+[90]: https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-basics?view=azure-bot-service-4.0
+[100]: https://docs.microsoft.com/en-us/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0
+[110]: https://docs.microsoft.com/en-us/azure/bot-service/?view=azure-bot-service-4.0
+[120]: https://docs.microsoft.com/en-us/cli/azure/?view=azure-cli-latest
+[130]: https://github.com/Microsoft/botbuilder-tools/tree/master/packages/MSBot
+[140]: https://portal.azure.com
+[150]: https://www.luis.ai

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/README.md
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/README.md
@@ -8,13 +8,13 @@ It uses application insights for logging details.
 
 This sample can also optionally use [Personality chat][160] to chat with the user if no match is found in QnA Maker. 
 
-It can optionally use [LUIS] [150] model to get the trained intent.
+It can optionally use [LUIS][150] model to get the trained intent.
 
 # To try this sample
 - Clone the samples repository
 - Update BotConfiguration.bot file with your kbid (KnowledgeBase Id) and endpointKey in the "qna" services section. You can find this information under "Settings" tab for your QnA Maker Knowledge Base at [QnAMaker.ai](https://www.qnamaker.ai)
-- Update BotConfiguration.bot file with Application insights instrumentation keys and app id. Refer [here] [170] for details.
-- [Optional] If you want to use LUIS, add the following to the BotConfiguration.bot file and update the LUIS details. Refer [here] [180] for details.
+- Update BotConfiguration.bot file with Application insights instrumentation keys and app id. Refer [here][170] for details.
+- [Optional] If you want to use LUIS, add the following to the BotConfiguration.bot file and update the LUIS details. Refer [here][180] for details.
 {
       "type": "luis",
       "name": "LuisBot",
@@ -26,7 +26,7 @@ It can optionally use [LUIS] [150] model to get the trained intent.
       "id": "158"
     },
     Also, add EnableLuis = true in Models/Constants.cs file
-- [Optional] If you are using [personality chat] [160], add this line to appsettings.json file:
+- [Optional] If you are using [personality chat][160], add this line to appsettings.json file:
 "personalityChatKey": "<Your PersonalityChat Key>" and make EnablePersonalityChat = true in Models/Constants.cs file
 - [Optional] Update the appsettings.json file under BotBuilder-Samples/experimental/csharp_dotnetcore/qnamaker-activelearning-bot/ with your botFileSecret. For Azure Bot Service bots, you can find the botFileSecret under application settings.
 

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/README.md
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/README.md
@@ -1,21 +1,38 @@
-﻿# Active learning in QnA Maker
-This sample shows how to integrate Active Learning in a QnA Maker bot with ASP.Net Core 2.
+# Support Bot in QnA Maker
+This sample demonstrates how to create a multiturn support bot with ASP.Net Core 2.
 
-#Concepts introduced in this sample
-The [QnA Maker Service][7] enables you to build, train and publish a simple question and answer bot based on FAQ URLs, structured documents or editorial content in minutes.
-In this sample, we demonstrate how to use the Active Learning to generate suggestions for knowledge base.
+This sample shows how to:
+Use QnA Maker to create a multiturn support bot.It also uses active learning feature of QnA Maker to generate suggestions and use them to further train the knowledge base. 
 
-#To try this sample
+It uses application insights for logging details.
+
+This sample can also optionally use [Personality chat][160] to chat with the user if no match is found in QnA Maker. 
+
+It can optionally use [LUIS] [150] model to get the trained intent.
+
+# To try this sample
 - Clone the samples repository
+- Update BotConfiguration.bot file with your kbid (KnowledgeBase Id) and endpointKey in the "qna" services section. You can find this information under "Settings" tab for your QnA Maker Knowledge Base at [QnAMaker.ai](https://www.qnamaker.ai)
+- Update BotConfiguration.bot file with Application insights instrumentation keys and app id. Refer [here] [170] for details.
+- [Optional] If you want to use LUIS, add the following to the BotConfiguration.bot file and update the LUIS details. Refer [here] [180] for details.
+{
+      "type": "luis",
+      "name": "LuisBot",
+      "appId": "<Your App Id>",
+      "version": "0.1",
+      "authoringKey": "<Your Authoring Key>",
+      "subscriptionKey": "<Your Subscription Key>",
+      "region": "<Your region>",
+      "id": "158"
+    },
+    Also, add EnableLuis = true in Models/Constants.cs file
+- [Optional] If you are using [personality chat] [160], add this line to appsettings.json file:
+"personalityChatKey": "<Your PersonalityChat Key>" and make EnablePersonalityChat = true in Models/Constants.cs file
 - [Optional] Update the appsettings.json file under BotBuilder-Samples/experimental/csharp_dotnetcore/qnamaker-activelearning-bot/ with your botFileSecret. For Azure Bot Service bots, you can find the botFileSecret under application settings.
 
 # Prerequisites
 - Follow instructions [here](https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/how-to/set-up-qnamaker-service-azure)
 to create a QnA Maker service.
-- Follow instructions [here](https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/quickstarts/create-publish-knowledge-base) to
-import and publish the [ActiveLearningSampleFAQ.tsv](CognitiveModels/ActiveLearningSampleFAQ.tsv) to your newly created QnA Maker service.
-- Update [qnamaker-activelearning.bot](qnamaker-activelearning.bot) with your kbid (KnowledgeBase Id) and endpointKey in the "qna" services section. You can find this
-information under "Settings" tab for your QnA Maker Knowledge Base at [QnAMaker.ai](https://www.qnamaker.ai)
 - (Optional) Follow instructions [here](https://github.com/Microsoft/botbuilder-tools/tree/master/packages/QnAMaker) to set up the
 QnA Maker CLI to deploy the model.
 
@@ -60,7 +77,6 @@ If you are new to Microsoft Azure, please refer to [Getting started with Azure][
 [5]: https://github.com/microsoft/botframework-emulator
 [6]: https://aka.ms/botframeworkemulator
 [7]: https://www.qnamaker.ai
-
 [50]: https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-deploy-azure?view=azure-bot-service-4.0
 [60]: https://portal.azure.com
 [70]: https://azure.microsoft.com/get-started/
@@ -72,3 +88,6 @@ If you are new to Microsoft Azure, please refer to [Getting started with Azure][
 [130]: https://github.com/Microsoft/botbuilder-tools/tree/master/packages/MSBot
 [140]: https://portal.azure.com
 [150]: https://www.luis.ai
+[160]: https://labs.cognitive.microsoft.com/en-us/project-personality-chat
+[170]: https://docs.microsoft.com/en-us/azure/bot-service/bot-service-resources-app-insights-keys?view=azure-bot-service-4.0
+[180]: https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-concept-keys 

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Service/BotServices.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Service/BotServices.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License
+
+namespace SupportBot.Service
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.ApplicationInsights;
+    using Microsoft.Bot.Builder.AI.Luis;
+    using Microsoft.Bot.Builder.AI.QnA;
+    using SupportBot.Middleware.Telemetry;
+
+    /// <summary>
+    /// Represents references to external services.
+    /// For example, the QnA Maker service is kept here as a singleton. This external service is configured
+    /// using the <see cref="Microsoft.Bot.Configuration.BotConfiguration"/> class
+    /// (based on the contents of your ".bot" file).
+    /// </summary>
+    public class BotServices
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BotServices"/> class.
+        /// </summary>
+        /// <param name="qnaServices">A dictionary of named <see cref="QnAMaker"/> instances for usage within the bot.</param>
+        public BotServices(Dictionary<string, TelemetryQnaMaker> qnaServices, Dictionary<string, LuisRecognizer> luisServices, TelemetryClient telemetryClient)
+        {
+            QnAServices = qnaServices ?? throw new ArgumentNullException(nameof(qnaServices));
+            LuisServices = luisServices ?? throw new ArgumentNullException(nameof(luisServices));
+            TelemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
+
+        }
+
+        /// <summary>
+        /// Gets the set of QnA Maker services used.
+        /// Given there can be multiple <see cref="QnAMaker"/> services used in a single bot,
+        /// QnA Maker instances are represented as a Dictionary.  This is also modeled in the
+        /// ".bot" file using named elements.
+        /// </summary>
+        /// <remarks>The QnA Maker services collection should not be modified while the bot is running.</remarks>
+        /// <value>
+        /// A <see cref="QnAMaker"/> client instance created based on configuration in the .bot file.
+        /// </value>
+        public Dictionary<string, TelemetryQnaMaker> QnAServices { get; } = new Dictionary<string, TelemetryQnaMaker>();
+
+        /// <summary>
+        /// Gets the set of LUIS services used.
+        /// Given there can be multiple <see cref="LuisServices"/> services used in a single bot,
+        /// LUIS service instances are represented as a Dictionary.  This is also modeled in the
+        /// ".bot" file using named elements.
+        /// </summary>
+        /// <remarks>The LUIS services collection should not be modified while the bot is running.</remarks>
+        /// <value>
+        /// A <see cref="LuisRecognizer"/> client instance created based on configuration in the .bot file.
+        /// </value>
+        public Dictionary<string, LuisRecognizer> LuisServices { get; } = new Dictionary<string, LuisRecognizer>();
+
+        public TelemetryClient TelemetryClient { get; set; }
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Service/SupportBotService.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Service/SupportBotService.cs
@@ -1,0 +1,589 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Service
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Bot.Builder;
+    using Microsoft.Bot.Builder.AI.QnA;
+    using Microsoft.Bot.Builder.Dialogs;
+    using Microsoft.Bot.Builder.Dialogs.Choices;
+    using Microsoft.Bot.Schema;
+    using Microsoft.Recognizers.Text;
+    using SupportBot.Dialogs.ShowQnAResult;
+    using SupportBot.Providers.PersonalityChat;
+    using SupportBot.Providers.QnAMaker;
+    using Constants = SupportBot.Models.Constants;
+
+    /// <summary>
+    /// For each interaction from the user, an instance of this class is created and
+    /// the OnTurnAsync method is called.
+    /// This is a Transient lifetime service. Transient lifetime services are created
+    /// each time they're requested. For each Activity received, a new instance of this
+    /// class is created. Objects that are expensive to construct, or have a lifetime
+    /// beyond the single Turn, should be carefully managed.
+    /// </summary>
+    public class SupportBotService : IBot
+    {
+        /// <summary>
+        /// Key in the bot config (.bot file) for the QnA Maker instance.
+        /// In the ".bot" file, multiple instances of QnA Maker can be configured.
+        /// </summary>
+        public static readonly string QnAMakerKey = "QnABot";
+        public static readonly string LuisKey = "LuisBot";
+
+        /// <summary>
+        /// Services configured from the ".bot" file.
+        /// </summary>
+        private readonly BotServices _services;
+        private readonly ShowQnAResultAccessor _accessors;
+        private DialogSet dialogs;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SupportBotService"/> class.
+        /// </summary>
+        /// <param name="services">A <see cref="BotServices"/> configured from the ".bot" file.</param>
+        /// <param name="accessor">Show QnA Result Accessor.</param>
+        public SupportBotService(BotServices services, ShowQnAResultAccessor accessor)
+        {
+            _services = services ?? throw new System.ArgumentNullException(nameof(services));
+            if (!_services.QnAServices.ContainsKey(QnAMakerKey))
+            {
+                throw new System.ArgumentException($"Invalid configuration. Please check your '.bot' file for a QnA service named '{QnAMakerKey}'.");
+            }
+
+            if (Constants.EnableLuis && !_services.LuisServices.ContainsKey(LuisKey))
+            {
+                throw new System.ArgumentException($"Invalid configuration. Please check your '.bot' file for a Luis service named '{LuisKey}'.");
+            }
+
+            _accessors = accessor ?? throw new System.ArgumentNullException(nameof(accessor));
+            dialogs = new DialogSet(_accessors.ConversationDialogState);
+            var choicePrompt = new ChoicePrompt("choicePrompt");
+            choicePrompt.Style = ListStyle.SuggestedAction;
+            choicePrompt.DefaultLocale = Culture.English;
+            dialogs.Add(choicePrompt);
+            dialogs.Add(new ChoicePrompt("cardPrompt"));
+        }
+
+        /// <summary>
+        /// Every conversation turn for our QnA bot will call this method.
+        /// There are no dialogs used, the sample only uses "single turn" processing,
+        /// meaning a single request and response, with no stateful conversation.
+        /// </summary>
+        /// <param name="turnContext">A <see cref="ITurnContext"/> containing all the data needed
+        /// for processing this conversation turn. </param>
+        /// <param name="cancellationToken">(Optional) A <see cref="CancellationToken"/> that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> that represents the work queued to execute.</returns>
+        /// <seealso cref="BotStateSet"/>
+        /// <seealso cref="ConversationState"/>
+        /// <seealso cref="IMiddleware"/>
+        public async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Handle Message activity type, which is the main activity type for shown within a conversational interface
+            // Message activities may contain text, speech, interactive cards, and binary or unknown attachments.
+            // see https://aka.ms/about-bot-activity-message to learn more about the message and other activity types
+            if (turnContext.Activity.Type == ActivityTypes.Message)
+            {
+                var dialogContext = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+                var qnastatus = await _accessors.QnAResultState.GetAsync(turnContext, () => new ShowQnAResultState());
+                if (qnastatus.IsFeedback)
+                {
+                    await HandleFeedbackFlow(qnastatus, turnContext, cancellationToken);
+                }
+
+                string requery = null;
+                if (qnastatus.ConsiderState)
+                {
+                    // Call Active Learning Train API
+                    if (qnastatus.ActiveLearningAnswer)
+                    {
+                        _services.QnAServices.TryGetValue(QnAMakerKey, out var qnaservice);
+                        var activeLearningData = new ActiveLearningDTO()
+                        {
+                            hostName = qnaservice.Endpoint.Host,
+                            endpointKey = qnaservice.Endpoint.EndpointKey,
+                            kbid = qnaservice.Endpoint.KnowledgeBaseId,
+                            userId = turnContext.Activity.From.Id,
+                            userQuestion = qnastatus.ActiveLearningUserQuestion,
+                        };
+
+                        requery = Utils.GetRequery(qnastatus, turnContext.Activity.Text, activeLearningData);
+                        if (requery != null)
+                        {
+                            TelemetryUtils.LogTrainApiResponse(this._services.TelemetryClient, TelemetryConstants.TrainApiEvent, turnContext.Activity, activeLearningData, requery);
+                        }
+                    }
+                    else
+                    {
+                        requery = Utils.GetRequery(qnastatus, turnContext.Activity.Text);
+                    }
+
+                    if (requery != null)
+                    {
+                        turnContext.Activity.Text = requery;
+                    }
+                }
+
+                QueryResult responseGeneral = null, responseLuis = null;
+
+                // Get QnA Answer for multiturn
+                var responseMultiturn = await GetMultiturnResponseFromKB(turnContext, qnastatus.QnaAnswer);
+                if (responseMultiturn == null)
+                {
+                    // Get general response from KB
+                    responseGeneral = await GetGeneralResponseFromKB(turnContext, qnastatus, true);
+                    if (responseGeneral == null)
+                    {
+                        // Get LUIS intent
+                        var luisIntent = await GetLuisIntent(turnContext, Constants.EnableLuis);
+                        if (!luisIntent.Equals("None"))
+                        {
+                            // Get Luis response
+                            responseLuis = await GetResponseWithLuisIntent(turnContext, luisIntent);
+                        }
+                    }
+                }
+
+                // choose response
+                var qnaresponse = Utils.SelectResponse(responseMultiturn, responseGeneral, responseLuis, qnastatus.QnaAnswer);
+                if (qnaresponse != null)
+                {
+                    if (qnaresponse.Options != null && qnaresponse.Options.Count != 0)
+                    {
+                        await ShowQnAResponseWithOptions(turnContext, qnaresponse, qnastatus);
+                    }
+                    else
+                    {
+                        await ShowQnAResponseWithText(turnContext, qnaresponse, qnastatus);
+                    }
+
+                    if (qnastatus.QnaAnswer.Name == Constants.MetadataValue.Redirection)
+                    {
+                        await ShowRedirection(Constants.RedirectionType.GuidedFlow, turnContext, cancellationToken);
+                    }
+
+                    if (qnastatus.NeuroconCount >= Constants.ConsecutiveNeuroconAnswersAllowed)
+                    {
+                        await ShowRedirection(Constants.RedirectionType.Neurocon, turnContext, cancellationToken);
+                    }
+                }
+                else
+                {
+                    // get answer from Nurocon
+                    var personalitychatanswer = await SendCognitiveServicesResponse(turnContext, cancellationToken, Constants.EnablePersonalityChat);
+                    if (personalitychatanswer == string.Empty || personalitychatanswer.Equals(@"Sorry, I don't have a response for that.", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var msg = @"I don't have an answer for that. Try typing MENU to go back to the main menu";
+                        TelemetryUtils.LogNoAnswerEvent(this._services.TelemetryClient, turnContext.Activity);
+                        qnastatus.NeuroconCount++;
+                        await _accessors.QnAResultState.SetAsync(turnContext, qnastatus);
+                        await _accessors.ConversationState.SaveChangesAsync(turnContext);
+                        await turnContext.SendActivityAsync(msg, cancellationToken: cancellationToken);
+                        if (qnastatus.NeuroconCount >= Constants.ConsecutiveNeuroconAnswersAllowed)
+                        {
+                            await ShowRedirection(Constants.RedirectionType.Neurocon, turnContext, cancellationToken);
+                        }
+                    }
+                    else
+                    {
+                        personalitychatanswer = personalitychatanswer + " [&#x1f6c8;](https://labs.cognitive.microsoft.com/en-us/project-personality-chat \"Auto generated answer using Personality chat. Click to know more\")";
+                        qnastatus.ConsiderState = false;
+                        qnastatus.QnaAnswer = null;
+                        qnastatus.NeuroconCount++;
+                        TelemetryUtils.LogNeuroconResponse(this._services.TelemetryClient, TelemetryConstants.NeuroconEvent, turnContext.Activity, qnastatus, personalitychatanswer);
+                        await _accessors.QnAResultState.SetAsync(turnContext, qnastatus);
+                        await _accessors.ConversationState.SaveChangesAsync(turnContext);
+                        await turnContext.SendActivityAsync(personalitychatanswer, cancellationToken: cancellationToken);
+                        if (qnastatus.NeuroconCount >= Constants.ConsecutiveNeuroconAnswersAllowed)
+                        {
+                            await ShowRedirection(Constants.RedirectionType.Neurocon, turnContext, cancellationToken);
+                        }
+                    }
+                }
+            }
+            else if (turnContext.Activity.Type == ActivityTypes.ConversationUpdate)
+            {
+                return;
+            }
+            else if (turnContext.Activity.Type == ActivityTypes.Event)
+            {
+                // Send a welcome message to the user.
+                var eventActivity = turnContext.Activity.AsEventActivity();
+                if (eventActivity.Name == Constants.EventWelcomeMessage)
+                {
+                    TelemetryUtils.LogWelcomeResponse(this._services.TelemetryClient, "Welcome Event Detected", turnContext.Activity);
+                    var dialogContext = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+                    var qnastatus = await _accessors.QnAResultState.GetAsync(turnContext, () => new ShowQnAResultState());
+                    qnastatus.ConsiderState = false;
+                    qnastatus.QnaAnswer.Text = Constants.WelcomeQuestion;
+                    qnastatus.QnaAnswer.Name = Constants.MetadataValue.Welcome;
+                    await _accessors.QnAResultState.SetAsync(turnContext, qnastatus);
+                    await _accessors.ConversationState.SaveChangesAsync(turnContext);
+                    await SendWelcomeMessageAsync(turnContext, cancellationToken);
+                }
+            }
+            else
+            {
+                await turnContext.SendActivityAsync($"{turnContext.Activity.Type} event detected", cancellationToken: cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Greet new users as they are added to the conversation.
+        /// </summary>
+        /// <param name="turnContext">A <see cref="ITurnContext"/> containing all the data needed
+        /// for processing this conversation turn. </param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> that represents the work queued to execute.</returns>
+        private async Task SendWelcomeMessageAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        {
+            var cardButtons = new List<CardAction>();
+            foreach (var promptoption in Constants.WelcomeOptions)
+            {
+                var card = new CardAction()
+                {
+                    Value = promptoption,
+                    Type = ActionTypes.ImBack,
+                    Title = promptoption,
+                };
+                cardButtons.Add(card);
+            }
+
+            var heroCard = new HeroCard
+            {
+                Title = Constants.HeroCardTitle,
+                Text = Constants.WelcomeQuestion,
+                Buttons = cardButtons,
+            };
+            var cardActivity = Activity.CreateMessageActivity();
+            cardActivity.AttachmentLayout = AttachmentLayoutTypes.Carousel;
+            var cardAttachment = heroCard.ToAttachment();
+            cardActivity.Attachments.Add(cardAttachment);
+            await turnContext.SendActivityAsync(cardActivity, cancellationToken);
+        }
+
+        private async Task<string> SendCognitiveServicesResponse(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken), bool enableNeurocon = false)
+        {
+            var personalilitychatanswer = string.Empty;
+            if (!enableNeurocon)
+            {
+                return personalilitychatanswer;
+            }
+            else
+            {
+                var personalityChatProvider = new PersonalityChatProvider();
+                var personalityChatResponse = await personalityChatProvider.GetResponse(turnContext.Activity.Text);
+                if (personalityChatResponse.Responses.Count > 0)
+                {
+                    var personaResponse = personalityChatResponse.Responses[0];
+                    personalilitychatanswer = personaResponse.Text;
+                }
+            }
+
+            return personalilitychatanswer;
+        }
+
+        private async Task<QueryResult> GetMultiturnResponseFromKB(ITurnContext turnContext, QnAMakerAnswer previousAnswer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (previousAnswer == null || string.IsNullOrEmpty(previousAnswer.Name))
+            {
+                return null;
+            }
+
+            var qnaOptions = new QnAMakerOptions();
+            var metadata = new Microsoft.Bot.Builder.AI.QnA.Metadata();
+
+            metadata.Name = Constants.MetadataName.Parent;
+            metadata.Value = previousAnswer.Name;
+            qnaOptions.StrictFilters = new Microsoft.Bot.Builder.AI.QnA.Metadata[] { metadata };
+            qnaOptions.Top = Constants.DefaultTop;
+            qnaOptions.ScoreThreshold = Constants.MultiturnThreshold;
+            var response = await _services.QnAServices[QnAMakerKey].GetAnswersAsync(turnContext, qnaOptions);
+            if (response != null && response.GetLength(0) != 0 && response[0].Score >= Constants.MultiturnThreshold)
+            {
+                return response[0];
+            }
+
+            return null;
+        }
+
+        private async Task<QueryResult> GetGeneralResponseFromKB(ITurnContext turnContext, ShowQnAResultState qnaStatus, bool considerActiveLearning = false, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var qnaOptions = new QnAMakerOptions();
+            if (considerActiveLearning)
+            {
+                qnaOptions.Top = Constants.ActiveLearningTop;
+                qnaOptions.ScoreThreshold = Constants.ActiveLearningThreshold;
+            }
+            else
+            {
+                qnaOptions.Top = Constants.DefaultTop;
+                qnaOptions.ScoreThreshold = Constants.DefaultThreshold;
+            }
+
+            var response = await _services.QnAServices[QnAMakerKey].GetAnswersAsync(turnContext, qnaOptions);
+            if (response != null && response.GetLength(0) != 0 && response[0].Score >= Constants.DefaultThreshold)
+            {
+                if (response.GetLength(0) == 1 || !considerActiveLearning || response[0].Score > 0.95F)
+                {
+                    return response[0];
+                }
+
+                var activeLearningResponse = HandleActiveLearning(response, qnaStatus, turnContext.Activity.Text);
+                TelemetryUtils.LogActiveLearningResponse(this._services.TelemetryClient, TelemetryConstants.ActiveLearningEvent, turnContext.Activity, activeLearningResponse);
+                return activeLearningResponse;
+            }
+
+            return null;
+        }
+
+        private async Task HandleFeedbackFlow(ShowQnAResultState qnastatus, ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var isValidFeedback = await this.IsValidFeedback(turnContext);
+            if (isValidFeedback)
+            {
+                TelemetryUtils.LogFeedbackResponse(this._services.TelemetryClient, TelemetryConstants.FeedbackEvent, turnContext.Activity, qnastatus);
+                turnContext.Activity.Text = qnastatus.QnaAnswer.Requery ?? null;
+            }
+
+            qnastatus.ConsiderState = false;
+            qnastatus.IsFeedback = false;
+            qnastatus.NeuroconCount = 0;
+        }
+
+        private async Task<bool> IsValidFeedback(ITurnContext turnContext)
+        {
+            var qnaOptions = new QnAMakerOptions();
+            qnaOptions.Top = Constants.DefaultTop;
+            qnaOptions.ScoreThreshold = Constants.DefaultThreshold;
+            var response = await _services.QnAServices[QnAMakerKey].GetAnswersAsync(turnContext, qnaOptions);
+
+            // if there is an answer with greater threshold from KB, it is not a feedback
+            if (response != null && response.GetLength(0) != 0 && response[0].Score >= 0.95F)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private QueryResult HandleActiveLearning(QueryResult[] response, ShowQnAResultState qnaStatus, string userQuestion)
+        {
+            var filteredResponse = response.Where(answer => answer.Score > Constants.DefaultThreshold).ToList();
+            var responseCandidates = ActiveLearning.GetLowScoreVariation(filteredResponse);
+            if (responseCandidates.Count > 1)
+            {
+                var activeLearningResponse = ActiveLearning.GenerateResponse(responseCandidates);
+                qnaStatus.ActiveLearningAnswer = true;
+                qnaStatus.ActiveLearningUserQuestion = userQuestion;
+                return activeLearningResponse;
+            }
+
+            return responseCandidates[0];
+        }
+
+        private async Task<string> GetLuisIntent(ITurnContext turnContext, bool enableLuis, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (!enableLuis)
+            {
+                return "None";
+            }
+
+            try
+            {
+                var luisResult = await _services.LuisServices[LuisKey].RecognizeAsync(turnContext, cancellationToken);
+                var topIntent = luisResult?.GetTopScoringIntent();
+                TelemetryUtils.LogLuisResponse(this._services.TelemetryClient, TelemetryConstants.LuisEvent, turnContext.Activity, topIntent.Value.intent + " score : " + topIntent.Value.score.ToString());
+                return topIntent.Value.intent;
+            }
+            catch (Exception e)
+            {
+                TelemetryUtils.LogException(this._services.TelemetryClient, turnContext.Activity, e, "luis", "expection while getting luis intent");
+                return "None";
+            }
+        }
+
+        private async Task<QueryResult> GetResponseWithLuisIntent(ITurnContext turnContext, string topIntent, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (topIntent != null && topIntent != "None")
+            {
+                var qnaOptions = new QnAMakerOptions();
+                var metadata = new Microsoft.Bot.Builder.AI.QnA.Metadata();
+
+                metadata.Name = Constants.MetadataName.Intent;
+                metadata.Value = topIntent;
+                qnaOptions.StrictFilters = new Microsoft.Bot.Builder.AI.QnA.Metadata[] { metadata };
+                qnaOptions.Top = Constants.DefaultTop;
+                qnaOptions.ScoreThreshold = 0.3F;
+                var activityText = turnContext.Activity.Text;
+                turnContext.Activity.Text = Constants.MetadataName.Intent + "=" + topIntent;
+                var response = await _services.QnAServices[QnAMakerKey].GetAnswersAsync(turnContext, qnaOptions);
+                turnContext.Activity.Text = activityText;
+                if (response != null && response.GetLength(0) != 0 && response[0].Score >= Constants.DefaultThreshold)
+                {
+                    return response[0];
+                }
+            }
+
+            return null;
+        }
+
+        private async Task ShowQnAResponseWithOptions(ITurnContext turnContext, QnAMakerAnswer qnaresponse, ShowQnAResultState qnastatus, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var cardActivity = Utils.GenerateResponseOptions(qnaresponse);
+            qnastatus.ConsiderState = true;
+            qnastatus.QnaAnswer = qnaresponse;
+            qnastatus.NeuroconCount = 0;
+            if (qnaresponse.Flowtype == Constants.MetadataValue.Feedback)
+            {
+                qnastatus.IsFeedback = true;
+            }
+            else
+            {
+                qnastatus.IsFeedback = false;
+            }
+
+            await _accessors.QnAResultState.SetAsync(turnContext, qnastatus);
+            await _accessors.ConversationState.SaveChangesAsync(turnContext);
+            await turnContext.SendActivityAsync(cardActivity, cancellationToken);
+        }
+
+        private async Task ShowQnAResponseWithText(ITurnContext turnContext, QnAMakerAnswer qnaresponse, ShowQnAResultState qnastatus, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            qnastatus.ConsiderState = true;
+            if (!qnaresponse.IsChitChat)
+            {
+                qnastatus.NeuroconCount = 0;
+            }
+            else
+            {
+                qnastatus.NeuroconCount++;
+            }
+
+            qnastatus.QnaAnswer = qnaresponse;
+            if (qnaresponse.Flowtype == Constants.MetadataValue.Feedback)
+            {
+                qnastatus.IsFeedback = true;
+            }
+            else
+            {
+                qnastatus.IsFeedback = false;
+            }
+
+            await _accessors.QnAResultState.SetAsync(turnContext, qnastatus);
+            await _accessors.ConversationState.SaveChangesAsync(turnContext);
+            await turnContext.SendActivityAsync(qnaresponse.Text);
+            if (!string.IsNullOrEmpty(qnaresponse.Requery) && !qnastatus.IsFeedback)
+            {
+                var showNextResponseText = true;
+                var counter = 0;
+                while (showNextResponseText)
+                {
+                    turnContext.Activity.Text = qnaresponse.Requery;
+                    qnastatus = await _accessors.QnAResultState.GetAsync(turnContext, () => new ShowQnAResultState());
+                    var response = await GetMultiturnResponseFromKB(turnContext, qnastatus.QnaAnswer);
+                    if (response == null)
+                    {
+                        showNextResponseText = false;
+                    }
+                    else
+                    {
+                        qnaresponse = Utils.GetQnAAnswerFromResponse(response);
+                        if (qnaresponse == qnastatus.QnaAnswer)
+                        {
+                            break;
+                        }
+
+                        if (qnaresponse.Options != null && qnaresponse.Options.Count != 0)
+                        {
+                            qnastatus.ConsiderState = true;
+                            qnastatus.QnaAnswer = qnaresponse;
+                            qnastatus.NeuroconCount = 0;
+                            if (qnaresponse.Flowtype == Constants.MetadataValue.Feedback)
+                            {
+                                qnastatus.IsFeedback = true;
+                            }
+                            else
+                            {
+                                qnastatus.IsFeedback = false;
+                            }
+                            await _accessors.QnAResultState.SetAsync(turnContext, qnastatus);
+                            await _accessors.ConversationState.SaveChangesAsync(turnContext);
+                            var cardActivity = Utils.GenerateResponseOptions(qnaresponse);
+                            await turnContext.SendActivityAsync(cardActivity, cancellationToken);
+                            showNextResponseText = false;
+                        }
+                        else
+                        {
+                            qnastatus.ConsiderState = true;
+                            qnastatus.QnaAnswer = qnaresponse;
+                            if (!qnaresponse.IsChitChat)
+                            {
+                                qnastatus.NeuroconCount = 0;
+                            }
+                            else
+                            {
+                                qnastatus.NeuroconCount++;
+                            }
+
+                            if (qnaresponse.Flowtype == Constants.MetadataValue.Feedback)
+                            {
+                                qnastatus.IsFeedback = true;
+                            }
+                            else
+                            {
+                                qnastatus.IsFeedback = false;
+                            }
+
+                            await _accessors.QnAResultState.SetAsync(turnContext, qnastatus);
+                            await _accessors.ConversationState.SaveChangesAsync(turnContext);
+                            await turnContext.SendActivityAsync(qnaresponse.Text);
+                        }
+
+                        counter++;
+                        if (counter > Constants.MaxContinuousTextDialogs || qnastatus.IsFeedback || qnastatus.QnaAnswer.Requery == null || qnastatus.NeuroconCount > Constants.ConsecutiveNeuroconAnswersAllowed)
+                        {
+                            showNextResponseText = false;
+                        }
+                    }
+                }
+            }
+        }
+
+        private async Task ShowRedirection(Constants.RedirectionType redirectionType, ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var dialogContext = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+            var qnastatus = await _accessors.QnAResultState.GetAsync(turnContext, () => new ShowQnAResultState());
+            if (redirectionType == Constants.RedirectionType.Neurocon)
+            {
+                turnContext.Activity.Text = Constants.NeuroconRedirectionQuestion;
+            }
+            else if (redirectionType == Constants.RedirectionType.GuidedFlow)
+            {
+                turnContext.Activity.Text = Constants.GuidedFlowRedirectionQuestion;
+            }
+
+            var responseGeneral = await GetGeneralResponseFromKB(turnContext, qnastatus);
+            var qnaresponse = Utils.GetQnAAnswerFromResponse(responseGeneral);
+            if (qnaresponse != null)
+            {
+                qnastatus.NeuroconCount = 0;
+                if (qnaresponse.Options != null && qnaresponse.Options.Count != 0)
+                {
+                    await ShowQnAResponseWithOptions(turnContext, qnaresponse, qnastatus);
+                }
+                else
+                {
+                    await ShowQnAResponseWithText(turnContext, qnaresponse, qnastatus);
+                }
+            }
+        }
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Service/TelemetryConstants.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Service/TelemetryConstants.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Service
+{
+    /// <summary>
+    /// Constants for telemetry logging.
+    /// </summary>
+    public class TelemetryConstants
+    {
+        public const string QueryProperty = "query";
+        public const string FeedbackProperty = "feedback";
+        public const string AnswerProperty = "answer";
+        public const string NeuroconCountProperty = "neuroconCount";
+        public const string UserNameProperty = "userName";
+        public const string EventNameProperty = "eventName";
+        public const string NeuroconEvent = "NeuroconMessage";
+        public const string FeedbackEvent = "FeedbackMessage";
+        public const string LuisEvent = "LuisMessage";
+        public const string LuisIntent = "LuisIntent";
+        public const string ChannelId = "ChannelId";
+        public const string FromID = "FromId";
+        public const string FromName = "FromName";
+        public const string TrainApiEvent = "TrainApi";
+        public const string ActiveLearningEvent = "ActiveLearningEvent";
+        public const string EndpointKey = "EndpointKey";
+        public const string NoAnswer = "NoAnswer";
+        public const string HostName = "HostName";
+        public const string Kbid = "Kbid";
+        public const string UserQuestion = "UserQuestion";
+        public const string UserSelectedPrompt = "UserSelectedPrompt";
+        public const string MetadataName = "MetadataName";
+        public const string MetadataParent = "MetadataParent";
+        public const string ActivityId = "ActivityId";
+        public const string ReplyToId = "ReplyToId";
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Service/TelemetryUtils.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Service/TelemetryUtils.cs
@@ -1,0 +1,193 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Service
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Bot.Builder.AI.QnA;
+    using Microsoft.Bot.Schema;
+    using SupportBot.Dialogs.ShowQnAResult;
+    using SupportBot.Providers.QnAMaker;
+
+    /// <summary>
+    /// Utilities for logging telemetry.
+    /// </summary>
+    public static class TelemetryUtils
+    {
+        /// <summary>
+        /// Log personality chat response.
+        /// </summary>
+        /// <param name="telemetryClient">telemetry client.</param>
+        /// <param name="eventName">event name.</param>
+        /// <param name="activity">activity.</param>
+        /// <param name="qnaStatus">QnA status.</param>
+        /// <param name="answer">answer.</param>
+        public static void LogNeuroconResponse(Microsoft.ApplicationInsights.TelemetryClient telemetryClient, string eventName, Activity activity, ShowQnAResultState qnaStatus, string answer)
+        {
+            var properties = new Dictionary<string, string>()
+                {
+                    { TelemetryConstants.QueryProperty, activity.Text },
+                    { TelemetryConstants.AnswerProperty, answer },
+                    { TelemetryConstants.NeuroconCountProperty, qnaStatus.NeuroconCount.ToString() },
+                };
+
+            AddBasicProperties(properties, activity);
+            telemetryClient.TrackEvent(eventName, properties);
+        }
+
+        /// <summary>
+        /// Log Feedback response.
+        /// </summary>
+        /// <param name="telemetryClient">telemetry client.</param>
+        /// <param name="eventName">event name.</param>
+        /// <param name="activity">activity.</param>
+        /// <param name="qnastatus">qna status.</param>
+        public static void LogFeedbackResponse(Microsoft.ApplicationInsights.TelemetryClient telemetryClient, string eventName, Activity activity, ShowQnAResultState qnastatus)
+        {
+            var properties = new Dictionary<string, string>()
+                {
+                    { TelemetryConstants.MetadataName, qnastatus.QnaAnswer.Name },
+                    { TelemetryConstants.MetadataParent, qnastatus.QnaAnswer.Parent },
+                    { TelemetryConstants.AnswerProperty, qnastatus.QnaAnswer.Text },
+                    { TelemetryConstants.QueryProperty, qnastatus.QnaAnswer.Requery},
+                    { TelemetryConstants.FeedbackProperty, activity.Text },
+                 };
+
+            AddBasicProperties(properties, activity);
+            telemetryClient.TrackEvent(eventName, properties);
+        }
+
+        /// <summary>
+        /// log welcome message.
+        /// </summary>
+        /// <param name="telemetryClient">telemetry client.</param>
+        /// <param name="eventName">ebent name.</param>
+        /// <param name="activity">activity.</param>
+        public static void LogWelcomeResponse(Microsoft.ApplicationInsights.TelemetryClient telemetryClient, string eventName, Activity activity)
+        {
+            var properties = new Dictionary<string, string>()
+                {
+                    { TelemetryConstants.FeedbackProperty, activity.Text },
+                 };
+
+            AddBasicProperties(properties, activity);
+            telemetryClient.TrackEvent(eventName, properties);
+        }
+
+        /// <summary>
+        /// Log train api call.
+        /// </summary>
+        /// <param name="telemetryClient">telemetry client.</param>
+        /// <param name="eventName">event name.</param>
+        /// <param name="activity">sctivity.</param>
+        /// <param name="activeLearningData">active learning data.</param>
+        /// <param name="requery">requery.</param>
+        public static void LogTrainApiResponse(Microsoft.ApplicationInsights.TelemetryClient telemetryClient, string eventName, Activity activity, ActiveLearningDTO activeLearningData, string requery)
+        {
+            var properties = new Dictionary<string, string>()
+                {
+                    { TelemetryConstants.EndpointKey, activeLearningData.endpointKey },
+                    { TelemetryConstants.HostName, activeLearningData.hostName },
+                    { TelemetryConstants.Kbid, activeLearningData.kbid },
+                    { TelemetryConstants.UserQuestion, activeLearningData.userQuestion },
+                    { TelemetryConstants.UserSelectedPrompt, requery },
+                };
+
+            AddBasicProperties(properties, activity);
+            telemetryClient.TrackEvent(eventName, properties);
+        }
+
+        /// <summary>
+        /// Log active learning response.
+        /// </summary>
+        /// <param name="telemetryClient">telemetry client.</param>
+        /// <param name="eventName">event name.</param>
+        /// <param name="activity">activity.</param>
+        /// <param name="activeLearningResponse">active learning response.</param>
+        public static void LogActiveLearningResponse(Microsoft.ApplicationInsights.TelemetryClient telemetryClient, string eventName, Activity activity, QueryResult activeLearningResponse)
+        {
+            var properties = new Dictionary<string, string>()
+                {
+                    { "Answer", activeLearningResponse.Answer },
+                    { "OriginalQuestion", activity.Text },
+                 };
+
+            foreach (var metadata in activeLearningResponse.Metadata)
+            {
+                properties.Add(metadata.Name, metadata.Value);
+            }
+
+            AddBasicProperties(properties, activity);
+            telemetryClient.TrackEvent(eventName, properties);
+        }
+
+        /// <summary>
+        /// Log Luis resposne.
+        /// </summary>
+        /// <param name="telemetryClient">telemetry client.</param>
+        /// <param name="eventName">event name.</param>
+        /// <param name="activity">activity.</param>
+        /// <param name="topintent">top intent.</param>
+        public static void LogLuisResponse(Microsoft.ApplicationInsights.TelemetryClient telemetryClient, string eventName, Activity activity, string topintent)
+        {
+            var properties = new Dictionary<string, string>()
+                {
+                    { TelemetryConstants.QueryProperty, activity.Text },
+                    { TelemetryConstants.LuisIntent, topintent },
+                 };
+
+            AddBasicProperties(properties, activity);
+            telemetryClient.TrackEvent(eventName, properties);
+        }
+
+        /// <summary>
+        /// Log exception.
+        /// </summary>
+        /// <param name="telemetryClient">telemetry client.</param>
+        /// <param name="activity">activity.</param>
+        /// <param name="e">exception</param>
+        /// <param name="propertyName">property name.</param>
+        /// <param name="propertyValue">property value.</param>
+
+        public static void LogException(Microsoft.ApplicationInsights.TelemetryClient telemetryClient, Activity activity, Exception e, string propertyName = "default", string propertyValue = "default")
+        {
+            var properties = new Dictionary<string, string>()
+            {
+                { propertyName, propertyValue },
+            };
+
+            AddBasicProperties(properties, activity);
+            telemetryClient.TrackException(e);
+        }
+
+        /// <summary>
+        /// Log event when No answer is shown to the user.
+        /// </summary>
+        /// <param name="telemetryClient">telemetry client.</param>
+        /// <param name="activity">activity.</param>
+
+        public static void LogNoAnswerEvent(Microsoft.ApplicationInsights.TelemetryClient telemetryClient, Activity activity)
+        {
+            var properties = new Dictionary<string, string>()
+            {
+                { TelemetryConstants.QueryProperty, activity.Text },
+            };
+
+            AddBasicProperties(properties, activity);
+            telemetryClient.TrackEvent(TelemetryConstants.NoAnswer, properties);
+        }
+
+        private static void AddBasicProperties(Dictionary<string, string> properties, Activity activity)
+        {
+            properties.Add(TelemetryConstants.FromID, activity.From.Id);
+            properties.Add(TelemetryConstants.FromName, activity.From.Name);
+            properties.Add(TelemetryConstants.ChannelId, activity.ChannelId);
+            properties.Add(TelemetryConstants.ActivityId, activity.Id);
+            if (activity.ReplyToId != null)
+            {
+                properties.Add(TelemetryConstants.ReplyToId, activity.ReplyToId);
+            }
+        }
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Service/Utils.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Service/Utils.cs
@@ -1,0 +1,280 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot.Service
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Bot.Builder.AI.QnA;
+    using Microsoft.Bot.Schema;
+    using SupportBot.Dialogs.ShowQnAResult;
+    using SupportBot.Models;
+    using SupportBot.Providers.QnAMaker;
+    using Constants = SupportBot.Models.Constants;
+
+    /// <summary>
+    /// Utility functions.
+    /// </summary>
+    public class Utils
+    {
+        /// <summary>
+        /// get requery text.
+        /// </summary>
+        /// <param name="qnastatus">qnastatus.</param>
+        /// <param name="activityText">activity text.</param>
+        /// <param name="activeLearningdata">activeleraning data.</param>
+        /// <returns></returns>
+        public static string GetRequery(ShowQnAResultState qnastatus, string activityText, ActiveLearningDTO activeLearningdata = null)
+        {
+            string requery = null;
+            if (qnastatus.QnaAnswer.Options != null && qnastatus.QnaAnswer.Options.Count != 0)
+            {
+                foreach (var promptoption in qnastatus.QnaAnswer.Options)
+                {
+                    if (promptoption.Option.Equals(activityText, StringComparison.CurrentCultureIgnoreCase))
+                    {
+                        requery = string.IsNullOrEmpty(promptoption.Requery) ? promptoption.Option : promptoption.Requery;
+
+                        // call train API if active learning
+                        if (qnastatus.ActiveLearningAnswer == true && activeLearningdata != null)
+                        {
+                            qnastatus.ActiveLearningAnswer = false;
+                            activeLearningdata.qnaId = promptoption.QnAId;
+                            ActiveLearning.CallTrainApi(activeLearningdata);
+                            qnastatus.ActiveLearningUserQuestion = null;
+                        }
+
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                requery = string.IsNullOrEmpty(qnastatus.QnaAnswer.Requery) ? null : qnastatus.QnaAnswer.Requery;
+            }
+
+            return requery;
+        }
+
+        /// <summary>
+        /// Get QnAAnswer from the query result.
+        /// </summary>
+        /// <param name="response">query result response.</param>
+        /// <returns>QnAMaker answer.</returns>
+        public static QnAMakerAnswer GetQnAAnswerFromResponse(Microsoft.Bot.Builder.AI.QnA.QueryResult response)
+        {
+            if (response == null)
+            {
+                return null;
+            }
+
+            var promptOptionDictionary = new Dictionary<int, PromptOption>();
+            var selectedResponse = response;
+            var qnaAnswer = new QnAMakerAnswer();
+            qnaAnswer.Text = selectedResponse.Answer ?? null;
+            foreach (var metadata in selectedResponse.Metadata)
+            {
+                if (metadata.Name.Contains(Constants.MetadataName.OptionRequery))
+                {
+                    var index = metadata.Name.Substring(13);
+                    if (int.TryParse(index, out var result))
+                    {
+                        if (promptOptionDictionary.ContainsKey(result))
+                        {
+                            promptOptionDictionary[result].Requery = metadata.Value;
+                        }
+                        else
+                        {
+                            var optionPrompt = new PromptOption();
+                            optionPrompt.Requery = metadata.Value;
+                            promptOptionDictionary.Add(result, optionPrompt);
+                        }
+                    }
+                }
+                else if (metadata.Name.Contains(Constants.MetadataName.Option))
+                {
+                    var index = metadata.Name.Substring(6);
+                    if (int.TryParse(index, out var result))
+                    {
+                        if (promptOptionDictionary.ContainsKey(result))
+                        {
+                            promptOptionDictionary[result].Option = metadata.Value;
+                        }
+                        else
+                        {
+                            var optionPrompt = new PromptOption();
+                            optionPrompt.Option = metadata.Value;
+                            promptOptionDictionary.Add(result, optionPrompt);
+                        }
+                    }
+                }
+                else if (metadata.Name.Contains(Constants.MetadataName.QnAId))
+                {
+                    var index = metadata.Name.Substring(5);
+                    if (int.TryParse(index, out var result))
+                    {
+                        int.TryParse(metadata.Value, out var id);
+                        if (promptOptionDictionary.ContainsKey(result))
+                        {
+                            promptOptionDictionary[result].QnAId = id;
+                        }
+                        else
+                        {
+                            var optionPrompt = new PromptOption();
+                            optionPrompt.QnAId = id;
+                            promptOptionDictionary.Add(result, optionPrompt);
+                        }
+                    }
+                }
+                else if (metadata.Name == Constants.MetadataName.Requery)
+                {
+                    qnaAnswer.Requery = metadata.Value ?? null;
+                }
+                else if (metadata.Name.Contains(Constants.MetadataName.Name))
+                {
+                    qnaAnswer.Name = metadata.Value ?? null;
+                }
+                else if (metadata.Name.Contains(Constants.MetadataName.Parent))
+                {
+                    qnaAnswer.Parent = metadata.Value ?? null;
+                }
+                else if (metadata.Name.Contains(Constants.MetadataName.Isroot))
+                {
+                    qnaAnswer.IsRoot = metadata.Value ?? null;
+                }
+                else if (metadata.Name.Contains(Constants.MetadataName.Flowtype))
+                {
+                    qnaAnswer.Flowtype = metadata.Value ?? null;
+                }
+            }
+
+            foreach (var promptOption in promptOptionDictionary)
+            {
+                qnaAnswer.Options.Add(promptOption.Value);
+            }
+
+            qnaAnswer.IsChitChat = IsResponseChitChat(response);
+            return qnaAnswer;
+        }
+
+        /// <summary>
+        /// Generate response with options.
+        /// </summary>
+        /// <param name="qnaresponse"QnAMaker answer.></param>
+        /// <returns>message activity with hero card.</returns>
+        public static IMessageActivity GenerateResponseOptions(QnAMakerAnswer qnaresponse)
+        {
+            var cardButtons = new List<CardAction>();
+            foreach (var promptoption in qnaresponse.Options)
+            {
+                var title = FormatOptionText(promptoption.Option);
+                var card = new CardAction()
+                {
+                    Value = title,
+                    Type = ActionTypes.ImBack,
+                    Title = title,
+                };
+                cardButtons.Add(card);
+            }
+
+            var heroCard = new HeroCard
+            {
+                Title = Constants.HeroCardTitle,
+                Text = qnaresponse.Text,
+                Buttons = cardButtons,
+            };
+            var cardActivity = Activity.CreateMessageActivity();
+            cardActivity.AttachmentLayout = AttachmentLayoutTypes.Carousel;
+            var cardAttachment = heroCard.ToAttachment();
+            cardActivity.Attachments.Add(cardAttachment);
+            return cardActivity;
+        }
+
+        /// <summary>
+        /// Handle capitalization and format the text before displaying.
+        /// </summary>
+        /// <param name="inputText">text to be formated.</param>
+        /// <returns>formated text.</returns>
+        public static string FormatOptionText(string inputText)
+        {
+            if (string.IsNullOrEmpty(inputText))
+            {
+                return string.Empty;
+            }
+
+            foreach (var word in HandleCaptitalization.formattedWords)
+            {
+                if (inputText.Contains(word.Original))
+                {
+                    inputText = inputText.Replace(word.Original, word.ConvertTo);
+                }
+            }
+
+            inputText = char.ToUpper(inputText[0]) + inputText.Substring(1);
+            return inputText;
+        }
+
+        /// <summary>
+        /// Select final response.
+        /// </summary>
+        /// <param name="responseMultiturn">multiturn response.</param>
+        /// <param name="responseGeneral">general response.</param>
+        /// <param name="luisresponse">luis response.</param>
+        /// <param name="previousAnswer">answer shoen previously.</param>
+        /// <returns>selected QnAMaker answer.</returns>
+
+        public static QnAMakerAnswer SelectResponse(QueryResult responseMultiturn, QueryResult responseGeneral, QueryResult luisresponse, QnAMakerAnswer previousAnswer)
+        {
+            if (responseMultiturn != null)
+            {
+                var qnaresponse = Utils.GetQnAAnswerFromResponse(responseMultiturn);
+                if (previousAnswer == null || !qnaresponse.IsEqual(previousAnswer))
+                {
+                    return qnaresponse;
+                }
+            }
+
+            if (responseGeneral != null)
+            {
+                var qnaresponse = Utils.GetQnAAnswerFromResponse(responseGeneral);
+                if (qnaresponse.IsRoot == null || !Constants.MetadataValue.ExcludeIsroot.Equals(qnaresponse.IsRoot))
+                {
+                    return qnaresponse;
+                }
+            }
+
+            if (luisresponse != null)
+            {
+                var qnaresponse = Utils.GetQnAAnswerFromResponse(luisresponse);
+                if (previousAnswer == null || !qnaresponse.IsEqual(previousAnswer))
+                {
+                    return qnaresponse;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// check if the response has metadata chitchat.
+        /// </summary>
+        /// <param name="response">response.</param>
+        /// <returns>true if it is chitchat response else false.</returns>
+
+        public static bool IsResponseChitChat(QueryResult response)
+        {
+            if (response != null)
+            {
+                foreach (var metadata in response.Metadata)
+                {
+                    if (metadata.Name == Constants.MetadataName.Editorial && metadata.Value == Constants.MetadataValue.ChitChat)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/Startup.cs
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/Startup.cs
@@ -1,0 +1,279 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SupportBot
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.ApplicationInsights;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Bot.Builder;
+    using Microsoft.Bot.Builder.AI.Luis;
+    using Microsoft.Bot.Builder.AI.QnA;
+    using Microsoft.Bot.Builder.Dialogs;
+    using Microsoft.Bot.Builder.Integration;
+    using Microsoft.Bot.Builder.Integration.ApplicationInsights.Core;
+    using Microsoft.Bot.Builder.Integration.AspNet.Core;
+    using Microsoft.Bot.Configuration;
+    using Microsoft.Bot.Connector.Authentication;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
+    using SupportBot.Dialogs.ShowQnAResult;
+    using SupportBot.Middleware.Telemetry;
+    using SupportBot.Models;
+    using SupportBot.Service;
+
+    /// <summary>
+    /// The Startup class configures services and the request pipeline.
+    /// </summary>
+    public class Startup
+    {
+        private ILoggerFactory _loggerFactory;
+        private bool _isProduction = false;
+
+        public Startup(IHostingEnvironment env)
+        {
+            _isProduction = env.IsProduction();
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
+                .AddEnvironmentVariables();
+            Configuration = builder.Build();
+        }
+
+        /// <summary>
+        /// Gets the configuration that represents a set of key/value application configuration properties.
+        /// </summary>
+        /// <value>
+        /// The <see cref="IConfiguration"/> that represents a set of key/value application configuration properties.
+        /// </value>
+        public IConfiguration Configuration { get; }
+
+        /// <summary>
+        /// This method gets called by the runtime. Use this method to add services to the container.
+        /// </summary>
+        /// <param name="services">Specifies the contract for a <see cref="IServiceCollection"/> of service descriptors.</param>
+        /// <seealso cref="https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-2.1"/>
+        public void ConfigureServices(IServiceCollection services)
+        {
+            var secretKey = Configuration.GetSection("botFileSecret")?.Value;
+            var botFilePath = Configuration.GetSection("botFilePath")?.Value;
+            Constants.PersonalityChatKey = Configuration.GetSection("personalityChatKey")?.Value;
+
+            // Loads .bot configuration file and adds a singleton that your Bot can access through dependency injection.
+            var botConfig = BotConfiguration.Load(botFilePath ?? @".\BotConfiguration.bot", secretKey);
+
+            // Add Application Insights
+            services.AddBotApplicationInsights(botConfig);
+
+            // Initialize Bot Connected Services clients.
+            var connectedServices = InitBotServices(botConfig);
+            services.AddSingleton(sp => connectedServices);
+            services.AddSingleton(sp => botConfig);
+
+            services.AddBot<SupportBotService>(options =>
+            {
+                services.AddSingleton(sp => botConfig ?? throw new InvalidOperationException($"The .bot configuration file could not be loaded. ({botConfig})"));
+
+                // Retrieve current endpoint.
+                var environment = _isProduction ? "production" : "development";
+                var service = botConfig.Services.Where(s => s.Type == "endpoint" && s.Name == environment).FirstOrDefault();
+                if (!(service is EndpointService endpointService))
+                {
+                    throw new InvalidOperationException($"The .bot file does not contain an endpoint with name '{environment}'.");
+                }
+
+                options.CredentialProvider = new SimpleCredentialProvider(endpointService.AppId, endpointService.AppPassword);
+
+                // Creates a telemetryClient for OnTurnError handler
+                var spTelemetry = services.BuildServiceProvider();
+                var telemetryClient = spTelemetry.GetService<IBotTelemetryClient>();
+
+                // Add TelemetryLoggerMiddleware (logs activity messages into Application Insights)
+                var appInsightsLogger = new TelemetryLoggerMiddleware(telemetryClient, logUserName: true, logOriginalMessage: true);
+                options.Middleware.Add(appInsightsLogger);
+
+                // Creates a logger for the application to use.
+                ILogger logger = _loggerFactory.CreateLogger<SupportBotService>();
+
+                // Catches any errors that occur during a conversation turn and logs them.
+                options.OnTurnError = async (context, exception) =>
+                {
+                    telemetryClient.TrackException(exception);
+                    await context.SendActivityAsync("I don't have an answer for that. Try typing MENU to go back to the main menu");
+                };
+
+                // The Memory Storage used here is for local bot debugging only. When the bot
+                // is restarted, everything stored in memory will be gone.
+                IStorage dataStore = new MemoryStorage();
+
+                // For production bots use the Azure Blob or
+                // Azure CosmosDB storage providers. For the Azure
+                // based storage providers, add the Microsoft.Bot.Builder.Azure
+                // Nuget package to your solution. That package is found at:
+                // https://www.nuget.org/packages/Microsoft.Bot.Builder.Azure/
+                // Uncomment the following lines to use Azure Blob Storage
+                // //Storage configuration name or ID from the .bot file.
+                // const string StorageConfigurationId = "<STORAGE-NAME-OR-ID-FROM-BOT-FILE>";
+                // var blobConfig = botConfig.FindServiceByNameOrId(StorageConfigurationId);
+                // if (!(blobConfig is BlobStorageService blobStorageConfig))
+                // {
+                //    throw new InvalidOperationException($"The .bot file does not contain an blob storage with name '{StorageConfigurationId}'.");
+                // }
+                // // Default container name.
+                // const string DefaultBotContainer = "<DEFAULT-CONTAINER>";
+                // var storageContainer = string.IsNullOrWhiteSpace(blobStorageConfig.Container) ? DefaultBotContainer : blobStorageConfig.Container;
+                // IStorage dataStore = new Microsoft.Bot.Builder.Azure.AzureBlobStorage(blobStorageConfig.ConnectionString, storageContainer);
+
+                // Create Conversation State object.
+                // The Conversation State object is where we persist anything at the conversation-scope.
+                var conversationState = new ConversationState(dataStore);
+
+                options.State.Add(conversationState);
+            });
+
+            // Acessors created here are passed into the IBot - derived class on every turn.
+            services.AddSingleton<ShowQnAResultAccessor>(sp =>
+          {
+              var options = sp.GetRequiredService<IOptions<BotFrameworkOptions>>().Value;
+              if (options == null)
+              {
+                  throw new InvalidOperationException("BotFrameworkOptions must be configured prior to setting up the state accessors");
+              }
+
+              var conversationState = options.State.OfType<ConversationState>().FirstOrDefault();
+              if (conversationState == null)
+              {
+                  throw new InvalidOperationException("ConversationState must be defined and added before adding conversation-scoped state accessors.");
+              }
+
+              // Create the custom QnAMaker accessor.
+              var accessors = new ShowQnAResultAccessor(conversationState)
+              {
+                  QnAResultState = conversationState.CreateProperty<ShowQnAResultState>(ShowQnAResultAccessor.QnAResultStateName),
+                  ConversationDialogState = conversationState.CreateProperty<DialogState>("DialogState"),
+              };
+              return accessors;
+          });
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        {
+            _loggerFactory = loggerFactory;
+
+            _loggerFactory.AddApplicationInsights(app.ApplicationServices, LogLevel.Information);
+
+            app.UseDefaultFiles()
+                .UseStaticFiles()
+                .UseBotFramework();
+        }
+
+        /// <summary>
+        /// Initialize the bot's references to external services.
+        /// For example, the QnA Maker instance is created here. This external service is configured
+        /// using the <see cref="BotConfiguration"/> class (based on the contents of your ".bot" file).
+        /// </summary>
+        /// <param name="config">The <see cref="BotConfiguration"/> object based on your ".bot" file.</param>
+        /// <returns>A <see cref="BotConfiguration"/> representing client objects to access external services the bot uses.</returns>
+        /// <seealso cref="BotConfiguration"/>
+        /// <seealso cref="QnAMaker"/>
+        private static BotServices InitBotServices(BotConfiguration config)
+        {
+            var qnaServices = new Dictionary<string, TelemetryQnaMaker>();
+            var luisServices = new Dictionary<string, LuisRecognizer>();
+            var telemetryClient = new TelemetryClient();
+
+            foreach (var service in config.Services)
+            {
+                switch (service.Type)
+                {
+                    case ServiceTypes.QnA:
+                        {
+                            // Create a QnA Maker that is initialized and suitable for passing
+                            // into the IBot-derived class (QnABot).
+                            var qna = (QnAMakerService)service;
+                            if (qna == null)
+                            {
+                                throw new InvalidOperationException("The QnA service is not configured correctly in your '.bot' file.");
+                            }
+
+                            if (string.IsNullOrWhiteSpace(qna.KbId))
+                            {
+                                throw new InvalidOperationException("The QnA KnowledgeBaseId ('kbId') is required to run this sample. Please update your '.bot' file.");
+                            }
+
+                            if (string.IsNullOrWhiteSpace(qna.EndpointKey))
+                            {
+                                throw new InvalidOperationException("The QnA EndpointKey ('endpointKey') is required to run this sample. Please update your '.bot' file.");
+                            }
+
+                            if (string.IsNullOrWhiteSpace(qna.Hostname))
+                            {
+                                throw new InvalidOperationException("The QnA Host ('hostname') is required to run this sample. Please update your '.bot' file.");
+                            }
+
+                            var qnaEndpoint = new QnAMakerEndpoint()
+                            {
+                                KnowledgeBaseId = qna.KbId,
+                                EndpointKey = qna.EndpointKey,
+                                Host = qna.Hostname,
+                            };
+
+                            var qnaMaker = new TelemetryQnaMaker(qnaEndpoint);
+                            qnaServices.Add(qna.Name, qnaMaker);
+
+                            break;
+                        }
+
+                    case ServiceTypes.Luis:
+                        {
+                            var luis = (LuisService)service;
+                            if (luis == null)
+                            {
+                                throw new InvalidOperationException("The LUIS service is not configured correctly in your '.bot' file.");
+                            }
+
+                            var app = new LuisApplication(luis.AppId, luis.AuthoringKey, luis.GetEndpoint());
+                            var recognizer = new LuisRecognizer(app);
+                            luisServices.Add(luis.Name, recognizer);
+                            break;
+                        }
+
+                    case ServiceTypes.AppInsights:
+                        {
+                            var appInsights = (AppInsightsService)service;
+                            if (appInsights == null)
+                            {
+                                if (appInsights == null)
+                                {
+                                    throw new InvalidOperationException("The Application Insights is not configured correctly in your '.bot' file.");
+                                }
+
+                                if (string.IsNullOrWhiteSpace(appInsights.InstrumentationKey))
+                                {
+                                    throw new InvalidOperationException("The Application Insights Instrumentation Key ('instrumentationKey') is required to run this sample.  Please update your '.bot' file.");
+                                }
+                            }
+
+                            var telemetryConfig = new TelemetryConfiguration(appInsights.InstrumentationKey);
+                            telemetryClient = new TelemetryClient(telemetryConfig)
+                            {
+                                InstrumentationKey = appInsights.InstrumentationKey,
+                            };
+
+                            break;
+                        }
+                }
+            }
+
+            var connectedServices = new BotServices(qnaServices, luisServices, telemetryClient);
+            return connectedServices;
+        }
+    }
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/appsettings.json
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/appsettings.json
@@ -1,0 +1,4 @@
+{
+  "botFilePath": "BotConfiguration.bot",
+  "botFileSecret": ""
+}

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/qnamaker-support-bot.csproj
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/qnamaker-support-bot.csproj
@@ -1,0 +1,51 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <CodeAnalysisRuleSet>BasicBot.ruleset</CodeAnalysisRuleSet>
+    <UserSecretsId>7dd9750e-9033-446a-85ea-b9e8634d9eee</UserSecretsId>
+    <ApplicationInsightsResourceId>/subscriptions/a18d1e5d-191d-4523-85f3-fd72c8fe5d63/resourcegroups/Default-ApplicationInsights-EastUS/providers/microsoft.insights/components/SupportBot</ApplicationInsightsResourceId>
+    <ApplicationInsightsAnnotationResourceId>/subscriptions/a18d1e5d-191d-4523-85f3-fd72c8fe5d63/resourcegroups/Default-ApplicationInsights-EastUS/providers/microsoft.insights/components/SupportBot</ApplicationInsightsAnnotationResourceId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="BasicBot.cs" />
+    <Compile Remove="BotServices.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
+    <PackageReference Include="Microsoft.Azure.CognitiveServices.ContentModerator" Version="0.12.1-preview" />
+    <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Configuration" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Graph" Version="1.10.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <WCFMetadata Include="Connected Services" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="BotConfiguration.bot">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+<Target Name="bug_242_workaround" AfterTargets="_TransformWebConfig">
+    <Exec Command="powershell &quot;(Get-Content '$(PublishDir)Web.config').replace(' -argFile IISExeLauncherArgs.txt', '') | Set-Content '$(PublishDir)Web.config'&quot;" />
+  </Target>
+
+</Project>

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/qnamaker-support-bot.sln
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/qnamaker-support-bot.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2041
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "qnamaker-support-bot", "qnamaker-support-bot.csproj", "{09DB6274-245F-410E-B375-805AC3B1966B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{09DB6274-245F-410E-B375-805AC3B1966B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{09DB6274-245F-410E-B375-805AC3B1966B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{09DB6274-245F-410E-B375-805AC3B1966B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{09DB6274-245F-410E-B375-805AC3B1966B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5A352046-7C14-45FD-BC57-DE3A92217F91}
+	EndGlobalSection
+EndGlobal

--- a/experimental/csharp_dotnetcore/qnamaker-support-bot/wwwroot/default.htm
+++ b/experimental/csharp_dotnetcore/qnamaker-support-bot/wwwroot/default.htm
@@ -1,0 +1,427 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Basic Bot sample</title>
+    <style>
+        body {
+            margin: 0px;
+            padding: 0px;
+            font-family: Segoe UI;
+        }
+
+        html,
+        body {
+            height: 100%;
+        }
+
+        header {
+            background-image: url("data:image/svg+xml,%3Csvg version='1.1' id='Layer_1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' viewBox='0 0 4638.9 651.6' style='enable-background:new 0 0 4638.9 651.6;' xml:space='preserve'%3E%3Cstyle type='text/css'%3E .st0%7Bfill:%2355A0E0;%7D .st1%7Bfill:none;%7D .st2%7Bfill:%230058A8;%7D .st3%7Bfill:%23328BD8;%7D .st4%7Bfill:%23B6DCF1;%7D .st5%7Bopacity:0.2;fill:url(%23SVGID_1_);enable-background:new ;%7D%0A%3C/style%3E%3Crect y='1.1' class='st0' width='4640' height='646.3'/%3E%3Cpath class='st1' d='M3987.8,323.6L4310.3,1.1h-65.6l-460.1,460.1c-17.5,17.5-46.1,17.5-63.6,0L3260.9,1.1H0v646.3h3660.3 L3889,418.7c17.5-17.5,46.1-17.5,63.6,0l228.7,228.7h66.6l-260.2-260.2C3970.3,369.8,3970.3,341.1,3987.8,323.6z'/%3E%3Cpath class='st2' d='M3784.6,461.2L4244.7,1.1h-983.9l460.1,460.1C3738.4,478.7,3767.1,478.7,3784.6,461.2z'/%3E%3Cpath class='st3' d='M4640,1.1h-329.8l-322.5,322.5c-17.5,17.5-17.5,46.1,0,63.6l260.2,260.2H4640L4640,1.1L4640,1.1z'/%3E%3Cpath class='st4' d='M3889,418.8l-228.7,228.7h521.1l-228.7-228.7C3935.2,401.3,3906.5,401.3,3889,418.8z'/%3E%3ClinearGradient id='SVGID_1_' gradientUnits='userSpaceOnUse' x1='3713.7576' y1='438.1175' x2='3911.4084' y2='14.2535' gradientTransform='matrix(1 0 0 -1 0 641.3969)'%3E%3Cstop offset='0' style='stop-color:%23FFFFFF;stop-opacity:0.5'/%3E%3Cstop offset='1' style='stop-color:%23FFFFFF'/%3E%3C/linearGradient%3E%3Cpath class='st5' d='M3952.7,124.5c-17.5-17.5-46.1-17.5-63.6,0l-523,523h1109.6L3952.7,124.5z'/%3E%3C/svg%3E%0A");
+            background-repeat: no-repeat;
+            background-size: 100%;
+            background-position: right;
+            background-color: #55A0E0;
+            width: 100%;
+            font-size: 44px;
+            height: 120px;
+            color: white;
+            padding: 30px 0 40px 0px;
+            display: inline-block;
+        }
+
+        .header-icon {
+            background-image: url("data:image/svg+xml;utf8,%3Csvg%20version%3D%221.1%22%20id%3D%22Layer_1%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20viewBox%3D%220%200%20150.2%20125%22%20style%3D%22enable-background%3Anew%200%200%20150.2%20125%3B%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cstyle%20type%3D%22text/css%22%3E%0A%09.st0%7Bfill%3Anone%3B%7D%0A%09.st1%7Bfill%3A%23FFFFFF%3B%7D%0A%3C/style%3E%0A%3Crect%20x%3D%220.5%22%20class%3D%22st0%22%20width%3D%22149.7%22%20height%3D%22125%22/%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M59%2C102.9L21.8%2C66c-3.5-3.5-3.5-9.1%2C0-12.5l37-36.5l2.9%2C3l-37%2C36.4c-1.8%2C1.8-1.8%2C4.7%2C0%2C6.6l37.2%2C37L59%2C102.9z%22%0A%09%09/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M92.5%2C102.9l-3-3l37.2-37c0.9-0.9%2C1.4-2%2C1.4-3.3c0-1.2-0.5-2.4-1.4-3.3L89.5%2C20l2.9-3l37.2%2C36.4%0A%09%09c1.7%2C1.7%2C2.6%2C3.9%2C2.6%2C6.3s-0.9%2C4.6-2.6%2C6.3L92.5%2C102.9z%22/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M90.1%2C68.4c-4.5%2C0-8-3.5-8-8.1c0-4.5%2C3.5-8.1%2C8-8.1c4.4%2C0%2C8%2C3.7%2C8%2C8.1C98.1%2C64.7%2C94.4%2C68.4%2C90.1%2C68.4z%0A%09%09%20M90.1%2C56.5c-2.2%2C0-3.8%2C1.7-3.8%2C3.9c0%2C2.2%2C1.7%2C3.9%2C3.8%2C3.9c1.9%2C0%2C3.8-1.6%2C3.8-3.9S91.9%2C56.5%2C90.1%2C56.5z%22/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M61.4%2C68.4c-4.5%2C0-8-3.5-8-8.1c0-4.5%2C3.5-8.1%2C8-8.1c4.4%2C0%2C8%2C3.7%2C8%2C8.1C69.5%2C64.7%2C65.8%2C68.4%2C61.4%2C68.4z%0A%09%09%20M61.4%2C56.5c-2.2%2C0-3.8%2C1.7-3.8%2C3.9c0%2C2.2%2C1.7%2C3.9%2C3.8%2C3.9c1.9%2C0%2C3.8-1.6%2C3.8-3.9S63.3%2C56.5%2C61.4%2C56.5z%22/%3E%0A%3C/g%3E%0A%3C/svg%3E%0A");
+            background-repeat: no-repeat;
+            float: left;
+            height: 140px;
+            width: 140px;
+            display: inline-block;
+            vertical-align: middle;
+        }
+
+        .header-text {
+            padding-left: 1%;
+            color: #FFFFFF;
+            font-family: "Segoe UI";
+            font-size: 72px;
+            font-weight: 300;
+            letter-spacing: 0.35px;
+            line-height: 96px;
+            display: inline-block;
+            vertical-align: middle;
+        }
+
+        .header-inner-container {
+            min-width: 480px;
+            max-width: 1366px;
+            margin-left: auto;
+            margin-right: auto;
+            vertical-align: middle;
+        }
+
+            .header-inner-container::after {
+                content: "";
+                clear: both;
+                display: table;
+            }
+
+        .main-content-area {
+            padding-left: 30px;
+        }
+
+        .content-title {
+            color: #000000;
+            font-family: "Segoe UI";
+            font-size: 46px;
+            font-weight: 300;
+            line-height: 62px;
+        }
+
+        .main-text {
+            color: #808080;
+            font-size: 24px;
+            font-family: "Segoe UI";
+            font-size: 24px;
+            font-weight: 200;
+            line-height: 32px;
+        }
+
+        .main-text-p1 {
+            padding-top: 48px;
+            padding-bottom: 28px;
+        }
+
+        .endpoint {
+            height: 32px;
+            width: 571px;
+            color: #808080;
+            font-family: "Segoe UI";
+            font-size: 24px;
+            font-weight: 200;
+            line-height: 32px;
+            padding-top: 28px;
+        }
+
+        .how-to-build-section {
+            padding-top: 20px;
+            padding-left: 30px;
+        }
+
+            .how-to-build-section > h3 {
+                font-size: 16px;
+                font-weight: 600;
+                letter-spacing: 0.35px;
+                line-height: 22px;
+                margin: 0 0 24px 0;
+                text-transform: uppercase;
+            }
+
+        .step-container {
+            display: flex;
+            align-items: stretch;
+            position: relative;
+        }
+
+            .step-container dl {
+                border-left: 1px solid #A0A0A0;
+                display: block;
+                padding: 0 24px;
+                margin: 0;
+            }
+
+                .step-container dl > dt::before {
+                    background-color: white;
+                    border: 1px solid #A0A0A0;
+                    border-radius: 100%;
+                    content: '';
+                    left: 47px;
+                    height: 11px;
+                    position: absolute;
+                    width: 11px;
+                }
+
+                .step-container dl > .test-bullet::before {
+                    background-color: blue;
+                }
+
+                .step-container dl > dt {
+                    display: block;
+                    font-size: inherit;
+                    font-weight: bold;
+                    line-height: 20px;
+                }
+
+                .step-container dl > dd {
+                    font-size: inherit;
+                    line-height: 20px;
+                    margin-left: 0;
+                    padding-bottom: 32px;
+                }
+
+            .step-container:last-child dl {
+                border-left: 1px solid transparent;
+            }
+
+        .ctaLink {
+            background-color: transparent;
+            border: 1px solid transparent;
+            color: #006AB1;
+            cursor: pointer;
+            font-weight: 600;
+            padding: 0;
+            white-space: normal;
+        }
+
+            .ctaLink:focus {
+                outline: 1px solid #00bcf2;
+            }
+
+            .ctaLink:hover {
+                text-decoration: underline;
+            }
+
+        .step-icon {
+            display: flex;
+            height: 38px;
+            margin-right: 15px;
+            width: 38px;
+        }
+
+            .step-icon > div {
+                height: 30px;
+                width: 30px;
+                background-repeat: no-repeat;
+            }
+
+        .ms-logo-container {
+            min-width: 580px;
+            max-width: 980px;
+            margin-left: auto;
+            margin-right: auto;
+            left: 0;
+            right: 0;
+            transition: bottom 400ms;
+        }
+
+        .ms-logo {
+            float: right;
+            background-image: url("data:image/svg+xml;utf8,%0A%3Csvg%20version%3D%221.1%22%20id%3D%22MS-symbol%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20viewBox%3D%220%200%20400%20120%22%20style%3D%22enable-background%3Anew%200%200%20400%20120%3B%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cstyle%20type%3D%22text/css%22%3E%0A%09.st0%7Bfill%3Anone%3B%7D%0A%09.st1%7Bfill%3A%23737474%3B%7D%0A%09.st2%7Bfill%3A%23D63F26%3B%7D%0A%09.st3%7Bfill%3A%23167D3E%3B%7D%0A%09.st4%7Bfill%3A%232E76BC%3B%7D%0A%09.st5%7Bfill%3A%23FDB813%3B%7D%0A%3C/style%3E%0A%3Crect%20x%3D%220.6%22%20class%3D%22st0%22%20width%3D%22398.7%22%20height%3D%22119%22/%3E%0A%3Cpath%20class%3D%22st1%22%20d%3D%22M171.3%2C38.4v43.2h-7.5V47.7h-0.1l-13.4%2C33.9h-5l-13.7-33.9h-0.1v33.9h-6.9V38.4h10.8l12.4%2C32h0.2l13.1-32H171.3%0A%09z%20M177.6%2C41.7c0-1.2%2C0.4-2.2%2C1.3-3c0.9-0.8%2C1.9-1.2%2C3.1-1.2c1.3%2C0%2C2.4%2C0.4%2C3.2%2C1.3c0.8%2C0.8%2C1.3%2C1.8%2C1.3%2C3c0%2C1.2-0.4%2C2.2-1.3%2C3%0A%09c-0.9%2C0.8-1.9%2C1.2-3.2%2C1.2s-2.3-0.4-3.1-1.2C178%2C43.8%2C177.6%2C42.8%2C177.6%2C41.7z%20M185.7%2C50.6v31h-7.3v-31H185.7z%20M207.8%2C76.3%0A%09c1.1%2C0%2C2.3-0.3%2C3.6-0.8c1.3-0.5%2C2.5-1.2%2C3.6-2v6.8c-1.2%2C0.7-2.5%2C1.2-4%2C1.5c-1.5%2C0.3-3.1%2C0.5-4.9%2C0.5c-4.6%2C0-8.3-1.4-11.1-4.3%0A%09c-2.9-2.9-4.3-6.6-4.3-11c0-5%2C1.5-9.1%2C4.4-12.3c2.9-3.2%2C7-4.8%2C12.4-4.8c1.4%2C0%2C2.7%2C0.2%2C4.1%2C0.5c1.4%2C0.4%2C2.5%2C0.8%2C3.3%2C1.2v7%0A%09c-1.1-0.8-2.3-1.5-3.4-1.9c-1.2-0.5-2.4-0.7-3.6-0.7c-2.9%2C0-5.2%2C0.9-7%2C2.8c-1.8%2C1.9-2.7%2C4.4-2.7%2C7.6c0%2C3.1%2C0.8%2C5.6%2C2.5%2C7.3%0A%09C202.6%2C75.4%2C204.9%2C76.3%2C207.8%2C76.3z%20M235.7%2C50.1c0.6%2C0%2C1.1%2C0%2C1.6%2C0.1s0.9%2C0.2%2C1.2%2C0.3v7.4c-0.4-0.3-0.9-0.5-1.7-0.8%0A%09c-0.7-0.3-1.6-0.4-2.7-0.4c-1.8%2C0-3.3%2C0.8-4.5%2C2.3c-1.2%2C1.5-1.9%2C3.8-1.9%2C7v15.6h-7.3v-31h7.3v4.9h0.1c0.7-1.7%2C1.7-3%2C3-4%0A%09C232.2%2C50.6%2C233.8%2C50.1%2C235.7%2C50.1z%20M238.9%2C66.6c0-5.1%2C1.4-9.2%2C4.3-12.2c2.9-3%2C6.9-4.5%2C12.1-4.5c4.8%2C0%2C8.6%2C1.4%2C11.3%2C4.3%0A%09c2.7%2C2.9%2C4.1%2C6.8%2C4.1%2C11.7c0%2C5-1.4%2C9-4.3%2C12c-2.9%2C3-6.8%2C4.5-11.8%2C4.5c-4.8%2C0-8.6-1.4-11.4-4.2C240.3%2C75.3%2C238.9%2C71.4%2C238.9%2C66.6z%0A%09%20M246.5%2C66.3c0%2C3.2%2C0.7%2C5.7%2C2.2%2C7.4c1.5%2C1.7%2C3.6%2C2.6%2C6.3%2C2.6c2.7%2C0%2C4.7-0.9%2C6.1-2.6c1.4-1.7%2C2.1-4.2%2C2.1-7.6c0-3.3-0.7-5.8-2.2-7.5%0A%09c-1.4-1.7-3.4-2.5-6-2.5c-2.7%2C0-4.7%2C0.9-6.2%2C2.7C247.2%2C60.5%2C246.5%2C63%2C246.5%2C66.3z%20M281.5%2C58.8c0%2C1%2C0.3%2C1.9%2C1%2C2.5%0A%09c0.7%2C0.6%2C2.1%2C1.3%2C4.4%2C2.2c2.9%2C1.2%2C5%2C2.5%2C6.1%2C3.9c1.2%2C1.5%2C1.8%2C3.2%2C1.8%2C5.3c0%2C2.9-1.1%2C5.3-3.4%2C7c-2.2%2C1.8-5.3%2C2.7-9.1%2C2.7%0A%09c-1.3%2C0-2.7-0.2-4.3-0.5c-1.6-0.3-2.9-0.7-4-1.2v-7.2c1.3%2C0.9%2C2.8%2C1.7%2C4.3%2C2.2c1.5%2C0.5%2C2.9%2C0.8%2C4.2%2C0.8c1.6%2C0%2C2.9-0.2%2C3.6-0.7%0A%09c0.8-0.5%2C1.2-1.2%2C1.2-2.3c0-1-0.4-1.9-1.2-2.5c-0.8-0.7-2.4-1.5-4.6-2.4c-2.7-1.1-4.6-2.4-5.7-3.8c-1.1-1.4-1.7-3.2-1.7-5.4%0A%09c0-2.8%2C1.1-5.1%2C3.3-6.9c2.2-1.8%2C5.1-2.7%2C8.6-2.7c1.1%2C0%2C2.3%2C0.1%2C3.6%2C0.4c1.3%2C0.2%2C2.5%2C0.6%2C3.4%2C0.9v6.9c-1-0.6-2.1-1.2-3.4-1.7%0A%09c-1.3-0.5-2.6-0.7-3.8-0.7c-1.4%2C0-2.5%2C0.3-3.2%2C0.8C281.9%2C57.1%2C281.5%2C57.8%2C281.5%2C58.8z%20M297.9%2C66.6c0-5.1%2C1.4-9.2%2C4.3-12.2%0A%09c2.9-3%2C6.9-4.5%2C12.1-4.5c4.8%2C0%2C8.6%2C1.4%2C11.3%2C4.3c2.7%2C2.9%2C4.1%2C6.8%2C4.1%2C11.7c0%2C5-1.4%2C9-4.3%2C12c-2.9%2C3-6.8%2C4.5-11.8%2C4.5%0A%09c-4.8%2C0-8.6-1.4-11.4-4.2C299.4%2C75.3%2C297.9%2C71.4%2C297.9%2C66.6z%20M305.5%2C66.3c0%2C3.2%2C0.7%2C5.7%2C2.2%2C7.4c1.5%2C1.7%2C3.6%2C2.6%2C6.3%2C2.6%0A%09c2.7%2C0%2C4.7-0.9%2C6.1-2.6c1.4-1.7%2C2.1-4.2%2C2.1-7.6c0-3.3-0.7-5.8-2.2-7.5c-1.4-1.7-3.4-2.5-6-2.5c-2.7%2C0-4.7%2C0.9-6.2%2C2.7%0A%09C306.3%2C60.5%2C305.5%2C63%2C305.5%2C66.3z%20M353.9%2C56.6h-10.9v25h-7.4v-25h-5.2v-6h5.2v-4.3c0-3.3%2C1.1-5.9%2C3.2-8c2.1-2.1%2C4.8-3.1%2C8.1-3.1%0A%09c0.9%2C0%2C1.7%2C0%2C2.4%2C0.1c0.7%2C0.1%2C1.3%2C0.2%2C1.8%2C0.4V42c-0.2-0.1-0.7-0.3-1.3-0.5c-0.6-0.2-1.3-0.3-2.1-0.3c-1.5%2C0-2.7%2C0.5-3.5%2C1.4%0A%09s-1.2%2C2.4-1.2%2C4.2v3.7h10.9v-7l7.3-2.2v9.2h7.4v6h-7.4v14.5c0%2C1.9%2C0.3%2C3.3%2C1%2C4c0.7%2C0.8%2C1.8%2C1.2%2C3.3%2C1.2c0.4%2C0%2C0.9-0.1%2C1.5-0.3%0A%09c0.6-0.2%2C1.1-0.4%2C1.6-0.7v6c-0.5%2C0.3-1.2%2C0.5-2.3%2C0.7c-1.1%2C0.2-2.1%2C0.3-3.2%2C0.3c-3.1%2C0-5.4-0.8-6.9-2.5c-1.5-1.6-2.3-4.1-2.3-7.4%0A%09V56.6z%22/%3E%0A%3Cg%3E%0A%09%3Crect%20x%3D%2231%22%20y%3D%2224%22%20class%3D%22st2%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2268.8%22%20y%3D%2224%22%20class%3D%22st3%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2231%22%20y%3D%2261.8%22%20class%3D%22st4%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2268.8%22%20y%3D%2261.8%22%20class%3D%22st5%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%3C/g%3E%0A%3C/svg%3E%0A");
+        }
+
+        .ms-logo-container > div {
+            min-height: 60px;
+            width: 150px;
+            background-repeat: no-repeat;
+        }
+
+        .row {
+            padding: 90px 0px 0 20px;
+            min-width: 480px;
+            max-width: 1366px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        .column {
+            float: left;
+            width: 45%;
+            padding-right: 20px;
+        }
+
+        .row:after {
+            content: "";
+            display: table;
+            clear: both;
+        }
+
+        a {
+            text-decoration: none;
+        }
+
+        .download-the-emulator {
+            height: 20px;
+            color: #0063B1;
+            font-size: 15px;
+            line-height: 20px;
+            padding-bottom: 70px;
+        }
+
+        .how-to-iframe {
+            max-width: 700px !important;
+            min-width: 650px !important;
+            height: 700px !important;
+        }
+
+        .remove-frame-height {
+            height: 10px;
+        }
+
+        @media only screen and (max-width: 1300px) {
+            .ms-logo {
+                padding-top: 30px;
+            }
+
+            .header-text {
+                font-size: 40x;
+            }
+
+            .column {
+                float: none;
+                padding-top: 30px;
+                width: 100%;
+            }
+
+            .ms-logo-container {
+                padding-top: 30px;
+                min-width: 480px;
+                max-width: 650px;
+                margin-left: auto;
+                margin-right: auto;
+            }
+
+            .row {
+                padding: 20px 0px 0 20px;
+                min-width: 480px;
+                max-width: 650px;
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
+
+        @media only screen and (max-width: 1370px) {
+            header {
+                background-color: #55A0E0;
+                background-size: auto 200px;
+            }
+        }
+
+        @media only screen and (max-width: 1230px) {
+            header {
+                background-color: #55A0E0;
+                background-size: auto 200px;
+            }
+
+            .header-text {
+                font-size: 44px;
+            }
+
+            .header-icon {
+                height: 120px;
+                width: 120px;
+            }
+        }
+
+        @media only screen and (max-width: 1000px) {
+            header {
+                background-color: #55A0E0;
+                background-image: none;
+            }
+        }
+
+        @media only screen and (max-width: 632px) {
+            .header-text {
+                font-size: 32px;
+            }
+
+            .row {
+                padding: 10px 0px 0 10px;
+                max-width: 490px !important;
+                min-width: 410px !important;
+            }
+
+            .endpoint {
+                font-size: 25px;
+            }
+
+            .main-text {
+                font-size: 20px;
+            }
+
+            .step-container dl > dd {
+                font-size: 14px;
+            }
+
+            .column {
+                padding-right: 5px;
+            }
+
+            .header-icon {
+                height: 110px;
+                width: 110px;
+            }
+
+            .how-to-iframe {
+                max-width: 480px !important;
+                min-width: 400px !important;
+                height: 650px !important;
+                overflow: hidden;
+            }
+        }
+
+        .remove-frame-height {
+            max-height: 10px;
+        }
+    </style>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            loadFrame();
+        });
+        var loadFrame = function () {
+            var iframe = document.createElement('iframe');
+            iframe.setAttribute("id", "iframe");
+            var offLineHTMLContent = "";
+            var frameElement = document.getElementById("how-to-iframe");
+            if (window.navigator.onLine) {
+                iframe.src = 'https://docs.botframework.com/static/abs/pages/f5.htm';
+                iframe.setAttribute("scrolling", "no");
+                iframe.setAttribute("frameborder", "0");
+                iframe.setAttribute("width", "100%");
+                iframe.setAttribute("height", "100%");
+                var frameDiv = document.getElementById("how-to-iframe");
+                frameDiv.appendChild(iframe);
+            } else {
+                frameElement.classList.add("remove-frame-height");
+            }
+        };
+    </script>
+</head>
+
+<body>
+    <header class="header">
+        <div class="header-inner-container">
+            <div class="header-icon" style="display: inline-block"></div>
+            <div class="header-text" style="display: inline-block">Basic Bot</div>
+        </div>
+    </header>
+    <div class="row">
+        <div class="column" class="main-content-area">
+            <div class="content-title">Your bot is ready!</div>
+            <div class="main-text main-text-p1">
+                You can test your bot in the Bot Framework Emulator<br />
+                by opening the .bot file in the project folder.
+            </div>
+            <div class="main-text download-the-emulator">
+                <a class="ctaLink" href="https://aka.ms/bot-framework-F5-download-emulator"
+                   target="_blank">Download the Emulator</a>
+            </div>
+            <div class="main-text">
+                Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home" target="_blank">
+                    Azure
+                    Bot Service
+                </a> to register your bot and add it to<br />
+                various channels. The bot's endpoint URL typically looks
+                like this:
+            </div>
+            <div class="endpoint">https://<i>your_bots_hostname</i>/api/messages</div>
+        </div>
+        <div class="column how-to-iframe" id="how-to-iframe"></div>
+    </div>
+    </div>
+    <div class="ms-logo-container">
+        <div class="ms-logo"></div>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
Adding a sample to demonstrates how to create a multiturn support bot with ASP.Net Core 2.
This sample shows how to:
Use QnA Maker to create a multiturn support bot. It also uses active learning feature of QnA Maker to generate suggestions and use them to further train the knowledge base. 
It uses application insights for logging details.
This sample can also optionally use Personality chat to chat with the user if no match is found in QnA Maker. 
It can optionally use LUISmodel to get the trained intent.