### PR TITLE
[DotNet] Fixed StyleCop warnings in all projects

### DIFF
--- a/samples/csharp_dotnetcore/01.console-echo/BotBuilder.Ruleset
+++ b/samples/csharp_dotnetcore/01.console-echo/BotBuilder.Ruleset
@@ -7,6 +7,7 @@
     <Rule Id="IDE0003" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1101" Action="None" /> <!-- local calls prefixed with this -->       
     <Rule Id="SA1129" Action="None" /> <!-- don't use value type constructor-->
     <Rule Id="SA1200" Action="None" />

--- a/samples/csharp_dotnetcore/02.b.echo-with-counter/EchoBotWithCounter.ruleset
+++ b/samples/csharp_dotnetcore/02.b.echo-with-counter/EchoBotWithCounter.ruleset
@@ -5,6 +5,7 @@
     <Description Resource="MinimumRecommendedRules_Description" />
   </Localization>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1101" Action="None" />

--- a/samples/csharp_dotnetcore/03.welcome-user/Startup.cs
+++ b/samples/csharp_dotnetcore/03.welcome-user/Startup.cs
@@ -63,6 +63,7 @@ namespace Microsoft.BotBuilderSamples
                 {
                     throw new FileNotFoundException($"The .bot configuration file was not found. botFilePath: {botFilePath}");
                 }
+
                 // Loads .bot configuration file and adds a singleton that your Bot can access through dependency injection.
                 var botConfig = BotConfiguration.Load(botFilePath ?? @".\welcome-user.bot", secretKey);
                 services.AddSingleton(sp => botConfig ?? throw new InvalidOperationException($"The .bot configuration file could not be loaded. botFilePath: {botFilePath}"));

--- a/samples/csharp_dotnetcore/03.welcome-user/WelcomeUserBot.cs
+++ b/samples/csharp_dotnetcore/03.welcome-user/WelcomeUserBot.cs
@@ -81,6 +81,7 @@ namespace Microsoft.BotBuilderSamples
                 if (didBotWelcomeUser.DidBotWelcomeUser == false)
                 {
                     didBotWelcomeUser.DidBotWelcomeUser = true;
+
                     // Update user state flag to reflect bot handled first user interaction.
                     await _welcomeUserStateAccessors.WelcomeUserState.SetAsync(turnContext, didBotWelcomeUser);
                     await _welcomeUserStateAccessors.UserState.SaveChangesAsync(turnContext);

--- a/samples/csharp_dotnetcore/03.welcome-user/samples.ruleset
+++ b/samples/csharp_dotnetcore/03.welcome-user/samples.ruleset
@@ -5,6 +5,7 @@
     <Description Resource="MinimumRecommendedRules_Description" />
   </Localization>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1101" Action="None" />

--- a/samples/csharp_dotnetcore/04.simple-prompt/BotBuilder.ruleset
+++ b/samples/csharp_dotnetcore/04.simple-prompt/BotBuilder.ruleset
@@ -5,6 +5,7 @@
     <Description Resource="MinimumRecommendedRules_Description" />
   </Localization>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1101" Action="None" />

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/BotBuilder.ruleset
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/BotBuilder.ruleset
@@ -5,6 +5,7 @@
     <Description Resource="MinimumRecommendedRules_Description" />
   </Localization>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1101" Action="None" />

--- a/samples/csharp_dotnetcore/06.using-cards/BotBuilder.ruleset
+++ b/samples/csharp_dotnetcore/06.using-cards/BotBuilder.ruleset
@@ -8,6 +8,7 @@
     <Rule Id="IDE0003" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1101" Action="None" />    <!-- local calls prefixed with this -->
     <Rule Id="SA1129" Action="None" />    <!-- don't use value type constructor-->
     <Rule Id="SA1200" Action="None" />

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/BotBuilder.ruleset
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/BotBuilder.ruleset
@@ -8,6 +8,7 @@
     <Rule Id="IDE0003" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1101" Action="None" />   <!-- local calls prefixed with this -->
     <Rule Id="SA1129" Action="None" />   <!-- don't use value type constructor-->
     <Rule Id="SA1200" Action="None" />

--- a/samples/csharp_dotnetcore/08.suggested-actions/BotBuilder.ruleset
+++ b/samples/csharp_dotnetcore/08.suggested-actions/BotBuilder.ruleset
@@ -8,6 +8,7 @@
     <Rule Id="IDE0003" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1101" Action="None" />   <!-- local calls prefixed with this -->
     <Rule Id="SA1129" Action="None" />   <!-- don't use value type constructor-->
     <Rule Id="SA1200" Action="None" />

--- a/samples/csharp_dotnetcore/09.message-routing/MessageRoutingBot.ruleset
+++ b/samples/csharp_dotnetcore/09.message-routing/MessageRoutingBot.ruleset
@@ -8,6 +8,7 @@
     <Rule Id="AvoidAsyncVoid" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1101" Action="None" />
     <Rule Id="SA1129" Action="None" />

--- a/samples/csharp_dotnetcore/10.prompt-validations/BotBuilder.ruleset
+++ b/samples/csharp_dotnetcore/10.prompt-validations/BotBuilder.ruleset
@@ -5,6 +5,7 @@
     <Description Resource="MinimumRecommendedRules_Description" />
   </Localization>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1101" Action="None" />

--- a/samples/csharp_dotnetcore/11.qnamaker/BotBuilder.ruleset
+++ b/samples/csharp_dotnetcore/11.qnamaker/BotBuilder.ruleset
@@ -5,6 +5,7 @@
     <Description Resource="MinimumRecommendedRules_Description" />
   </Localization>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1101" Action="None" />

--- a/samples/csharp_dotnetcore/12.nlp-with-luis/LuisBot.ruleset
+++ b/samples/csharp_dotnetcore/12.nlp-with-luis/LuisBot.ruleset
@@ -5,6 +5,7 @@
     <Description Resource="MinimumRecommendedRules_Description" />
   </Localization>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1101" Action="None" />

--- a/samples/csharp_dotnetcore/13.basic-bot/BasicBot.cs
+++ b/samples/csharp_dotnetcore/13.basic-bot/BasicBot.cs
@@ -211,7 +211,7 @@ namespace Microsoft.BotBuilderSamples
         private Attachment CreateAdaptiveCardAttachment()
         {
             // combine path for cross platform support
-            string[] paths = {".", "Dialogs", "Welcome", "Resources", "welcomeCard.json"};
+            string[] paths = { ".", "Dialogs", "Welcome", "Resources", "welcomeCard.json" };
             string fullPath = Path.Combine(paths);
             var adaptiveCard = File.ReadAllText(fullPath);
             return new Attachment()

--- a/samples/csharp_dotnetcore/13.basic-bot/BasicBot.ruleset
+++ b/samples/csharp_dotnetcore/13.basic-bot/BasicBot.ruleset
@@ -8,6 +8,7 @@
     <Rule Id="AvoidAsyncVoid" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1101" Action="None" />
     <Rule Id="SA1129" Action="None" />

--- a/samples/csharp_dotnetcore/14.nlp-with-dispatch/NLP-With-Dispatch-Bot.ruleset
+++ b/samples/csharp_dotnetcore/14.nlp-with-dispatch/NLP-With-Dispatch-Bot.ruleset
@@ -5,6 +5,7 @@
     <Description Resource="MinimumRecommendedRules_Description" />
   </Localization>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1101" Action="None" />

--- a/samples/csharp_dotnetcore/14.nlp-with-dispatch/Startup.cs
+++ b/samples/csharp_dotnetcore/14.nlp-with-dispatch/Startup.cs
@@ -81,7 +81,6 @@ namespace NLP_With_Dispatch_Bot
 
             services.AddBot<NlpDispatchBot>(options =>
             {
-
                 options.CredentialProvider = new SimpleCredentialProvider(endpointService.AppId, endpointService.AppPassword);
 
                 // Creates a logger for the application to use.
@@ -182,7 +181,6 @@ namespace NLP_With_Dispatch_Bot
                             // {
                             //     throw new InvalidOperationException("The Subscription Key ('subscriptionKey') is required to run this sample. Please update your '.bot' file.");
                             // }
-
                             if (string.IsNullOrWhiteSpace(luis.Region))
                             {
                                 throw new InvalidOperationException("The Region ('region') is required to run this sample. Please update your '.bot' file.");

--- a/samples/csharp_dotnetcore/15.handling-attachments/BotBuilder.ruleset
+++ b/samples/csharp_dotnetcore/15.handling-attachments/BotBuilder.ruleset
@@ -8,6 +8,7 @@
     <Rule Id="IDE0003" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1101" Action="None" />   <!-- local calls prefixed with this -->
     <Rule Id="SA1129" Action="None" />   <!-- don't use value type constructor-->
     <Rule Id="SA1200" Action="None" />

--- a/samples/csharp_dotnetcore/16.proactive-messages/BotBuilder.ruleset
+++ b/samples/csharp_dotnetcore/16.proactive-messages/BotBuilder.ruleset
@@ -5,6 +5,7 @@
     <Description Resource="MinimumRecommendedRules_Description" />
   </Localization>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1101" Action="None" />

--- a/samples/csharp_dotnetcore/16.proactive-messages/Startup.cs
+++ b/samples/csharp_dotnetcore/16.proactive-messages/Startup.cs
@@ -120,7 +120,6 @@ namespace Microsoft.BotBuilderSamples
                     logger.LogError($"Exception caught : {exception}");
                     await context.SendActivityAsync("Sorry, it looks like something went wrong.");
                 };
-
             });
 
             services.AddSingleton(sp =>
@@ -133,7 +132,6 @@ namespace Microsoft.BotBuilderSamples
 
                 return (EndpointService)service;
             });
-
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)

--- a/samples/csharp_dotnetcore/17.multilingual-bot/BotBuilder.ruleset
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/BotBuilder.ruleset
@@ -8,6 +8,7 @@
     <Rule Id="AvoidAsyncVoid" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1101" Action="None" />
     <Rule Id="SA1129" Action="None" />

--- a/samples/csharp_dotnetcore/17.multilingual-bot/Startup.cs
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/Startup.cs
@@ -68,7 +68,7 @@ namespace Microsoft.BotBuilderSamples
                 // Loads .bot configuration file and adds a singleton that your Bot can access through dependency injection.
                 var botConfig = BotConfiguration.Load(botFilePath ?? @".\multilingual-bot.bot", secretKey);
                 services.AddSingleton(sp => botConfig ?? throw new InvalidOperationException($"The .bot configuration file could not be loaded. botFilePath: {botFilePath}"));
-              
+
                 // Retrieve current endpoint.
                 var environment = _isProduction ? "production" : "development";
                 var service = botConfig.Services.FirstOrDefault(s => s.Type == "endpoint" && s.Name == environment);

--- a/samples/csharp_dotnetcore/18.bot-authentication/BotBuilder.ruleset
+++ b/samples/csharp_dotnetcore/18.bot-authentication/BotBuilder.ruleset
@@ -8,6 +8,7 @@
     <Rule Id="IDE0003" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1101" Action="None" />   <!-- local calls prefixed with this -->
     <Rule Id="SA1129" Action="None" />   <!-- don't use value type constructor-->
     <Rule Id="SA1200" Action="None" />

--- a/samples/csharp_dotnetcore/19.custom-dialogs/Custom-Dialog-Bot.ruleset
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/Custom-Dialog-Bot.ruleset
@@ -5,6 +5,7 @@
     <Description Resource="MinimumRecommendedRules_Description" />
   </Localization>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1101" Action="None" />

--- a/samples/csharp_dotnetcore/20.qna-with-appinsights/QnABot.ruleset
+++ b/samples/csharp_dotnetcore/20.qna-with-appinsights/QnABot.ruleset
@@ -5,6 +5,7 @@
     <Description Resource="MinimumRecommendedRules_Description" />
   </Localization>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1101" Action="None" />

--- a/samples/csharp_dotnetcore/21.luis-with-appinsights/LuisBot.ruleset
+++ b/samples/csharp_dotnetcore/21.luis-with-appinsights/LuisBot.ruleset
@@ -5,6 +5,7 @@
     <Description Resource="MinimumRecommendedRules_Description" />
   </Localization>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1101" Action="None" />

--- a/samples/csharp_dotnetcore/21.luis-with-appinsights/Startup.cs
+++ b/samples/csharp_dotnetcore/21.luis-with-appinsights/Startup.cs
@@ -182,7 +182,6 @@ namespace Microsoft.BotBuilderSamples
                             // {
                             //     throw new InvalidOperationException("The Subscription Key ('subscriptionKey') is required to run this sample.  Please update your '.bot' file.");
                             // }
-
                             if (string.IsNullOrWhiteSpace(luis.Region))
                             {
                                 throw new InvalidOperationException("The Region ('region') is required to run this sample.  Please update your '.bot' file.");

--- a/samples/csharp_dotnetcore/22.conversation-history/BotBuilder.ruleset
+++ b/samples/csharp_dotnetcore/22.conversation-history/BotBuilder.ruleset
@@ -5,6 +5,7 @@
     <Description Resource="MinimumRecommendedRules_Description" />
   </Localization>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1101" Action="None" />

--- a/samples/csharp_dotnetcore/23.facebook-events/BotBuilder.ruleset
+++ b/samples/csharp_dotnetcore/23.facebook-events/BotBuilder.ruleset
@@ -8,6 +8,7 @@
     <Rule Id="AvoidAsyncVoid" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1101" Action="None" />
     <Rule Id="SA1129" Action="None" />

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/BotBuilder.ruleset
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/BotBuilder.ruleset
@@ -9,6 +9,7 @@
     <Rule Id="IDE0003" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1101" Action="None" />   <!-- local calls prefixed with this -->
     <Rule Id="SA1129" Action="None" />   <!-- don't use value type constructor-->
     <Rule Id="SA1200" Action="None" />

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/GraphAuthenticationBotAccessors.cs
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/GraphAuthenticationBotAccessors.cs
@@ -12,6 +12,12 @@ namespace Microsoft.BotBuilderSamples
     /// </summary>
     public class GraphAuthenticationBotAccessors
     {
+        // The name of the dialog state.
+        public static readonly string DialogStateName = $"{nameof(GraphAuthenticationBotAccessors)}.DialogState";
+
+        // The name of the command state.
+        public static readonly string CommandStateName = $"{nameof(GraphAuthenticationBotAccessors)}.CommandState";
+
         /// <summary>
         /// Initializes a new instance of the <see cref="GraphAuthenticationBotAccessors"/> class.
         /// Contains the <see cref="ConversationState"/> and associated <see cref="IStatePropertyAccessor{T}"/>.
@@ -23,12 +29,6 @@ namespace Microsoft.BotBuilderSamples
             UserState = userState ?? throw new ArgumentNullException(nameof(userState));
             ConversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
         }
-
-        // The name of the dialog state.
-        public static readonly string DialogStateName = $"{nameof(GraphAuthenticationBotAccessors)}.DialogState";
-
-        // The name of the command state.
-        public static readonly string CommandStateName = $"{nameof(GraphAuthenticationBotAccessors)}.CommandState";
 
         /// <summary>
         /// Gets or Sets the DialogState accessor value.

--- a/samples/csharp_dotnetcore/30.asp-mvc-bot/Asp-Mvc-Bot.ruleset
+++ b/samples/csharp_dotnetcore/30.asp-mvc-bot/Asp-Mvc-Bot.ruleset
@@ -5,6 +5,7 @@
     <Description Resource="MinimumRecommendedRules_Description" />
   </Localization>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1101" Action="None" />

--- a/samples/csharp_dotnetcore/42.scaleout/Scaleout-Bot.ruleset
+++ b/samples/csharp_dotnetcore/42.scaleout/Scaleout-Bot.ruleset
@@ -5,6 +5,7 @@
     <Description Resource="MinimumRecommendedRules_Description" />
   </Localization>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1101" Action="None" />

--- a/samples/csharp_dotnetcore/51.cafe-bot/BotBuilder.ruleset
+++ b/samples/csharp_dotnetcore/51.cafe-bot/BotBuilder.ruleset
@@ -5,6 +5,7 @@
     <Description Resource="MinimumRecommendedRules_Description" />
   </Localization>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments -->
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1101" Action="None" />

--- a/samples/csharp_dotnetcore/51.cafe-bot/CafeBot.cs
+++ b/samples/csharp_dotnetcore/51.cafe-bot/CafeBot.cs
@@ -212,7 +212,7 @@ namespace Microsoft.BotBuilderSamples
                         await turnContext.SendActivityAsync("Hello, I am the Contoso Cafe Bot!");
                         await turnContext.SendActivityAsync("I can help book a table and more..");
                         var activity = turnContext.Activity.CreateReply();
-                        activity.Attachments = new List<Attachment> { Helpers.CreateAdaptiveCardAttachment(new []{ ".", "Dialogs", "Welcome", "Resources", "welcomeCard.json" }), };
+                        activity.Attachments = new List<Attachment> { Helpers.CreateAdaptiveCardAttachment(new[] { ".", "Dialogs", "Welcome", "Resources", "welcomeCard.json" }), };
 
                         // Send welcome card.
                         await turnContext.SendActivityAsync(activity);


### PR DESCRIPTION
## Proposed Changes
- Fix syntax that's non-compliant with StyleCop guidelines

- Set to ignore rule [SA0001](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0001.md)  by modifying the ruleset files