### PR TITLE
Removes reference to deleted QnaWithAppInsights csproj from sln file

### DIFF
--- a/samples/csharp_dotnetcore/csharp_dotnetcore.sln
+++ b/samples/csharp_dotnetcore/csharp_dotnetcore.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.156
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2035
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Console-EchoBot", "01.console-echo\Console-EchoBot.csproj", "{ECFF9720-28CF-4F7D-896B-DA489D1032EA}"
 EndProject

--- a/samples/csharp_dotnetcore/csharp_dotnetcore.sln
+++ b/samples/csharp_dotnetcore/csharp_dotnetcore.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2035
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.156
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Console-EchoBot", "01.console-echo\Console-EchoBot.csproj", "{ECFF9720-28CF-4F7D-896B-DA489D1032EA}"
 EndProject
@@ -30,8 +30,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AuthenticationBot", "18.bot-authentication\AuthenticationBot.csproj", "{F858B0CA-16DC-40CF-8663-5D277992BA54}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Custom-Dialogs", "19.custom-dialogs\Custom-Dialogs.csproj", "{9C086713-E88C-4B1F-9AC9-A026064EED88}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QnABotAppInsights", "20.qna-with-appinsights\QnABotAppInsights.csproj", "{A59864BD-F52A-49FB-9735-DA4641B22B72}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LuisBotAppInsights", "21.luis-with-appinsights\LuisBotAppInsights.csproj", "{57990910-7837-4BBE-96B9-EDE8D776320D}"
 EndProject
@@ -113,10 +111,6 @@ Global
 		{9C086713-E88C-4B1F-9AC9-A026064EED88}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9C086713-E88C-4B1F-9AC9-A026064EED88}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9C086713-E88C-4B1F-9AC9-A026064EED88}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A59864BD-F52A-49FB-9735-DA4641B22B72}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A59864BD-F52A-49FB-9735-DA4641B22B72}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A59864BD-F52A-49FB-9735-DA4641B22B72}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A59864BD-F52A-49FB-9735-DA4641B22B72}.Release|Any CPU.Build.0 = Release|Any CPU
 		{57990910-7837-4BBE-96B9-EDE8D776320D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{57990910-7837-4BBE-96B9-EDE8D776320D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{57990910-7837-4BBE-96B9-EDE8D776320D}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
Hi @stevengum, the QnAWithAppInsights.cscrpoj wasn't removed from the sln file when it was deleted. This PR addresses that.