### PR TITLE
Added AutoSaveMiddleWare to 18.bot-authentication to simplify sample

### DIFF
--- a/samples/csharp_dotnetcore/18.bot-authentication/Startup.cs
+++ b/samples/csharp_dotnetcore/18.bot-authentication/Startup.cs
@@ -115,6 +115,10 @@ namespace Microsoft.BotBuilderSamples
                 var conversationState = new ConversationState(dataStore);
 
                 options.State.Add(conversationState);
+
+                // Automatically save state at the end of a turn.
+                options.Middleware
+                    .Add(new AutoSaveStateMiddleware(conversationState));
             });
 
             // Create and register state accessors.


### PR DESCRIPTION
Fixes  #1338 

## Proposed Changes
Added AutoSaveMiddleWare to this sample so it is easier to use and doesn't confuse people learning OAuth flows. 
Without saving state the proposed WaterfallDialog will never reach all of its steps and confuse learners without any benefit.
