### PR TITLE
Replaces .bot file reference with steps for running bot in Emulator

### DIFF
--- a/generators/dotnet-templates/README.md
+++ b/generators/dotnet-templates/README.md
@@ -163,7 +163,9 @@ dotnet run
 ```
 
 ## Interacting With Your Bot Using the Emulator
-Launch the [Bot Framework Emulator v4][3] and open the generated project's `.bot` file.
+- Launch Bot Framework Emulator
+- File -> Open Bot
+- Enter a Bot URL of `http://localhost:3978/api/messages`
 
 Once the Emulator is connected, you can interact with and receive messages from your bot.
 


### PR DESCRIPTION
Fixes #1493 

## Proposed Changes
Replaces outdated reference to .bot file for testing bot in Emulator. Replaced reference with steps for connecting and running bot in Emulator. Brings parity with generator-botbuilder.

generator-botbuilder:
![image](https://user-images.githubusercontent.com/18403946/57409777-02f6a200-719e-11e9-9256-d768d71f1648.png)

generators/dotnet-template:
![image](https://user-images.githubusercontent.com/18403946/57409846-30435000-719e-11e9-8b31-f1b49f4341e5.png)
