### PR TITLE
Added missing await to context.sendActivity in onTurnError

### DIFF
--- a/samples/javascript_typescript/13.basic-bot/src/index.ts
+++ b/samples/javascript_typescript/13.basic-bot/src/index.ts
@@ -58,7 +58,7 @@ adapter.onTurnError = async (context, error) => {
     //       application insights.
     console.error(`\n [onTurnError]: ${ error }`);
     // Send a message to the user
-    context.sendActivity(`Oops. Something went wrong!`);
+    await context.sendActivity(`Oops. Something went wrong!`);
     // Clear out state
     await conversationState.delete(context);
 };


### PR DESCRIPTION
## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->
<!-- If you are introducing a new sample, make sure that the sample adheres to sample guidelines -->

  - The "context.sendActivity" located in index.ts, line 61, in adapter.onTurnError is missing an await. Without, the bot fails with an ugly error.