### PR TITLE
add debug support to samples

### DIFF
--- a/experimental/adaptive-dialog/csharp_dotnetcore/05.multi-turn-prompt/AdapterWithErrorHandler.cs
+++ b/experimental/adaptive-dialog/csharp_dotnetcore/05.multi-turn-prompt/AdapterWithErrorHandler.cs
@@ -11,6 +11,8 @@ using System.IO;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.LanguageGeneration.Renderer;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Debugging;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.BotBuilderSamples
 {
@@ -19,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
         private TemplateEngine _lgEngine;
 
         public AdapterWithErrorHandler(ICredentialProvider credentialProvider, ILogger<BotFrameworkHttpAdapter> logger, IStorage storage,
-            UserState userState, ConversationState conversationState, ResourceExplorer resourceExplorer)
+            UserState userState, ConversationState conversationState, ResourceExplorer resourceExplorer, IConfiguration configuration)
             : base(credentialProvider)
         {
             // combine path for cross platform support
@@ -30,7 +32,7 @@ namespace Microsoft.BotBuilderSamples
             this.UseStorage(storage);
             this.UseState(userState, conversationState);
             this.UseLanguageGenerator(new LGLanguageGenerator(resourceExplorer));
-
+            this.UseDebugger(configuration.GetValue<int>("debugport", 4712));
 
             OnTurnError = async (turnContext, exception) =>
             {

--- a/experimental/adaptive-dialog/csharp_dotnetcore/05.multi-turn-prompt/MultiTurnPromptBot.csproj
+++ b/experimental/adaptive-dialog/csharp_dotnetcore/05.multi-turn-prompt/MultiTurnPromptBot.csproj
@@ -15,10 +15,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.5.0-Preview-2019-04-27-02" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.5.0-Preview-2019-04-27-02" />
-    <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration" Version="4.5.0-Preview-2019-04-27-02" />
-    <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration.Renderer" Version="4.5.0-Preview-2019-04-27-02" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.5.0-Preview-2019-04-28-01" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.5.0-Preview-2019-04-28-01" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.5.0-Preview-2019-04-28-01" />
+    <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration" Version="4.5.0-Preview-2019-04-28-01" />
+    <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration.Renderer" Version="4.5.0-Preview-2019-04-28-01" />
   </ItemGroup>
 
 </Project>

--- a/experimental/adaptive-dialog/csharp_dotnetcore/05.multi-turn-prompt/Startup.cs
+++ b/experimental/adaptive-dialog/csharp_dotnetcore/05.multi-turn-prompt/Startup.cs
@@ -42,8 +42,8 @@ namespace Microsoft.BotBuilderSamples
             var resourceExplorer = ResourceExplorer.LoadProject(Directory.GetCurrentDirectory(), ignoreFolders: new string[] { "models" });
             services.AddSingleton(resourceExplorer);
 
-            // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
-            services.AddTransient<IBot, DialogBot<RootDialog>>();
+            // Create the bot. the ASP Controller is expecting an IBot.
+            services.AddSingleton<IBot, DialogBot<RootDialog>>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/experimental/adaptive-dialog/csharp_dotnetcore/06.using-cards/AdapterWithErrorHandler.cs
+++ b/experimental/adaptive-dialog/csharp_dotnetcore/06.using-cards/AdapterWithErrorHandler.cs
@@ -8,9 +8,11 @@ using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
 using Microsoft.Bot.Builder.LanguageGeneration;
 using System.IO;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Debugging;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.LanguageGeneration.Renderer;
-using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.BotBuilderSamples
 {
@@ -19,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
         private TemplateEngine _lgEngine;
 
         public AdapterWithErrorHandler(ICredentialProvider credentialProvider, ILogger<BotFrameworkHttpAdapter> logger, IStorage storage,
-            UserState userState, ConversationState conversationState, ResourceExplorer resourceExplorer)
+            UserState userState, ConversationState conversationState, ResourceExplorer resourceExplorer, IConfiguration configuration)
             : base(credentialProvider)
         {
             // combine path for cross platform support
@@ -30,7 +32,7 @@ namespace Microsoft.BotBuilderSamples
             this.UseStorage(storage);
             this.UseState(userState, conversationState);
             this.UseLanguageGenerator(new LGLanguageGenerator(resourceExplorer));
-
+            this.UseDebugger(configuration.GetValue<int>("debugport", 4712));
 
             OnTurnError = async (turnContext, exception) =>
             {

--- a/experimental/adaptive-dialog/csharp_dotnetcore/06.using-cards/CardsBot.csproj
+++ b/experimental/adaptive-dialog/csharp_dotnetcore/06.using-cards/CardsBot.csproj
@@ -7,14 +7,15 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.5.0-Preview-2019-04-24-01" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.5.0-Preview-2019-04-24-01" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.5.0-Preview-2019-04-24-01" />
-    <PackageReference Include="Microsoft.Bot.Builder.Expressions" Version="4.5.0-Preview-2019-04-24-01" />
-    <PackageReference Include="Microsoft.Bot.Builder.Expressions.Parser" Version="4.5.0-Preview-2019-04-24-01" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.5.0-Preview-2019-04-24-01" />
-    <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration" Version="4.5.0-Preview-2019-04-24-01" />
-    <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration.Renderer" Version="4.5.0-Preview-2019-04-24-01" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.5.0-Preview-2019-04-28-01" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.5.0-Preview-2019-04-28-01" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.5.0-Preview-2019-04-28-01" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.5.0-Preview-2019-04-28-01" />
+    <PackageReference Include="Microsoft.Bot.Builder.Expressions" Version="4.5.0-Preview-2019-04-28-01" />
+    <PackageReference Include="Microsoft.Bot.Builder.Expressions.Parser" Version="4.5.0-Preview-2019-04-28-01" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.5.0-Preview-2019-04-28-01" />
+    <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration" Version="4.5.0-Preview-2019-04-28-01" />
+    <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration.Renderer" Version="4.5.0-Preview-2019-04-28-01" />
   </ItemGroup>
 
 </Project>

--- a/experimental/adaptive-dialog/csharp_dotnetcore/06.using-cards/Startup.cs
+++ b/experimental/adaptive-dialog/csharp_dotnetcore/06.using-cards/Startup.cs
@@ -42,8 +42,8 @@ namespace Microsoft.BotBuilderSamples
             var resourceExplorer = ResourceExplorer.LoadProject(Directory.GetCurrentDirectory(), ignoreFolders: new string[] { "models" });
             services.AddSingleton(resourceExplorer);
 
-            // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
-            services.AddTransient<IBot, DialogBot<RootDialog>>();
+            // Create the bot. the ASP Controller is expecting an IBot.
+            services.AddSingleton<IBot, DialogBot<RootDialog>>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/experimental/adaptive-dialog/csharp_dotnetcore/todo-bot/AdapterWithErrorHandler.cs
+++ b/experimental/adaptive-dialog/csharp_dotnetcore/todo-bot/AdapterWithErrorHandler.cs
@@ -2,13 +2,14 @@
 // Licensed under the MIT License.
 
 using System;
-using System.IO;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Debugging;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.LanguageGeneration.Renderer;
 using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
@@ -16,12 +17,13 @@ namespace Microsoft.BotBuilderSamples
     public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
     {
         public AdapterWithErrorHandler(ICredentialProvider credentialProvider, ILogger<BotFrameworkHttpAdapter> logger, IStorage storage,
-            UserState userState, ConversationState conversationState, ResourceExplorer resourceExplorer)
+            UserState userState, ConversationState conversationState, ResourceExplorer resourceExplorer, IConfiguration configuration)
             : base(credentialProvider)
         {
             this.UseStorage(storage);
             this.UseState(userState, conversationState);
             this.UseLanguageGenerator(new LGLanguageGenerator(resourceExplorer));
+            this.UseDebugger(configuration.GetValue<int>("debugport", 4712));
 
             OnTurnError = async (turnContext, exception) =>
             {

--- a/experimental/adaptive-dialog/csharp_dotnetcore/todo-bot/Startup.cs
+++ b/experimental/adaptive-dialog/csharp_dotnetcore/todo-bot/Startup.cs
@@ -42,8 +42,8 @@ namespace Microsoft.BotBuilderSamples
             // The Dialog that will be run by the bot.
             services.AddSingleton<RootDialog>();
 
-            // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
-            services.AddTransient<IBot, DialogBot<RootDialog>>();
+            // Create the bot. the ASP Controller is expecting an IBot.
+            services.AddSingleton<IBot, DialogBot<RootDialog>>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/experimental/adaptive-dialog/csharp_dotnetcore/todo-bot/ToDoBotWithLUIS.csproj
+++ b/experimental/adaptive-dialog/csharp_dotnetcore/todo-bot/ToDoBotWithLUIS.csproj
@@ -15,11 +15,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.5.0-Preview-2019-04-27-02" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.5.0-Preview-2019-04-27-02" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.5.0-Preview-2019-04-27-02" />
-    <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration" Version="4.5.0-Preview-2019-04-27-02" />
-    <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration.Renderer" Version="4.5.0-Preview-2019-04-27-02" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.5.0-Preview-2019-04-28-01" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.5.0-Preview-2019-04-28-01" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Debugging" Version="4.5.0-Preview-2019-04-28-01" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.5.0-Preview-2019-04-28-01" />
+    <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration" Version="4.5.0-Preview-2019-04-28-01" />
+    <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration.Renderer" Version="4.5.0-Preview-2019-04-28-01" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Vishwacs samples didn't have debug extensions installed
- added USeDebugger() 
- Added configuration
- changed from transient to singleton for bot
