### PR TITLE
Removes reference to LuisBotAppInsights.csproj file from sln file.

### DIFF
--- a/samples/csharp_dotnetcore/csharp_dotnetcore.sln
+++ b/samples/csharp_dotnetcore/csharp_dotnetcore.sln
@@ -31,8 +31,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AuthenticationBot", "18.bot
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Custom-Dialogs", "19.custom-dialogs\Custom-Dialogs.csproj", "{9C086713-E88C-4B1F-9AC9-A026064EED88}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LuisBotAppInsights", "21.luis-with-appinsights\LuisBotAppInsights.csproj", "{57990910-7837-4BBE-96B9-EDE8D776320D}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Facebook-Events-Bot", "23.facebook-events\Facebook-Events-Bot.csproj", "{F1F85057-BAFA-46E2-830C-36060270659F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BotAuthenticationMSGraph", "24.bot-authentication-msgraph\BotAuthenticationMSGraph.csproj", "{3434227D-B8F8-41D0-8465-310099349C61}"
@@ -111,10 +109,6 @@ Global
 		{9C086713-E88C-4B1F-9AC9-A026064EED88}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9C086713-E88C-4B1F-9AC9-A026064EED88}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9C086713-E88C-4B1F-9AC9-A026064EED88}.Release|Any CPU.Build.0 = Release|Any CPU
-		{57990910-7837-4BBE-96B9-EDE8D776320D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{57990910-7837-4BBE-96B9-EDE8D776320D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{57990910-7837-4BBE-96B9-EDE8D776320D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{57990910-7837-4BBE-96B9-EDE8D776320D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F1F85057-BAFA-46E2-830C-36060270659F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F1F85057-BAFA-46E2-830C-36060270659F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F1F85057-BAFA-46E2-830C-36060270659F}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
The reference to the LuisBotAppInsights.cspoj file wasn't removed from the sln file when it was deleted. This PR addresses that issue.