### PR TITLE
Fix urls in lg docs

### DIFF
--- a/experimental/language-generation/docs/lg-file-format.md
+++ b/experimental/language-generation/docs/lg-file-format.md
@@ -211,7 +211,7 @@ Here is an example that illustrates that -
 The above example uses the [join][5] pre-built function to list all values in the `recentTasks` collection. 
 
 [1]:https://github.com/Microsoft/botbuilder-tools/blob/master/packages/Ludown/docs/lu-file-format.md
-[2]:./docs/api-reference.md
+[2]:./api-reference.md
 [3]:../../common-expression-language#readme
 [4]:../../common-expression-language/prebuilt-functions.md
 [5]:../../common-expression-language/prebuilt-functions.md#join

--- a/experimental/language-generation/docs/lg-file-format.md
+++ b/experimental/language-generation/docs/lg-file-format.md
@@ -212,9 +212,9 @@ The above example uses the [join][5] pre-built function to list all values in th
 
 [1]:https://github.com/Microsoft/botbuilder-tools/blob/master/packages/Ludown/docs/lu-file-format.md
 [2]:./docs/api-reference.md
-[3]:../common-expression-language/readme.md
-[4]:../common-expression-language/prebuilt-functions.md
-[5]:../common-expression-language/prebuilt-functions.md#join
+[3]:../../common-expression-language/readme.md
+[4]:../../common-expression-language/prebuilt-functions.md
+[5]:../../common-expression-language/prebuilt-functions.md#join
 [6]:https://github.com/Microsoft/botbuilder-tools/tree/master/packages/Chatdown
 [7]:https://github.com/Microsoft/botbuilder-tools/tree/master/packages/Chatdown#chat-file-format
 [8]:https://github.com/Microsoft/botbuilder-tools/blob/master/packages/Chatdown/Examples/CardExamples.chat

--- a/experimental/language-generation/docs/lg-file-format.md
+++ b/experimental/language-generation/docs/lg-file-format.md
@@ -212,7 +212,7 @@ The above example uses the [join][5] pre-built function to list all values in th
 
 [1]:https://github.com/Microsoft/botbuilder-tools/blob/master/packages/Ludown/docs/lu-file-format.md
 [2]:./docs/api-reference.md
-[3]:../../common-expression-language/readme.md
+[3]:../../common-expression-language#readme
 [4]:../../common-expression-language/prebuilt-functions.md
 [5]:../../common-expression-language/prebuilt-functions.md#join
 [6]:https://github.com/Microsoft/botbuilder-tools/tree/master/packages/Chatdown


### PR DESCRIPTION
Some of the relative links are wrong in the lg readme.