### PR TITLE
Small update to documentation of javascript_nodejs/11.qnamaker

### DIFF
--- a/samples/javascript_nodejs/11.qnamaker/README.md
+++ b/samples/javascript_nodejs/11.qnamaker/README.md
@@ -59,7 +59,7 @@ QnA Maker enables you to power a question and answer service from your semi-stru
 One of the basic requirements in writing your own bot is to seed it with questions and answers. In many cases, the questions and answers already exist in content like FAQ URLs/documents, product manuals, etc. With QnA Maker, users can query your application in a natural, conversational manner. QnA Maker uses machine learning to extract relevant question-answer pairs from your content. It also uses powerful matching and ranking algorithms to provide the best possible match between the user query and the questions.
 
 # Deploy the bot to Azure
-After creating the bot and testing it locally, you can deploy it to Azure to make it accessible from anywhere.  [To deploy your bot to Azure][42]
+After creating the bot and testing it locally, [you can deploy it to Azure][40] to make it accessible from anywhere.
 
 ### Publishing Changes to Azure Bot Service
 As you make changes to your locally running bot, you can deploy those changes to Azure Bot Service using a _publish_ helper.  See `publish.cmd` if you are on Windows or `./publish` if you are on a non-Windows platform.  The following is an example of publishing local changes to Azure:
@@ -73,9 +73,6 @@ npm run build
 # run the publish helper (non-Windows) to update Azure Bot Service.  Use publish.cmd if running on Windows
 ./publish
 ```
-
-### Getting Additional Help with Deploying to Azure
-To learn more about deploying a bot to Azure, see [Deploy your bot to Azure][40] for a complete list of deployment instructions.
 
 # Further reading
 - [Bot Framework Documentation][20]

--- a/samples/javascript_nodejs/11.qnamaker/README.md
+++ b/samples/javascript_nodejs/11.qnamaker/README.md
@@ -59,12 +59,7 @@ QnA Maker enables you to power a question and answer service from your semi-stru
 One of the basic requirements in writing your own bot is to seed it with questions and answers. In many cases, the questions and answers already exist in content like FAQ URLs/documents, product manuals, etc. With QnA Maker, users can query your application in a natural, conversational manner. QnA Maker uses machine learning to extract relevant question-answer pairs from your content. It also uses powerful matching and ranking algorithms to provide the best possible match between the user query and the questions.
 
 # Deploy the bot to Azure
-After creating the bot and testing it locally, you can deploy it to Azure to make it accessible from anywhere.  To deploy your bot to Azure:
-
-```bash
-# login to Azure
-az login
-```
+After creating the bot and testing it locally, you can deploy it to Azure to make it accessible from anywhere.  [To deploy your bot to Azure][42]
 
 ### Publishing Changes to Azure Bot Service
 As you make changes to your locally running bot, you can deploy those changes to Azure Bot Service using a _publish_ helper.  See `publish.cmd` if you are on Windows or `./publish` if you are on a non-Windows platform.  The following is an example of publishing local changes to Azure:
@@ -116,3 +111,4 @@ To learn more about deploying a bot to Azure, see [Deploy your bot to Azure][40]
 [32]: https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-basics?view=azure-bot-service-4.0
 [40]: https://aka.ms/azuredeployment
 [41]: ./PREREQUISITES.md
+[42]: https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-deploy-az-cli?view=azure-bot-service-4.0

--- a/samples/javascript_nodejs/11.qnamaker/README.md
+++ b/samples/javascript_nodejs/11.qnamaker/README.md
@@ -108,4 +108,3 @@ npm run build
 [32]: https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-basics?view=azure-bot-service-4.0
 [40]: https://aka.ms/azuredeployment
 [41]: ./PREREQUISITES.md
-[42]: https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-deploy-az-cli?view=azure-bot-service-4.0


### PR DESCRIPTION
## Proposed Changes
  - Small change to the documentation of sample 11.qnamaker, from javascript_nodejs collection. The documentation included only the first step of deploying a bot and included the link to the full instructions further below. I was confused at first and found the link later on, I hope by pushing the link to the top it's more helpful to immediately refer to the full instructions.