### PR TITLE
Sets dialogId for UserProfileDialog to nameof(UserProfileDialog)

### DIFF
--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/Dialogs/UserProfileDialog.cs
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/Dialogs/UserProfileDialog.cs
@@ -12,10 +12,10 @@ namespace Microsoft.BotBuilderSamples
 {
     public class UserProfileDialog : ComponentDialog
     {
-        private IStatePropertyAccessor<UserProfile> _userProfileAccessor;
+        private readonly IStatePropertyAccessor<UserProfile> _userProfileAccessor;
 
         public UserProfileDialog(UserState userState)
-            : base("root")
+            : base(nameof(UserProfileDialog))
         {
             _userProfileAccessor = userState.CreateProperty<UserProfile>("UserProfile");
 


### PR DESCRIPTION
Fixes #1349 (see issue for more details)
