### PR TITLE
Updated link to INSTALLING_CLI_TOOLS.md in sample README.md's

### DIFF
--- a/samples/csharp_dotnetcore/02.b.echo-with-counter/README.md
+++ b/samples/csharp_dotnetcore/02.b.echo-with-counter/README.md
@@ -39,7 +39,7 @@ In this example, the bot's state is used to track number of messages.
     - User properties can be used for many purposes, such as determining where the user's prior conversation left off or simply greeting a returning user by name. If you store a user's preferences, you can use that information to customize the conversation the next time you chat. For example, you might alert the user to a news article about a topic that interests her, or alert a user when an appointment becomes available. You should clear them if the bot receives a delete user data activity.
 
 # Deploy this bot to Azure
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 
 To clone this bot, run
 ```bash

--- a/samples/csharp_dotnetcore/03.welcome-user/README.md
+++ b/samples/csharp_dotnetcore/03.welcome-user/README.md
@@ -19,7 +19,7 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 - Type `dotnet run`.
 
 # Deploy this bot to Azure
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 
 To clone this bot, run
 

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/README.md
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/README.md
@@ -28,7 +28,7 @@ developers to test and debug their bots on localhost or running remotely through
 - Select `multi-turn-prompt.bot` file.
 # Deploy this bot to Azure
 
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 
 To clone this bot, run
 

--- a/samples/csharp_dotnetcore/06.using-cards/README.md
+++ b/samples/csharp_dotnetcore/06.using-cards/README.md
@@ -33,7 +33,7 @@ developers to test and debug their bots on localhost or running remotely through
 - File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/06.using-cards` folder.
 - Select `using-cards.bot` file.
 # Deploy this bot to Azure
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 
 To clone this bot, run
 ```

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/README.md
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/README.md
@@ -31,7 +31,7 @@ git clone https://github.com/microsoft/botbuilder-samples.git
 
 # Deploy this bot to Azure
 
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 
 To clone this bot, run
 ```bash

--- a/samples/csharp_dotnetcore/08.suggested-actions/README.md
+++ b/samples/csharp_dotnetcore/08.suggested-actions/README.md
@@ -31,7 +31,7 @@ git clone https://github.com/microsoft/botbuilder-samples.git
 - Type `dotnet run`.
 
 # Deploy this bot to Azure
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 
 To clone this bot, run
 

--- a/samples/csharp_dotnetcore/09.message-routing/README.md
+++ b/samples/csharp_dotnetcore/09.message-routing/README.md
@@ -26,7 +26,7 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 - Select `message-routing.bot` file
 # Deploy this bot to Azure
 
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 
 To clone this bot, run
 

--- a/samples/csharp_dotnetcore/12.nlp-with-luis/README.md
+++ b/samples/csharp_dotnetcore/12.nlp-with-luis/README.md
@@ -71,7 +71,7 @@ their bots on localhost or running remotely through a tunnel.
 - Select `nlp-with-luis.bot` file
 # Deploy this bot to Azure
 
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 
 To clone this bot, run
 

--- a/samples/csharp_dotnetcore/13.basic-bot/README.md
+++ b/samples/csharp_dotnetcore/13.basic-bot/README.md
@@ -118,7 +118,7 @@ their bots on localhost or running remotely through a tunnel.
 - Select `basic-bot.bot` file
 
 # Deploy this bot to Azure
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 
 To clone this bot, run
 

--- a/samples/csharp_dotnetcore/15.handling-attachments/README.md
+++ b/samples/csharp_dotnetcore/15.handling-attachments/README.md
@@ -39,7 +39,7 @@ git clone https://github.com/microsoft/botbuilder-samples.git
 - Select `handling-attachments.bot` file.
 
 # Deploy this bot to Azure
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 
 To clone this bot, run
 

--- a/samples/csharp_dotnetcore/16.proactive-messages/README.md
+++ b/samples/csharp_dotnetcore/16.proactive-messages/README.md
@@ -51,7 +51,7 @@ Build run your bot locally and open two instances of the emulator.
 - Open two conversations in the emulator, see that the proactive message goes to the correct conversation
 
 # Deploy this bot to Azure
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 
 To clone this bot, run
 ```bash

--- a/samples/csharp_dotnetcore/17.multilingual-bot/README.md
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/README.md
@@ -52,7 +52,7 @@ Paste the key in the ```translationKey``` placeholder within the appsettings.jso
 - Select `MultiLingualBot.bot` file
 
 # Deploy this bot to Azure
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 
 To clone this bot, run
 ```bash

--- a/samples/csharp_dotnetcore/18.bot-authentication/README.md
+++ b/samples/csharp_dotnetcore/18.bot-authentication/README.md
@@ -47,7 +47,7 @@ developers to test and debug their bots on localhost or running remotely through
 - File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/18.bot-authentication` folder.
 - Select `bot-authentication.bot` file.
 # Deploy this bot to Azure
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 To clone this bot, run
 ```bash
 msbot clone services -f deploymentScripts/msbotClone -n <BOT-NAME> -l <Azure-location> --subscriptionId <Azure-subscription-id> --appId <YOUR APP ID> --appSecret <YOUR APP SECRET PASSWORD>

--- a/samples/csharp_dotnetcore/19.custom-dialogs/README.md
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/README.md
@@ -27,7 +27,7 @@ developers to test and debug their bots on localhost or running remotely through
 - File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/19.custom-dialogs` folder.
 - Select `custom-dialogs.bot` file.
 # Deploy this bot to Azure
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 
 To clone this bot, run
 ```bash

--- a/samples/csharp_dotnetcore/22.conversation-history/README.md
+++ b/samples/csharp_dotnetcore/22.conversation-history/README.md
@@ -34,7 +34,7 @@ developers to test and debug their bots on localhost or running remotely through
 - Select `ConversationHistory.bot` file.
 
 # Deploy this bot to Azure
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 
 To clone this bot, run
 ```bash

--- a/samples/csharp_dotnetcore/23.facebook-events/README.md
+++ b/samples/csharp_dotnetcore/23.facebook-events/README.md
@@ -40,7 +40,7 @@ The final step to test Facebook-specific features is to publish your bot for the
 and the detailed steps are explained in the [Bot Framework Channel Documentation](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-channel-connect-facebook?view=azure-bot-service-3.0).
 
 # Deploy this bot to Azure
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 
 To clone this bot, run
 ```bash

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/README.md
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/README.md
@@ -55,7 +55,7 @@ developers to test and debug their bots on localhost or running remotely through
 - File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/24.bot-authentication-msgraph` folder.
 - Select `bot-authentication-msgraph.bot` file.
 # Deploy this bot to Azure
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 
 To clone this bot, run
 ```bash

--- a/samples/csharp_dotnetcore/30.asp-mvc-bot/README.md
+++ b/samples/csharp_dotnetcore/30.asp-mvc-bot/README.md
@@ -34,7 +34,7 @@ developers to test and debug their bots on localhost or running remotely through
 - Select `asp-mvc-bot.bot` file.
 
 # Deploy this bot to Azure
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 
 To clone this bot, run
 ```bash

--- a/samples/csharp_dotnetcore/42.scaleout/README.md
+++ b/samples/csharp_dotnetcore/42.scaleout/README.md
@@ -36,7 +36,7 @@ developers to test and debug their bots on localhost or running remotely through
 - File -> Open bot and navigate to `botbuilder-samples/samples/csharp_dotnetcore/42.scaleout` folder.
 - Select `scaleout.bot` file.
 # Deploy this bot to Azure
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 
 To clone this bot, run
 ```bash

--- a/samples/csharp_webapi/02.b.echo-with-counter/README.md
+++ b/samples/csharp_webapi/02.b.echo-with-counter/README.md
@@ -34,7 +34,7 @@ In this example, the bot's state is used to track number of messages.
     - User properties can be used for many purposes, such as determining where the user's prior conversation left off or simply greeting a returning user by name. If you store a user's preferences, you can use that information to customize the conversation the next time you chat. For example, you might alert the user to a news article about a topic that interests her, or alert a user when an appointment becomes available. You should clear them if the bot receives a delete user data activity.
 
 # Deploy this bot to Azure
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 
 To clone this bot, run
 ```bash

--- a/samples/csharp_webapi/13.basic-bot/README.md
+++ b/samples/csharp_webapi/13.basic-bot/README.md
@@ -15,7 +15,7 @@ git clone https://github.com/Microsoft/botbuilder-samples.git
 cd BotBuilder-Samples/samples/csharp_webapi/13.Basic-Bot-Template
 ```
 
-To configure any services this sample depends on. In order to install the needed and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md). 
+To configure any services this sample depends on. In order to install the needed and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md). 
 
 Create LUIS json model file (this will consume two .lu files combined into one model):
 ```bash

--- a/samples/javascript_nodejs/50.diceroller-skill/README.md
+++ b/samples/javascript_nodejs/50.diceroller-skill/README.md
@@ -52,7 +52,7 @@ Cortana skills tend to be more multi-modal in their use of both speech and text.
 When creating skills targeted at Cortana for the desktop you'll want to fill in both the `text` and `speak` fields of the outgoing activity and you'll find the thing you want to show to the user and speak to the user are often quite different.  The sample includes a simple `Language Generation (LG)` module that simplifies composing activities containing both `text` and `speak` fields.
 
 # Deploy this bot to Azure
-You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../Installing_CLI_tools.md).
+You can use the [MSBot](https://github.com/microsoft/botbuilder-tools) Bot Builder CLI tool to clone and configure any services this sample depends on. In order to install this and other tools, you can read [Installing CLI Tools](../../../INSTALLING_CLI_TOOLS.md).
 
 To clone this bot, run
 ```


### PR DESCRIPTION
Fixes #1428 

## Proposed Changes
Per issue #1228, updated samples' `README.md` link to Installing CLI Tools from `../../../installing_cli_tools.md` to `../../../INSTALLING_CLI_TOOLS.md`.