### PR TITLE
Adding base path to service url to fix 404 error

### DIFF
--- a/Node/core-GetConversationMembers/app.js
+++ b/Node/core-GetConversationMembers/app.js
@@ -107,10 +107,13 @@ function addTokenToClient(connector, clientPromise) {
 function printMembersInChannel(conversationAddress, members) {
     if (!members || members.length === 0) return;
 
-    var memberList = members.map(function (m) { return '* ' + m.name + ' (Id: ' + m.id + ')'; })
-        .join('\n ');
+    const memberList = members.map((member) => {
+        const memberName = member.name || '';
+        const memberId = member.id || '';
+        return `* ${memberName} Id: ${memberId}`;
+    }).join('\n ');
 
-    var reply = new builder.Message()
+    const reply = new builder.Message()
         .address(conversationAddress)
         .text('These are the members of this conversation: \n ' + memberList);
     bot.send(reply);

--- a/Node/core-GetConversationMembers/app.js
+++ b/Node/core-GetConversationMembers/app.js
@@ -50,6 +50,7 @@ var bot = new builder.UniversalBot(connector, function (session) {
         var serviceScheme = serviceUrl.protocol.split(':')[0];
         client.setSchemes([serviceScheme]);
         client.setHost(serviceUrl.host);
+        client.setBasePath(serviceUrl.path);
         // 3. GET /v3/conversations/{conversationId}/members
         return client.Conversations.Conversations_GetConversationMembers({ conversationId: conversationId })
             .then(function (res) {


### PR DESCRIPTION
Fixes #
This PR contains a fix for the issue described here:
https://github.com/Microsoft/BotBuilder-V3/issues/133

## Proposed Changes
I found that the 404 error was a result of the base path ('/amer/') being omitted from the service URL. 

This fix was to set the base path using the Swagger 'setBasePath' method:
client.setBasePath(serviceUrl.path);


## Testing
No new tests should be needed for this change - manual testing results in the expected behavior of the bot returning the conversation members.