### PR TITLE
Updated code to align with code generated by VSIX and some other updates

### DIFF
--- a/samples/csharp_dotnetcore/03.welcome-user/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/03.welcome-user/AdapterWithErrorHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.BotBuilderSamples
                 // Log any leaked exception from the application.
                 logger.LogError($"Exception caught : {exception.Message}");
 
-                // Send a catch-all appology to the user.
+                // Send a catch-all apology to the user.
                 await turnContext.SendActivityAsync("Sorry, it looks like something went wrong.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/AdapterWithErrorHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.BotBuilderSamples
                 // Log any leaked exception from the application.
                 logger.LogError($"Exception caught : {exception.Message}");
 
-                // Send a catch-all appology to the user.
+                // Send a catch-all apology to the user.
                 await turnContext.SendActivityAsync("Sorry, it looks like something went wrong.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/Bots/DialogBot.cs
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/Bots/DialogBot.cs
@@ -10,41 +10,41 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    // This IBot implementation can run any type of Dialog. The use of type parameterization is to allows multiple different bots
+    // This IBot implementation can run any type of Dialog. The use of type parametrization is to allows multiple different bots
     // to be run at different endpoints within the same project. This can be achieved by defining distinct Controller types
     // each with dependency on distinct IBot types, this way ASP Dependency Injection can glue everything together without ambiguity.
     // The ConversationState is used by the Dialog system. The UserState isn't, however, it might have been used in a Dialog implementation,
     // and the requirement is that all BotState objects are saved at the end of a turn.
     public class DialogBot<T> : ActivityHandler where T : Dialog 
     {
-        protected readonly Dialog _dialog;
-        protected readonly BotState _conversationState;
-        protected readonly BotState _userState;
-        protected readonly ILogger _logger;
+        protected readonly Dialog Dialog;
+        protected readonly BotState ConversationState;
+        protected readonly BotState UserState;
+        protected readonly ILogger Logger;
 
         public DialogBot(ConversationState conversationState, UserState userState, T dialog, ILogger<DialogBot<T>> logger)
         {
-            _conversationState = conversationState;
-            _userState = userState;
-            _dialog = dialog;
-            _logger = logger;
+            ConversationState = conversationState;
+            UserState = userState;
+            Dialog = dialog;
+            Logger = logger;
         }
 
-        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
         {
             await base.OnTurnAsync(turnContext, cancellationToken);
 
             // Save any state changes that might have occured during the turn.
-            await _conversationState.SaveChangesAsync(turnContext, false, cancellationToken);
-            await _userState.SaveChangesAsync(turnContext, false, cancellationToken);
+            await ConversationState.SaveChangesAsync(turnContext, false, cancellationToken);
+            await UserState.SaveChangesAsync(turnContext, false, cancellationToken);
         }
 
         protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Running dialog with Message Activity.");
+            Logger.LogInformation("Running dialog with Message Activity.");
 
             // Run the Dialog with the new message Activity.
-            await _dialog.Run(turnContext, _conversationState.CreateProperty<DialogState>("DialogState"), cancellationToken);
+            await Dialog.Run(turnContext, ConversationState.CreateProperty<DialogState>(nameof(DialogState)), cancellationToken);
         }
     }
 }

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/Bots/DialogBot.cs
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/Bots/DialogBot.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    // This IBot implementation can run any type of Dialog. The use of type parametrization is to allows multiple different bots
+    // This IBot implementation can run any type of Dialog. The use of type parameterization is to allows multiple different bots
     // to be run at different endpoints within the same project. This can be achieved by defining distinct Controller types
     // each with dependency on distinct IBot types, this way ASP Dependency Injection can glue everything together without ambiguity.
     // The ConversationState is used by the Dialog system. The UserState isn't, however, it might have been used in a Dialog implementation,

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/DialogExtensions.cs
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/DialogExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.BotBuilderSamples
 {
     public static class DialogExtensions
     {
-        public static async Task Run(this Dialog dialog, ITurnContext turnContext, IStatePropertyAccessor<DialogState> accessor, CancellationToken cancellationToken)
+        public static async Task Run(this Dialog dialog, ITurnContext turnContext, IStatePropertyAccessor<DialogState> accessor, CancellationToken cancellationToken = default(CancellationToken))
         {
             var dialogSet = new DialogSet(accessor);
             dialogSet.Add(dialog);

--- a/samples/csharp_dotnetcore/06.using-cards/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/06.using-cards/AdapterWithErrorHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.BotBuilderSamples
                 // Log any leaked exception from the application.
                 logger.LogError($"Exception caught : {exception.Message}");
 
-                // Send a catch-all appology to the user.
+                // Send a catch-all apology to the user.
                 await turnContext.SendActivityAsync("Sorry, it looks like something went wrong.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/06.using-cards/Bots/DialogBot.cs
+++ b/samples/csharp_dotnetcore/06.using-cards/Bots/DialogBot.cs
@@ -10,41 +10,41 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    // This IBot implementation can run any type of Dialog. The use of type parameterization is to allows multiple different bots
+    // This IBot implementation can run any type of Dialog. The use of type parametrization is to allows multiple different bots
     // to be run at different endpoints within the same project. This can be achieved by defining distinct Controller types
     // each with dependency on distinct IBot types, this way ASP Dependency Injection can glue everything together without ambiguity.
     // The ConversationState is used by the Dialog system. The UserState isn't, however, it might have been used in a Dialog implementation,
     // and the requirement is that all BotState objects are saved at the end of a turn.
-    public class DialogBot<T> : ActivityHandler where T : Dialog 
+    public class DialogBot<T> : ActivityHandler where T : Dialog
     {
-        protected readonly Dialog _dialog;
-        protected readonly BotState _conversationState;
-        protected readonly BotState _userState;
-        protected readonly ILogger _logger;
+        protected readonly BotState ConversationState;
+        protected readonly Dialog Dialog;
+        protected readonly ILogger Logger;
+        protected readonly BotState UserState;
 
         public DialogBot(ConversationState conversationState, UserState userState, T dialog, ILogger<DialogBot<T>> logger)
         {
-            _conversationState = conversationState;
-            _userState = userState;
-            _dialog = dialog;
-            _logger = logger;
+            ConversationState = conversationState;
+            UserState = userState;
+            Dialog = dialog;
+            Logger = logger;
         }
 
-        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
         {
             await base.OnTurnAsync(turnContext, cancellationToken);
 
             // Save any state changes that might have occured during the turn.
-            await _conversationState.SaveChangesAsync(turnContext, false, cancellationToken);
-            await _userState.SaveChangesAsync(turnContext, false, cancellationToken);
+            await ConversationState.SaveChangesAsync(turnContext, false, cancellationToken);
+            await UserState.SaveChangesAsync(turnContext, false, cancellationToken);
         }
 
         protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Running dialog with Message Activity.");
+            Logger.LogInformation("Running dialog with Message Activity.");
 
             // Run the Dialog with the new message Activity.
-            await _dialog.Run(turnContext, _conversationState.CreateProperty<DialogState>("DialogState"), cancellationToken);
+            await Dialog.Run(turnContext, ConversationState.CreateProperty<DialogState>(nameof(DialogState)), cancellationToken);
         }
     }
 }

--- a/samples/csharp_dotnetcore/06.using-cards/Bots/DialogBot.cs
+++ b/samples/csharp_dotnetcore/06.using-cards/Bots/DialogBot.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    // This IBot implementation can run any type of Dialog. The use of type parametrization is to allows multiple different bots
+    // This IBot implementation can run any type of Dialog. The use of type parameterization is to allows multiple different bots
     // to be run at different endpoints within the same project. This can be achieved by defining distinct Controller types
     // each with dependency on distinct IBot types, this way ASP Dependency Injection can glue everything together without ambiguity.
     // The ConversationState is used by the Dialog system. The UserState isn't, however, it might have been used in a Dialog implementation,

--- a/samples/csharp_dotnetcore/06.using-cards/DialogExtensions.cs
+++ b/samples/csharp_dotnetcore/06.using-cards/DialogExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.BotBuilderSamples
 {
     public static class DialogExtensions
     {
-        public static async Task Run(this Dialog dialog, ITurnContext turnContext, IStatePropertyAccessor<DialogState> accessor, CancellationToken cancellationToken)
+        public static async Task Run(this Dialog dialog, ITurnContext turnContext, IStatePropertyAccessor<DialogState> accessor, CancellationToken cancellationToken = default(CancellationToken))
         {
             var dialogSet = new DialogSet(accessor);
             dialogSet.Add(dialog);

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/AdapterWithErrorHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.BotBuilderSamples
                 // Log any leaked exception from the application.
                 logger.LogError($"Exception caught : {exception.Message}");
 
-                // Send a catch-all appology to the user.
+                // Send a catch-all apology to the user.
                 await turnContext.SendActivityAsync("Sorry, it looks like something went wrong.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/AdaptiveCardsBot.csproj
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/AdaptiveCardsBot.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdaptiveCards" Version="1.0.3" />
+    <PackageReference Include="AdaptiveCards" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.3.2" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.3.2" />

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/AdaptiveCardsBot.csproj
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/AdaptiveCardsBot.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdaptiveCards" Version="1.1.2" />
+    <PackageReference Include="AdaptiveCards" Version="1.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.3.2" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.3.2" />

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/Bots/AdaptiveCardsBot.cs
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/Bots/AdaptiveCardsBot.cs
@@ -4,14 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using AdaptiveCards;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
-using Remotion.Linq.Parsing.Structure.IntermediateModel;
 
 namespace Microsoft.BotBuilderSamples
 {
@@ -48,7 +45,7 @@ namespace Microsoft.BotBuilderSamples
         protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
             Random r = new Random();
-            var cardAttachment = CreateAdaptiveCardAttachment(this._cards[r.Next(this._cards.Length)]);
+            var cardAttachment = CreateAdaptiveCardAttachment(_cards[r.Next(_cards.Length)]);
 
             //turnContext.Activity.Attachments = new List<Attachment>() { cardAttachment };
             await turnContext.SendActivityAsync(MessageFactory.Attachment(cardAttachment), cancellationToken);

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/Controllers/BotController.cs
@@ -15,8 +15,8 @@ namespace Microsoft.BotBuilderSamples
     [ApiController]
     public class BotController : ControllerBase
     {
-        private IBotFrameworkHttpAdapter _adapter;
-        private IBot _bot;
+        private readonly IBotFrameworkHttpAdapter _adapter;
+        private readonly IBot _bot;
 
         public BotController(IBotFrameworkHttpAdapter adapter, IBot bot)
         {

--- a/samples/csharp_dotnetcore/13.core-bot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/13.core-bot/AdapterWithErrorHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.BotBuilderSamples
                 // Log any leaked exception from the application.
                 logger.LogError($"Exception caught : {exception.Message}");
 
-                // Send a catch-all appology to the user.
+                // Send a catch-all apology to the user.
                 await turnContext.SendActivityAsync("Sorry, it looks like something went wrong.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/13.core-bot/Bots/DialogBot.cs
+++ b/samples/csharp_dotnetcore/13.core-bot/Bots/DialogBot.cs
@@ -10,41 +10,41 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    // This IBot implementation can run any type of Dialog. The use of type parameterization is to allows multiple different bots
+    // This IBot implementation can run any type of Dialog. The use of type parametrization is to allows multiple different bots
     // to be run at different endpoints within the same project. This can be achieved by defining distinct Controller types
     // each with dependency on distinct IBot types, this way ASP Dependency Injection can glue everything together without ambiguity.
     // The ConversationState is used by the Dialog system. The UserState isn't, however, it might have been used in a Dialog implementation,
     // and the requirement is that all BotState objects are saved at the end of a turn.
-    public class DialogBot<T> : ActivityHandler where T : Dialog 
+    public class DialogBot<T> : ActivityHandler where T : Dialog
     {
-        protected readonly Dialog _dialog;
-        protected readonly BotState _conversationState;
-        protected readonly BotState _userState;
-        protected readonly ILogger _logger;
+        protected readonly BotState ConversationState;
+        protected readonly Dialog Dialog;
+        protected readonly ILogger Logger;
+        protected readonly BotState UserState;
 
         public DialogBot(ConversationState conversationState, UserState userState, T dialog, ILogger<DialogBot<T>> logger)
         {
-            _conversationState = conversationState;
-            _userState = userState;
-            _dialog = dialog;
-            _logger = logger;
+            ConversationState = conversationState;
+            UserState = userState;
+            Dialog = dialog;
+            Logger = logger;
         }
 
-        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
         {
             await base.OnTurnAsync(turnContext, cancellationToken);
 
             // Save any state changes that might have occured during the turn.
-            await _conversationState.SaveChangesAsync(turnContext, false, cancellationToken);
-            await _userState.SaveChangesAsync(turnContext, false, cancellationToken);
+            await ConversationState.SaveChangesAsync(turnContext, false, cancellationToken);
+            await UserState.SaveChangesAsync(turnContext, false, cancellationToken);
         }
 
         protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Running dialog with Message Activity.");
+            Logger.LogInformation("Running dialog with Message Activity.");
 
             // Run the Dialog with the new message Activity.
-            await _dialog.Run(turnContext, _conversationState.CreateProperty<DialogState>("DialogState"), cancellationToken);
+            await Dialog.Run(turnContext, ConversationState.CreateProperty<DialogState>(nameof(DialogState)), cancellationToken);
         }
     }
 }

--- a/samples/csharp_dotnetcore/13.core-bot/Bots/DialogBot.cs
+++ b/samples/csharp_dotnetcore/13.core-bot/Bots/DialogBot.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    // This IBot implementation can run any type of Dialog. The use of type parametrization is to allows multiple different bots
+    // This IBot implementation can run any type of Dialog. The use of type parameterization is to allows multiple different bots
     // to be run at different endpoints within the same project. This can be achieved by defining distinct Controller types
     // each with dependency on distinct IBot types, this way ASP Dependency Injection can glue everything together without ambiguity.
     // The ConversationState is used by the Dialog system. The UserState isn't, however, it might have been used in a Dialog implementation,

--- a/samples/csharp_dotnetcore/13.core-bot/DialogExtensions.cs
+++ b/samples/csharp_dotnetcore/13.core-bot/DialogExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.BotBuilderSamples
 {
     public static class DialogExtensions
     {
-        public static async Task Run(this Dialog dialog, ITurnContext turnContext, IStatePropertyAccessor<DialogState> accessor, CancellationToken cancellationToken)
+        public static async Task Run(this Dialog dialog, ITurnContext turnContext, IStatePropertyAccessor<DialogState> accessor, CancellationToken cancellationToken = default(CancellationToken))
         {
             var dialogSet = new DialogSet(accessor);
             dialogSet.Add(dialog);

--- a/samples/csharp_dotnetcore/15.handling-attachments/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/15.handling-attachments/AdapterWithErrorHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.BotBuilderSamples
                 // Log any leaked exception from the application.
                 logger.LogError($"Exception caught : {exception.Message}");
 
-                // Send a catch-all appology to the user.
+                // Send a catch-all apology to the user.
                 await turnContext.SendActivityAsync("Sorry, it looks like something went wrong.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/16.proactive-messages/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/16.proactive-messages/AdapterWithErrorHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.BotBuilderSamples
                 // Log any leaked exception from the application.
                 logger.LogError($"Exception caught : {exception.Message}");
 
-                // Send a catch-all appology to the user.
+                // Send a catch-all apology to the user.
                 await turnContext.SendActivityAsync("Sorry, it looks like something went wrong.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/17.multilingual-bot/MultiLingualBot.csproj
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/MultiLingualBot.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.3.2" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.3.2" />

--- a/samples/csharp_dotnetcore/17.multilingual-bot/Startup.cs
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/Startup.cs
@@ -173,7 +173,7 @@ namespace Microsoft.BotBuilderSamples
                 // State accessors enable other components to read and write individual properties of state.
                 var accessors = new MultiLingualBotAccessors(conversationState, userState)
                 {
-                    ConversationDialogState = conversationState.CreateProperty<DialogState>("DialogState"),
+                    ConversationDialogState = conversationState.CreateProperty<DialogState>(nameof(DialogState)),
                     LanguagePreference = userState.CreateProperty<string>("LanguagePreference"),
                 };
 

--- a/samples/csharp_dotnetcore/18.bot-authentication/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/18.bot-authentication/AdapterWithErrorHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.BotBuilderSamples
                 // Log any leaked exception from the application.
                 logger.LogError($"Exception caught : {exception.Message}");
 
-                // Send a catch-all appology to the user.
+                // Send a catch-all apology to the user.
                 await turnContext.SendActivityAsync("Sorry, it looks like something went wrong.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/18.bot-authentication/Bots/AuthBot.cs
+++ b/samples/csharp_dotnetcore/18.bot-authentication/Bots/AuthBot.cs
@@ -24,17 +24,17 @@ namespace Microsoft.BotBuilderSamples
             {
                 if (member.Id != turnContext.Activity.Recipient.Id)
                 {
-                    await turnContext.SendActivityAsync(MessageFactory.Text($"Welcome to AuthenticationBot. Type anything to get logged in. Type 'logout' to sign-out."), cancellationToken);
+                    await turnContext.SendActivityAsync(MessageFactory.Text("Welcome to AuthenticationBot. Type anything to get logged in. Type 'logout' to sign-out."), cancellationToken);
                 }
             }
         }
 
         protected override async Task OnTokenResponseEventAsync(ITurnContext<IEventActivity> turnContext, CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Running dialog with Token Response Event Activity.");
+            Logger.LogInformation("Running dialog with Token Response Event Activity.");
 
             // Run the Dialog with the new Token Response Event Activity.
-            await _dialog.Run(turnContext, _conversationState.CreateProperty<DialogState>(nameof(DialogState)), cancellationToken);
+            await Dialog.Run(turnContext, ConversationState.CreateProperty<DialogState>(nameof(DialogState)), cancellationToken);
         }
     }
 }

--- a/samples/csharp_dotnetcore/18.bot-authentication/Bots/DialogBot.cs
+++ b/samples/csharp_dotnetcore/18.bot-authentication/Bots/DialogBot.cs
@@ -10,41 +10,41 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    // This IBot implementation can run any type of Dialog. The use of type parameterization is to allows multiple different bots
+    // This IBot implementation can run any type of Dialog. The use of type parametrization is to allows multiple different bots
     // to be run at different endpoints within the same project. This can be achieved by defining distinct Controller types
     // each with dependency on distinct IBot types, this way ASP Dependency Injection can glue everything together without ambiguity.
     // The ConversationState is used by the Dialog system. The UserState isn't, however, it might have been used in a Dialog implementation,
     // and the requirement is that all BotState objects are saved at the end of a turn.
-    public class DialogBot<T> : ActivityHandler where T : Dialog 
+    public class DialogBot<T> : ActivityHandler where T : Dialog
     {
-        protected readonly Dialog _dialog;
-        protected readonly BotState _conversationState;
-        protected readonly BotState _userState;
-        protected readonly ILogger _logger;
+        protected readonly BotState ConversationState;
+        protected readonly Dialog Dialog;
+        protected readonly ILogger Logger;
+        protected readonly BotState UserState;
 
         public DialogBot(ConversationState conversationState, UserState userState, T dialog, ILogger<DialogBot<T>> logger)
         {
-            _conversationState = conversationState;
-            _userState = userState;
-            _dialog = dialog;
-            _logger = logger;
+            ConversationState = conversationState;
+            UserState = userState;
+            Dialog = dialog;
+            Logger = logger;
         }
 
-        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
         {
             await base.OnTurnAsync(turnContext, cancellationToken);
 
             // Save any state changes that might have occured during the turn.
-            await _conversationState.SaveChangesAsync(turnContext, false, cancellationToken);
-            await _userState.SaveChangesAsync(turnContext, false, cancellationToken);
+            await ConversationState.SaveChangesAsync(turnContext, false, cancellationToken);
+            await UserState.SaveChangesAsync(turnContext, false, cancellationToken);
         }
 
         protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Running dialog with Message Activity.");
+            Logger.LogInformation("Running dialog with Message Activity.");
 
-            // Run the Dialog with the new Message Activity.
-            await _dialog.Run(turnContext, _conversationState.CreateProperty<DialogState>(nameof(DialogState)), cancellationToken);
+            // Run the Dialog with the new message Activity.
+            await Dialog.Run(turnContext, ConversationState.CreateProperty<DialogState>(nameof(DialogState)), cancellationToken);
         }
     }
 }

--- a/samples/csharp_dotnetcore/18.bot-authentication/Bots/DialogBot.cs
+++ b/samples/csharp_dotnetcore/18.bot-authentication/Bots/DialogBot.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    // This IBot implementation can run any type of Dialog. The use of type parametrization is to allows multiple different bots
+    // This IBot implementation can run any type of Dialog. The use of type parameterization is to allows multiple different bots
     // to be run at different endpoints within the same project. This can be achieved by defining distinct Controller types
     // each with dependency on distinct IBot types, this way ASP Dependency Injection can glue everything together without ambiguity.
     // The ConversationState is used by the Dialog system. The UserState isn't, however, it might have been used in a Dialog implementation,

--- a/samples/csharp_dotnetcore/18.bot-authentication/DialogExtensions.cs
+++ b/samples/csharp_dotnetcore/18.bot-authentication/DialogExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.BotBuilderSamples
 {
     public static class DialogExtensions
     {
-        public static async Task Run(this Dialog dialog, ITurnContext turnContext, IStatePropertyAccessor<DialogState> accessor, CancellationToken cancellationToken)
+        public static async Task Run(this Dialog dialog, ITurnContext turnContext, IStatePropertyAccessor<DialogState> accessor, CancellationToken cancellationToken = default(CancellationToken))
         {
             var dialogSet = new DialogSet(accessor);
             dialogSet.Add(dialog);

--- a/samples/csharp_dotnetcore/18.bot-authentication/Dialogs/LogoutDialog.cs
+++ b/samples/csharp_dotnetcore/18.bot-authentication/Dialogs/LogoutDialog.cs
@@ -17,9 +17,9 @@ namespace Microsoft.BotBuilderSamples
             ConnectionName = connectionName;
         }
 
-        protected string ConnectionName { get; private set; }
+        protected string ConnectionName { get; }
 
-        protected override async Task<DialogTurnResult> OnBeginDialogAsync(DialogContext innerDc, object options, CancellationToken cancellationToken)
+        protected override async Task<DialogTurnResult> OnBeginDialogAsync(DialogContext innerDc, object options, CancellationToken cancellationToken = default(CancellationToken))
         {
             var result = await InterruptAsync(innerDc, cancellationToken);
             if (result != null)
@@ -30,7 +30,7 @@ namespace Microsoft.BotBuilderSamples
             return await base.OnBeginDialogAsync(innerDc, options, cancellationToken);
         }
 
-        protected override async Task<DialogTurnResult> OnContinueDialogAsync(DialogContext innerDc, CancellationToken cancellationToken)
+        protected override async Task<DialogTurnResult> OnContinueDialogAsync(DialogContext innerDc, CancellationToken cancellationToken = default(CancellationToken))
         {
             var result = await InterruptAsync(innerDc, cancellationToken);
             if (result != null)
@@ -41,7 +41,7 @@ namespace Microsoft.BotBuilderSamples
             return await base.OnContinueDialogAsync(innerDc, cancellationToken);
         }
 
-        private async Task<DialogTurnResult> InterruptAsync(DialogContext innerDc, CancellationToken cancellationToken)
+        private async Task<DialogTurnResult> InterruptAsync(DialogContext innerDc, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (innerDc.Context.Activity.Type == ActivityTypes.Message)
             {
@@ -53,9 +53,10 @@ namespace Microsoft.BotBuilderSamples
                     var botAdapter = (BotFrameworkAdapter)innerDc.Context.Adapter;
                     await botAdapter.SignOutUserAsync(innerDc.Context, ConnectionName, null, cancellationToken);
                     await innerDc.Context.SendActivityAsync(MessageFactory.Text("You have been signed out."), cancellationToken);
-                    return await innerDc.CancelAllDialogsAsync();
+                    return await innerDc.CancelAllDialogsAsync(cancellationToken);
                 }
             }
+
             return null;
         }
     }

--- a/samples/csharp_dotnetcore/18.bot-authentication/Dialogs/MainDialog.cs
+++ b/samples/csharp_dotnetcore/18.bot-authentication/Dialogs/MainDialog.cs
@@ -13,12 +13,12 @@ namespace Microsoft.BotBuilderSamples
 {
     public class MainDialog : LogoutDialog
     {
-        protected readonly ILogger _logger;
+        protected readonly ILogger Logger;
 
         public MainDialog(IConfiguration configuration, ILogger<MainDialog> logger)
             : base(nameof(MainDialog), configuration["ConnectionName"])
         {
-            _logger = logger;
+            Logger = logger;
 
             AddDialog(new OAuthPrompt(
                 nameof(OAuthPrompt),
@@ -61,7 +61,7 @@ namespace Microsoft.BotBuilderSamples
             }
 
             await stepContext.Context.SendActivityAsync(MessageFactory.Text("Login was not successful please try again."), cancellationToken);
-            return await stepContext.EndDialogAsync();
+            return await stepContext.EndDialogAsync(cancellationToken: cancellationToken);
         }
 
         private async Task<DialogTurnResult> DisplayTokenPhase1Async(WaterfallStepContext stepContext, CancellationToken cancellationToken)
@@ -82,7 +82,7 @@ namespace Microsoft.BotBuilderSamples
                 return await stepContext.BeginDialogAsync(nameof(OAuthPrompt), cancellationToken: cancellationToken);
             }
 
-            return await stepContext.EndDialogAsync();
+            return await stepContext.EndDialogAsync(cancellationToken: cancellationToken);
         }
 
         private async Task<DialogTurnResult> DisplayTokenPhase2Async(WaterfallStepContext stepContext, CancellationToken cancellationToken)
@@ -93,7 +93,7 @@ namespace Microsoft.BotBuilderSamples
                 await stepContext.Context.SendActivityAsync(MessageFactory.Text($"Here is your token {tokenResponse.Token}"), cancellationToken);
             }
 
-            return await stepContext.EndDialogAsync();
+            return await stepContext.EndDialogAsync(cancellationToken: cancellationToken);
         }
     }
 }

--- a/samples/csharp_dotnetcore/18.bot-authentication/Program.cs
+++ b/samples/csharp_dotnetcore/18.bot-authentication/Program.cs
@@ -16,7 +16,7 @@ namespace Microsoft.BotBuilderSamples
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .ConfigureLogging((logging) =>
+                .ConfigureLogging(logging =>
                 {
                     logging.AddDebug();
                     logging.AddConsole();

--- a/samples/csharp_dotnetcore/18.bot-authentication/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/18.bot-authentication/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "Using_Cards": {
+    "AuthenticationBot": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/18.bot-authentication/README.md
+++ b/samples/csharp_dotnetcore/18.bot-authentication/README.md
@@ -13,7 +13,6 @@ updates also take steps towards an improved user experience by eliminating the m
 ```bash
 git clone https://github.com/microsoft/botbuilder-samples.git
 ```
-- [Optional] Update the `appsettings.json` file under `botbuilder-samples/samples/csharp_dotnetcore/18.bot-authentication` with your botFileSecret. For Azure Bot Service bots, you can find the botFileSecret under application settings.
 ## Prerequisites
 In this sample we are assuming the OAuth 2 provider
 is Azure Active Directory v2 (AADv2) and are utilizing the Microsoft Graph API to retrieve data about the

--- a/samples/csharp_dotnetcore/19.custom-dialogs/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/AdapterWithErrorHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.BotBuilderSamples
                 // Log any leaked exception from the application.
                 logger.LogError($"Exception caught : {exception.Message}");
 
-                // Send a catch-all appology to the user.
+                // Send a catch-all apology to the user.
                 await turnContext.SendActivityAsync("Sorry, it looks like something went wrong.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/19.custom-dialogs/Bots/DialogBot.cs
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/Bots/DialogBot.cs
@@ -10,41 +10,41 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    // This IBot implementation can run any type of Dialog. The use of type parameterization is to allows multiple different bots
+    // This IBot implementation can run any type of Dialog. The use of type parametrization is to allows multiple different bots
     // to be run at different endpoints within the same project. This can be achieved by defining distinct Controller types
     // each with dependency on distinct IBot types, this way ASP Dependency Injection can glue everything together without ambiguity.
     // The ConversationState is used by the Dialog system. The UserState isn't, however, it might have been used in a Dialog implementation,
     // and the requirement is that all BotState objects are saved at the end of a turn.
-    public class DialogBot<T> : ActivityHandler where T : Dialog 
+    public class DialogBot<T> : ActivityHandler where T : Dialog
     {
-        protected readonly Dialog _dialog;
-        protected readonly BotState _conversationState;
-        protected readonly BotState _userState;
-        protected readonly ILogger _logger;
+        protected readonly BotState ConversationState;
+        protected readonly Dialog Dialog;
+        protected readonly ILogger Logger;
+        protected readonly BotState UserState;
 
         public DialogBot(ConversationState conversationState, UserState userState, T dialog, ILogger<DialogBot<T>> logger)
         {
-            _conversationState = conversationState;
-            _userState = userState;
-            _dialog = dialog;
-            _logger = logger;
+            ConversationState = conversationState;
+            UserState = userState;
+            Dialog = dialog;
+            Logger = logger;
         }
 
-        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
         {
             await base.OnTurnAsync(turnContext, cancellationToken);
 
             // Save any state changes that might have occured during the turn.
-            await _conversationState.SaveChangesAsync(turnContext, false, cancellationToken);
-            await _userState.SaveChangesAsync(turnContext, false, cancellationToken);
+            await ConversationState.SaveChangesAsync(turnContext, false, cancellationToken);
+            await UserState.SaveChangesAsync(turnContext, false, cancellationToken);
         }
 
         protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Running dialog with Message Activity.");
+            Logger.LogInformation("Running dialog with Message Activity.");
 
             // Run the Dialog with the new message Activity.
-            await _dialog.Run(turnContext, _conversationState.CreateProperty<DialogState>("DialogState"), cancellationToken);
+            await Dialog.Run(turnContext, ConversationState.CreateProperty<DialogState>(nameof(DialogState)), cancellationToken);
         }
     }
 }

--- a/samples/csharp_dotnetcore/19.custom-dialogs/Bots/DialogBot.cs
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/Bots/DialogBot.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    // This IBot implementation can run any type of Dialog. The use of type parametrization is to allows multiple different bots
+    // This IBot implementation can run any type of Dialog. The use of type parameterization is to allows multiple different bots
     // to be run at different endpoints within the same project. This can be achieved by defining distinct Controller types
     // each with dependency on distinct IBot types, this way ASP Dependency Injection can glue everything together without ambiguity.
     // The ConversationState is used by the Dialog system. The UserState isn't, however, it might have been used in a Dialog implementation,

--- a/samples/csharp_dotnetcore/19.custom-dialogs/DialogExtensions.cs
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/DialogExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.BotBuilderSamples
 {
     public static class DialogExtensions
     {
-        public static async Task Run(this Dialog dialog, ITurnContext turnContext, IStatePropertyAccessor<DialogState> accessor, CancellationToken cancellationToken)
+        public static async Task Run(this Dialog dialog, ITurnContext turnContext, IStatePropertyAccessor<DialogState> accessor, CancellationToken cancellationToken = default(CancellationToken))
         {
             var dialogSet = new DialogSet(accessor);
             dialogSet.Add(dialog);

--- a/samples/csharp_dotnetcore/23.facebook-events/Facebook-Events-Bot.csproj
+++ b/samples/csharp_dotnetcore/23.facebook-events/Facebook-Events-Bot.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.3.2" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.3.2" />

--- a/samples/csharp_dotnetcore/23.facebook-events/Startup.cs
+++ b/samples/csharp_dotnetcore/23.facebook-events/Startup.cs
@@ -139,7 +139,7 @@ namespace Facebook_Events_Bot
                 // to hand it to our IBot class that is create per-request.
                 var accessors = new BotAccessors
                 {
-                    ConversationDialogState = conversationState.CreateProperty<DialogState>("DialogState"),
+                    ConversationDialogState = conversationState.CreateProperty<DialogState>(nameof(DialogState)),
                 };
 
                 return accessors;

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/AdapterWithErrorHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.BotBuilderSamples
                 // Log any leaked exception from the application.
                 logger.LogError($"Exception caught : {exception.Message}");
 
-                // Send a catch-all appology to the user.
+                // Send a catch-all apology to the user.
                 await turnContext.SendActivityAsync("Sorry, it looks like something went wrong.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/Bots/AuthBot.cs
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/Bots/AuthBot.cs
@@ -31,10 +31,10 @@ namespace Microsoft.BotBuilderSamples
 
         protected override async Task OnTokenResponseEventAsync(ITurnContext<IEventActivity> turnContext, CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Running dialog with Token Response Event Activity.");
+            Logger.LogInformation("Running dialog with Token Response Event Activity.");
 
             // Run the Dialog with the new Token Response Event Activity.
-            await _dialog.Run(turnContext, _conversationState.CreateProperty<DialogState>(nameof(DialogState)), cancellationToken);
+            await Dialog.Run(turnContext, ConversationState.CreateProperty<DialogState>(nameof(DialogState)), cancellationToken);
         }
     }
 }

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/Bots/DialogBot.cs
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/Bots/DialogBot.cs
@@ -10,41 +10,41 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    // This IBot implementation can run any type of Dialog. The use of type parameterization is to allows multiple different bots
+    // This IBot implementation can run any type of Dialog. The use of type parametrization is to allows multiple different bots
     // to be run at different endpoints within the same project. This can be achieved by defining distinct Controller types
     // each with dependency on distinct IBot types, this way ASP Dependency Injection can glue everything together without ambiguity.
     // The ConversationState is used by the Dialog system. The UserState isn't, however, it might have been used in a Dialog implementation,
     // and the requirement is that all BotState objects are saved at the end of a turn.
-    public class DialogBot<T> : ActivityHandler where T : Dialog 
+    public class DialogBot<T> : ActivityHandler where T : Dialog
     {
-        protected readonly Dialog _dialog;
-        protected readonly BotState _conversationState;
-        protected readonly BotState _userState;
-        protected readonly ILogger _logger;
+        protected readonly BotState ConversationState;
+        protected readonly Dialog Dialog;
+        protected readonly ILogger Logger;
+        protected readonly BotState UserState;
 
         public DialogBot(ConversationState conversationState, UserState userState, T dialog, ILogger<DialogBot<T>> logger)
         {
-            _conversationState = conversationState;
-            _userState = userState;
-            _dialog = dialog;
-            _logger = logger;
+            ConversationState = conversationState;
+            UserState = userState;
+            Dialog = dialog;
+            Logger = logger;
         }
 
-        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
         {
             await base.OnTurnAsync(turnContext, cancellationToken);
 
             // Save any state changes that might have occured during the turn.
-            await _conversationState.SaveChangesAsync(turnContext, false, cancellationToken);
-            await _userState.SaveChangesAsync(turnContext, false, cancellationToken);
+            await ConversationState.SaveChangesAsync(turnContext, false, cancellationToken);
+            await UserState.SaveChangesAsync(turnContext, false, cancellationToken);
         }
 
         protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Running dialog with Message Activity.");
+            Logger.LogInformation("Running dialog with Message Activity.");
 
             // Run the Dialog with the new message Activity.
-            await _dialog.Run(turnContext, _conversationState.CreateProperty<DialogState>("DialogState"), cancellationToken);
+            await Dialog.Run(turnContext, ConversationState.CreateProperty<DialogState>(nameof(DialogState)), cancellationToken);
         }
     }
 }

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/Bots/DialogBot.cs
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/Bots/DialogBot.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    // This IBot implementation can run any type of Dialog. The use of type parametrization is to allows multiple different bots
+    // This IBot implementation can run any type of Dialog. The use of type parameterization is to allows multiple different bots
     // to be run at different endpoints within the same project. This can be achieved by defining distinct Controller types
     // each with dependency on distinct IBot types, this way ASP Dependency Injection can glue everything together without ambiguity.
     // The ConversationState is used by the Dialog system. The UserState isn't, however, it might have been used in a Dialog implementation,

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/DialogExtensions.cs
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/DialogExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.BotBuilderSamples
 {
     public static class DialogExtensions
     {
-        public static async Task Run(this Dialog dialog, ITurnContext turnContext, IStatePropertyAccessor<DialogState> accessor, CancellationToken cancellationToken)
+        public static async Task Run(this Dialog dialog, ITurnContext turnContext, IStatePropertyAccessor<DialogState> accessor, CancellationToken cancellationToken = default(CancellationToken))
         {
             var dialogSet = new DialogSet(accessor);
             dialogSet.Add(dialog);

--- a/samples/csharp_dotnetcore/40.timex-resolution/Constraints.cs
+++ b/samples/csharp_dotnetcore/40.timex-resolution/Constraints.cs
@@ -15,7 +15,7 @@ namespace Microsoft.BotBuilderSamples
     {
         public static void Examples()
         {
-            // When you give the recognzier the text "Wednesday 4 o'clock" you get these distinct TIMEX values back.
+            // When you give the recognizer the text "Wednesday 4 o'clock" you get these distinct TIMEX values back.
 
             // But our bot logic knows that whatever the user says it should be evaluated against the constraints of
             // a week from today with respect to the date part and in the evening with respect to the time part.

--- a/samples/csharp_dotnetcore/40.timex-resolution/LanguageGeneration.cs
+++ b/samples/csharp_dotnetcore/40.timex-resolution/LanguageGeneration.cs
@@ -7,15 +7,15 @@ using Microsoft.Recognizers.Text.DataTypes.TimexExpression;
 namespace Microsoft.BotBuilderSamples
 {
     /// <summary>
-    /// This langauge generation capabilitis are the logical opposite of what the recognizer does.
-    /// As an experiment try feeding the result of lanaguage generation back into a recognizer.
+    /// This language generation capabilities are the logical opposite of what the recognizer does.
+    /// As an experiment try feeding the result of language generation back into a recognizer.
     /// You should get back the same TIMEX expression in the result.
     /// </summary>
     public static class LanguageGeneration
     {
         private static void Describe(TimexProperty t)
         {
-            // Note natural language is often relative, for example the senstence "Yesterday all my troubles seemed so far away."
+            // Note natural language is often relative, for example the sentence "Yesterday all my troubles seemed so far away."
             // Having your bot say something like "next Wednesday" in a response can make it sound more natural.
             var referenceDate = DateTime.Now;
             Console.WriteLine($"{t.TimexValue} {t.ToNaturalLanguage(referenceDate)}");

--- a/samples/csharp_dotnetcore/40.timex-resolution/Parsing.cs
+++ b/samples/csharp_dotnetcore/40.timex-resolution/Parsing.cs
@@ -13,7 +13,7 @@ namespace Microsoft.BotBuilderSamples
     /// The "Types" property infers a datetimeV2 type from the underlying set of properties.
     /// If you take a TIMEX with date components and add time components you add the
     /// inferred type datetime (its still a date).
-    /// Logic can be written against the inferred type, perhaps to have the bot ask the user for disamiguation.
+    /// Logic can be written against the inferred type, perhaps to have the bot ask the user for disambiguation.
     /// </summary>
     public static class Parsing
     {

--- a/samples/csharp_dotnetcore/40.timex-resolution/Resolution.cs
+++ b/samples/csharp_dotnetcore/40.timex-resolution/Resolution.cs
@@ -13,7 +13,7 @@ namespace Microsoft.BotBuilderSamples
     {
         public static void Examples()
         {
-            // When you give the recognzier the text "Wednesday 4 o'clock" you get these distinct TIMEX values back.
+            // When you give the recognizer the text "Wednesday 4 o'clock" you get these distinct TIMEX values back.
 
             var today = DateTime.Now;
             var resolution = TimexResolver.Resolve(new[] { "XXXX-WXX-3T04", "XXXX-WXX-3T16" }, today);

--- a/samples/csharp_dotnetcore/40.timex-resolution/Timex-Resolution.csproj
+++ b/samples/csharp_dotnetcore/40.timex-resolution/Timex-Resolution.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.1.5" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.1.5" />
   </ItemGroup>
 
 </Project>

--- a/samples/csharp_dotnetcore/42.scaleout/DialogExtensions.cs
+++ b/samples/csharp_dotnetcore/42.scaleout/DialogExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.BotBuilderSamples
 {
     public static class DialogExtensions
     {
-        public static async Task Run(this Dialog dialog, ITurnContext turnContext, IStatePropertyAccessor<DialogState> accessor, CancellationToken cancellationToken)
+        public static async Task Run(this Dialog dialog, ITurnContext turnContext, IStatePropertyAccessor<DialogState> accessor, CancellationToken cancellationToken = default(CancellationToken))
         {
             var dialogSet = new DialogSet(accessor);
             dialogSet.Add(dialog);

--- a/samples/csharp_dotnetcore/43.complex-dialog/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/43.complex-dialog/AdapterWithErrorHandler.cs
@@ -22,7 +22,7 @@ namespace Microsoft.BotBuilderSamples
                 // Log any leaked exception from the application.
                 logger.LogError($"Exception caught : {exception.Message}");
 
-                // Send a catch-all appology to the user.
+                // Send a catch-all apology to the user.
                 await turnContext.SendActivityAsync("Sorry, it looks like something went wrong.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/43.complex-dialog/Bots/DialogBot.cs
+++ b/samples/csharp_dotnetcore/43.complex-dialog/Bots/DialogBot.cs
@@ -10,41 +10,41 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    // This IBot implementation can run any type of Dialog. The use of type parameterization is to allows multiple different bots
+    // This IBot implementation can run any type of Dialog. The use of type parametrization is to allows multiple different bots
     // to be run at different endpoints within the same project. This can be achieved by defining distinct Controller types
     // each with dependency on distinct IBot types, this way ASP Dependency Injection can glue everything together without ambiguity.
     // The ConversationState is used by the Dialog system. The UserState isn't, however, it might have been used in a Dialog implementation,
     // and the requirement is that all BotState objects are saved at the end of a turn.
-    public class DialogBot<T> : ActivityHandler where T : Dialog 
+    public class DialogBot<T> : ActivityHandler where T : Dialog
     {
-        protected readonly Dialog _dialog;
-        protected readonly BotState _conversationState;
-        protected readonly BotState _userState;
-        protected readonly ILogger _logger;
+        protected readonly BotState ConversationState;
+        protected readonly Dialog Dialog;
+        protected readonly ILogger Logger;
+        protected readonly BotState UserState;
 
         public DialogBot(ConversationState conversationState, UserState userState, T dialog, ILogger<DialogBot<T>> logger)
         {
-            _conversationState = conversationState;
-            _userState = userState;
-            _dialog = dialog;
-            _logger = logger;
+            ConversationState = conversationState;
+            UserState = userState;
+            Dialog = dialog;
+            Logger = logger;
         }
 
-        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
         {
             await base.OnTurnAsync(turnContext, cancellationToken);
 
             // Save any state changes that might have occured during the turn.
-            await _conversationState.SaveChangesAsync(turnContext, false, cancellationToken);
-            await _userState.SaveChangesAsync(turnContext, false, cancellationToken);
+            await ConversationState.SaveChangesAsync(turnContext, false, cancellationToken);
+            await UserState.SaveChangesAsync(turnContext, false, cancellationToken);
         }
 
         protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Running dialog with Message Activity.");
+            Logger.LogInformation("Running dialog with Message Activity.");
 
             // Run the Dialog with the new message Activity.
-            await _dialog.Run(turnContext, _conversationState.CreateProperty<DialogState>("DialogState"), cancellationToken);
+            await Dialog.Run(turnContext, ConversationState.CreateProperty<DialogState>(nameof(DialogState)), cancellationToken);
         }
     }
 }

--- a/samples/csharp_dotnetcore/43.complex-dialog/Bots/DialogBot.cs
+++ b/samples/csharp_dotnetcore/43.complex-dialog/Bots/DialogBot.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    // This IBot implementation can run any type of Dialog. The use of type parametrization is to allows multiple different bots
+    // This IBot implementation can run any type of Dialog. The use of type parameterization is to allows multiple different bots
     // to be run at different endpoints within the same project. This can be achieved by defining distinct Controller types
     // each with dependency on distinct IBot types, this way ASP Dependency Injection can glue everything together without ambiguity.
     // The ConversationState is used by the Dialog system. The UserState isn't, however, it might have been used in a Dialog implementation,

--- a/samples/csharp_dotnetcore/43.complex-dialog/DialogExtensions.cs
+++ b/samples/csharp_dotnetcore/43.complex-dialog/DialogExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.BotBuilderSamples
 {
     public static class DialogExtensions
     {
-        public static async Task Run(this Dialog dialog, ITurnContext turnContext, IStatePropertyAccessor<DialogState> accessor, CancellationToken cancellationToken)
+        public static async Task Run(this Dialog dialog, ITurnContext turnContext, IStatePropertyAccessor<DialogState> accessor, CancellationToken cancellationToken = default(CancellationToken))
         {
             var dialogSet = new DialogSet(accessor);
             dialogSet.Add(dialog);

--- a/samples/csharp_dotnetcore/44.prompt-users-for-input/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/44.prompt-users-for-input/AdapterWithErrorHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.BotBuilderSamples
                 // Log any leaked exception from the application.
                 logger.LogError($"Exception caught : {exception.Message}");
 
-                // Send a catch-all appology to the user.
+                // Send a catch-all apology to the user.
                 await turnContext.SendActivityAsync("Sorry, it looks like something went wrong.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/44.prompt-users-for-input/Bots/CustomPromptBot.cs
+++ b/samples/csharp_dotnetcore/44.prompt-users-for-input/Bots/CustomPromptBot.cs
@@ -13,13 +13,13 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.BotBuilderSamples
 {
-    // This IBot implementation can run any type of Dialog. The use of type parameterization is to allows multiple different bots
+    // This IBot implementation can run any type of Dialog. The use of type parametrization is to allows multiple different bots
     // to be run at different endpoints within the same project. This can be achieved by defining distinct Controller types
     // each with dependency on distinct IBot types, this way ASP Dependency Injection can glue everything together without ambiguity.
     public class CustomPromptBot : ActivityHandler 
     {
-        private BotState _userState;
-        private BotState _conversationState;
+        private readonly BotState _userState;
+        private readonly BotState _conversationState;
         
         public CustomPromptBot(ConversationState conversationState, UserState userState)
         {

--- a/samples/csharp_dotnetcore/44.prompt-users-for-input/Bots/CustomPromptBot.cs
+++ b/samples/csharp_dotnetcore/44.prompt-users-for-input/Bots/CustomPromptBot.cs
@@ -13,7 +13,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.BotBuilderSamples
 {
-    // This IBot implementation can run any type of Dialog. The use of type parametrization is to allows multiple different bots
+    // This IBot implementation can run any type of Dialog. The use of type parameterization is to allows multiple different bots
     // to be run at different endpoints within the same project. This can be achieved by defining distinct Controller types
     // each with dependency on distinct IBot types, this way ASP Dependency Injection can glue everything together without ambiguity.
     public class CustomPromptBot : ActivityHandler 

--- a/samples/csharp_dotnetcore/45.state-management/Bots/StateManagementBot.cs
+++ b/samples/csharp_dotnetcore/45.state-management/Bots/StateManagementBot.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
             _userState = userState;
         }
 
-        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
         {
             await base.OnTurnAsync(turnContext, cancellationToken);
 


### PR DESCRIPTION
- Updated Program.cs code to align with code generated by VSIX.
- Updated reference to WindowsAzure.Storage to Microsoft.Azure.Storage.Blob in ScalueoutBot.csproj
- Changed await _dialog.Run(turnContext, _conversationState.CreateProperty(**"DialogState"**), cancellationToken);
By await _dialog.Run(turnContext, _conversationState.CreateProperty(**nameof(DialogState)**), cancellationToken);
- Changed capitalization for protected Xyz _fieldName to protected Xyz FieldName.
- Changed calls to CreateProperty("DialogState")
to use nameof(DialogState)
- Added cancellationTokens to some calls where they were missing.
- Changed
"public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken)" to
"public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))"
- Consolidated references to Microsoft.ApplicationInsights.AspNetCore
- Fixed some typos in code comments