### PR TITLE
Apply coding convertions to the migration v4 framework sample

### DIFF
--- a/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/AdapterWithErrorHandler.cs
+++ b/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/AdapterWithErrorHandler.cs
@@ -1,17 +1,21 @@
-﻿using System;
-using System.Diagnostics;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.WebApi;
 using Microsoft.Bot.Connector.Authentication;
-using Microsoft.Extensions.Logging;
+using System;
 
 namespace ContosoHelpdeskChatBot
 {
     public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
     {
-        private static log4net.ILog logger = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        private static log4net.ILog logger
+            = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        public AdapterWithErrorHandler(ICredentialProvider credentialProvider, ConversationState conversationState = null)
+        public AdapterWithErrorHandler(
+            ICredentialProvider credentialProvider,
+            ConversationState conversationState = null)
             : base(credentialProvider)
         {
             OnTurnError = async (turnContext, exception) =>

--- a/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/App_Start/WebApiConfig.cs
+++ b/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/App_Start/WebApiConfig.cs
@@ -1,8 +1,8 @@
-﻿using Newtonsoft.Json;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Web.Http;
 
 namespace ContosoHelpdeskChatBot

--- a/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Bots/DialogBot.cs
+++ b/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Bots/DialogBot.cs
@@ -1,23 +1,26 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Logging;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace ContosoHelpdeskChatBot.Bots
 {
-    // This IBot implementation can run any type of Dialog. The use of type parameterization is to allows multiple different bots
-    // to be run at different endpoints within the same project. This can be achieved by defining distinct Controller types
-    // each with dependency on distinct IBot types, this way ASP Dependency Injection can glue everything together without ambiguity.
-    // The ConversationState is used by the Dialog system. The UserState isn't, however, it might have been used in a Dialog implementation,
-    // and the requirement is that all BotState objects are saved at the end of a turn.
+    // This IBot implementation can run any type of Dialog. The use of type parameterization is to 
+    // allow multiple different bots to be run at different endpoints within the same project. This
+    // can be achieved by defining distinct Controller typesk, each with dependency on distinct IBot
+    // types, this way ASP Dependency Injection can glue everything together without ambiguity.
+    // The ConversationState is used by the Dialog system. The UserState isn't, however, it might
+    // have been used in a Dialog implementation, and the requirement is that all BotState objects
+    // are saved at the end of a turn.
     public class DialogBot<T> : ActivityHandler where T : Dialog
     {
         protected readonly Dialog _dialog;
         protected readonly BotState _conversationState;
-        
+
         public DialogBot(ConversationState conversationState, T dialog)
         {
             _conversationState = conversationState;
@@ -32,10 +35,15 @@ namespace ContosoHelpdeskChatBot.Bots
             await _conversationState.SaveChangesAsync(turnContext, false, cancellationToken);
         }
 
-        protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
+        protected override async Task OnMessageActivityAsync(
+            ITurnContext<IMessageActivity> turnContext,
+            CancellationToken cancellationToken)
         {
             // Run the Dialog with the new message Activity.
-            await _dialog.Run(turnContext, _conversationState.CreateProperty<DialogState>("DialogState"), cancellationToken);
+            await _dialog.Run(
+                turnContext,
+                _conversationState.CreateProperty<DialogState>("DialogState"),
+                cancellationToken);
         }
     }
 }

--- a/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Controllers/MessagesController.cs
+++ b/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Controllers/MessagesController.cs
@@ -1,23 +1,18 @@
-﻿using System;
-using System.Net;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.WebApi;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http;
-using Bot.Builder.Community.Dialogs.FormFlow;
-using ContosoHelpdeskChatBot.Dialogs;
-using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Builder.Integration.AspNet.WebApi;
-using Microsoft.Bot.Connector.Authentication;
-using Microsoft.Bot.Schema;
 
 namespace ContosoHelpdeskChatBot
 {
     public class MessagesController : ApiController
     {
-        IBotFrameworkHttpAdapter _adapter;
-        IBot _bot;
+        private readonly IBotFrameworkHttpAdapter _adapter;
+        private readonly IBot _bot;
         
         public MessagesController(IBotFrameworkHttpAdapter adapter, IBot bot)
         {

--- a/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/DialogExtensions.cs
+++ b/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/DialogExtensions.cs
@@ -1,15 +1,21 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Schema;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace ContosoHelpdeskChatBot
 {
     public static class DialogExtensions
     {
-        public static async Task Run(this Dialog dialog, ITurnContext turnContext, IStatePropertyAccessor<DialogState> accessor, CancellationToken cancellationToken)
+        public static async Task Run(
+            this Dialog dialog,
+            ITurnContext turnContext,
+            IStatePropertyAccessor<DialogState> accessor,
+            CancellationToken cancellationToken)
         {
             var dialogSet = new DialogSet(accessor);
             dialogSet.Add(dialog);
@@ -19,11 +25,11 @@ namespace ContosoHelpdeskChatBot
             // Handle 'cancel' interruption
             if (turnContext.Activity.Text.Equals("cancel", StringComparison.InvariantCultureIgnoreCase))
             {
-                Activity reply = turnContext.Activity.CreateReply($"Ok restarting conversation.");
+                var reply = turnContext.Activity.CreateReply($"Ok restarting conversation.");
                 await turnContext.SendActivityAsync(reply);
                 await dialogContext.CancelAllDialogsAsync();
             }
-            
+
             var results = await dialogContext.ContinueDialogAsync(cancellationToken);
             if (results.Status == DialogTurnStatus.Empty)
             {

--- a/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Dialogs/InstallAppDialog.cs
+++ b/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Dialogs/InstallAppDialog.cs
@@ -1,38 +1,35 @@
-﻿namespace ContosoHelpdeskChatBot.Dialogs
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using ContosoHelpdeskChatBot.Models;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Choices;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ContosoHelpdeskChatBot.Dialogs
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using ContosoHelpdeskChatBot.Models;
-    using Microsoft.Bot.Builder;
-    using Microsoft.Bot.Builder.Dialogs;
-    using Microsoft.Bot.Builder.Dialogs.Choices;
-
-
     public class InstallAppDialog : ComponentDialog
     {
-        // Set up our dialog and prompt IDs as constants.
-        private const string MainId = "mainDialog";
-        private const string TextId = "textPrompt";
-        private const string ChoiceId = "choicePrompt";
-
         // Set up keys for managing collected information.
         private const string InstallInfo = "installInfo";
 
-        public InstallAppDialog(string id)
-            : base(id)
+        public InstallAppDialog()
+            : base(nameof(InstallAppDialog))
         {
             // Initialize our dialogs and prompts.
-            InitialDialogId = MainId;
-            AddDialog(new WaterfallDialog(MainId, new WaterfallStep[] {
+            InitialDialogId = nameof(WaterfallDialog);
+            AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[] {
                 GetSearchTermAsync,
                 ResolveAppNameAsync,
                 GetMachineNameAsync,
                 SubmitRequestAsync,
             }));
-            AddDialog(new TextPrompt(TextId));
-            AddDialog(new ChoicePrompt(ChoiceId));
+            AddDialog(new TextPrompt(nameof(TextPrompt)));
+            AddDialog(new ChoicePrompt(nameof(ChoicePrompt)));
         }
 
         private async Task<DialogTurnResult> GetSearchTermAsync(
@@ -44,14 +41,13 @@
 
             // Ask for the search term.
             return await stepContext.PromptAsync(
-                TextId,
+                nameof(TextPrompt),
                 new PromptOptions
                 {
                     Prompt = MessageFactory.Text("Ok let's get started. What is the name of the application? "),
                 },
                 cancellationToken);
         }
-
 
         private async Task<DialogTurnResult> ResolveAppNameAsync(
     WaterfallStepContext stepContext,
@@ -61,7 +57,7 @@
             var appname = stepContext.Result as string;
 
             // Query the database for matches.
-            var names = await this.getAppsAsync(appname);
+            var names = await this.GetAppsAsync(appname);
 
             if (names.Count == 1)
             {
@@ -75,7 +71,7 @@
             {
                 // Ask the user to choose from the list of matches.
                 return await stepContext.PromptAsync(
-                    ChoiceId,
+                    nameof(ChoicePrompt),
                     new PromptOptions
                     {
                         Prompt = MessageFactory.Text("I found the following applications. Please choose one:"),
@@ -108,7 +104,7 @@
 
             // We now need the machine name, so prompt for it.
             return await stepContext.PromptAsync(
-                TextId,
+                nameof(TextPrompt),
                 new PromptOptions
                 {
                     Prompt = MessageFactory.Text(
@@ -121,7 +117,7 @@
             WaterfallStepContext stepContext,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            InstallApp install = default(InstallApp);
+            var install = default(InstallApp);
             if (stepContext.Reason != DialogReason.CancelCalled)
             {
                 // Get the tracking info and add the machine name.
@@ -138,9 +134,9 @@
             return await stepContext.EndDialogAsync(null, cancellationToken);
         }
 
-        private async Task<List<string>> getAppsAsync(string Name)
+        private async Task<List<string>> GetAppsAsync(string Name)
         {
-            List<string> names = new List<string>();
+            var names = new List<string>();
 
             // Simulate querying the database for applications that match.
             return (from app in AppMsis

--- a/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Dialogs/LocalAdminDialog.cs
+++ b/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Dialogs/LocalAdminDialog.cs
@@ -1,22 +1,20 @@
-﻿using System.Threading;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using Bot.Builder.Community.Dialogs.FormFlow;
 using ContosoHelpdeskChatBot.Models;
 using Microsoft.Bot.Builder.Dialogs;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace ContosoHelpdeskChatBot.Dialogs
 {
     public class LocalAdminDialog : ComponentDialog
     {
-        // Set up our dialog and prompt IDs as constants.
-        private const string MainDialog = "mainDialog";
-        private static string AdminDialog { get; } = nameof(LocalAdminPrompt);
-
-        public LocalAdminDialog(string dialogId) : base(dialogId)
+        public LocalAdminDialog() : base(nameof(LocalAdminDialog))
         {
-            InitialDialogId = MainDialog;
-
-            AddDialog(new WaterfallDialog(MainDialog, new WaterfallStep[]
+            InitialDialogId = nameof(WaterfallDialog);
+            AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[]
             {
                 BeginFormflowAsync,
                 SaveResultAsync,
@@ -31,7 +29,9 @@ namespace ContosoHelpdeskChatBot.Dialogs
             await stepContext.Context.SendActivityAsync("Great I will help you request local machine admin.");
 
             // Begin the Formflow dialog.
-            return await stepContext.BeginDialogAsync(AdminDialog, cancellationToken: cancellationToken);
+            return await stepContext.BeginDialogAsync(
+                nameof(LocalAdminPrompt),
+                cancellationToken: cancellationToken);
         }
 
         private async Task<DialogTurnResult> SaveResultAsync(
@@ -52,12 +52,12 @@ namespace ContosoHelpdeskChatBot.Dialogs
         // Nearly the same as before.
         private IForm<LocalAdminPrompt> BuildLocalAdminForm()
         {
-            //here's an example of how validation can be used in form builder
+            // Here's an example of how validation can be used with FormBuilder.
             return new FormBuilder<LocalAdminPrompt>()
                 .Field(nameof(LocalAdminPrompt.MachineName),
                 validate: async (state, value) =>
                 {
-                    ValidateResult result = new ValidateResult { IsValid = true, Value = value };
+                    var result = new ValidateResult { IsValid = true, Value = value };
                     //add validation here
 
                     //this.admin.MachineName = (string)value;
@@ -66,7 +66,7 @@ namespace ContosoHelpdeskChatBot.Dialogs
                 .Field(nameof(LocalAdminPrompt.AdminDuration),
                 validate: async (state, value) =>
                 {
-                    ValidateResult result = new ValidateResult { IsValid = true, Value = value };
+                    var result = new ValidateResult { IsValid = true, Value = value };
                     //add validation here
 
                     //this.admin.AdminDuration = Convert.ToInt32((long)value) as int?;

--- a/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Dialogs/ResetPasswordDialog.cs
+++ b/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Dialogs/ResetPasswordDialog.cs
@@ -1,23 +1,22 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using Bot.Builder.Community.Dialogs.FormFlow;
 using ContosoHelpdeskChatBot.Models;
 using Microsoft.Bot.Builder.Dialogs;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace ContosoHelpdeskChatBot.Dialogs
 {
     public class ResetPasswordDialog : ComponentDialog
     {
-        // Set up our dialog and prompt IDs as constants.
-        private const string MainDialog = "mainDialog";
-        private static string ResetDialog { get; } = nameof(ResetPasswordPrompt);
-
-        public ResetPasswordDialog(string dialogId) : base(dialogId)
+        public ResetPasswordDialog()
+            : base(nameof(ResetPasswordDialog))
         {
-            InitialDialogId = MainDialog;
-
-            AddDialog(new WaterfallDialog(MainDialog, new WaterfallStep[]
+            InitialDialogId = nameof(WaterfallDialog);
+            AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[]
             {
                 BeginFormflowAsync,
                 ProcessRequestAsync,
@@ -32,9 +31,11 @@ namespace ContosoHelpdeskChatBot.Dialogs
             await stepContext.Context.SendActivityAsync("Alright I will help you create a temp password.");
 
             // Check the passcode and fail out or begin the Formflow dialog.
-            if (sendPassCode(stepContext))
+            if (SendPassCode(stepContext))
             {
-                return await stepContext.BeginDialogAsync(ResetDialog, cancellationToken: cancellationToken);
+                return await stepContext.BeginDialogAsync(
+                    nameof(ResetPasswordPrompt),
+                    cancellationToken: cancellationToken);
             }
             else
             {
@@ -43,7 +44,7 @@ namespace ContosoHelpdeskChatBot.Dialogs
             }
         }
 
-        private bool sendPassCode(DialogContext context)
+        private bool SendPassCode(DialogContext context)
         {
             //bool result = false;
 

--- a/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Dialogs/RootDialog.cs
+++ b/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Dialogs/RootDialog.cs
@@ -1,41 +1,51 @@
-﻿namespace ContosoHelpdeskChatBot.Dialogs
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Microsoft.Bot.Builder;
-    using Microsoft.Bot.Builder.Dialogs;
-    using Microsoft.Bot.Builder.Dialogs.Choices;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Choices;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ContosoHelpdeskChatBot.Dialogs
+{
     public class RootDialog : ComponentDialog
     {
-        private static log4net.ILog logger = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        private static log4net.ILog logger
+            = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         private const string InstallAppOption = "Install Application (install)";
         private const string ResetPasswordOption = "Reset Password (password)";
         private const string LocalAdminOption = "Request Local Admin (admin)";
-        private const string GreetMessage = "Welcome to **Contoso Helpdesk Chat Bot**.\n\nI am designed to use with mobile email app, make sure your replies do not contain signatures. \n\nFollowing is what I can help you with, just reply with word in parenthesis:";
+        private const string GreetMessage
+            = "Welcome to **Contoso Helpdesk Chat Bot**.\n\nI am designed to use with mobile email app, " +
+            "make sure your replies do not contain signatures. \n\nFollowing is what I can help you with, " +
+            "just reply with word in parenthesis:";
         private const string ErrorMessage = "Not a valid option";
+
         private static List<Choice> HelpdeskOptions = new List<Choice>()
             {
-                new Choice(InstallAppOption) { Synonyms = new List<string>(){ "install" } },
-                new Choice(ResetPasswordOption) { Synonyms = new List<string>(){ "password" } },
-                new Choice(LocalAdminOption)  { Synonyms = new List<string>(){ "admin" } }
+                new Choice(InstallAppOption) { Synonyms = new List<string> { "install" } },
+                new Choice(ResetPasswordOption) { Synonyms = new List<string> { "password" } },
+                new Choice(LocalAdminOption)  { Synonyms = new List<string> { "admin" } }
             };
 
         public RootDialog()
             : base(nameof(RootDialog))
         {
-            AddDialog(new WaterfallDialog("choiceswaterfall", new WaterfallStep[]
+            InitialDialogId = nameof(WaterfallDialog);
+            AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[]
             {
                 PromptForOptionsAsync,
                 ShowChildDialogAsync,
                 ResumeAfterAsync,
             }));
-            AddDialog(new InstallAppDialog(nameof(InstallAppDialog)));
-            AddDialog(new LocalAdminDialog(nameof(LocalAdminDialog)));
-            AddDialog(new ResetPasswordDialog(nameof(ResetPasswordDialog)));
-            AddDialog(new ChoicePrompt("options"));
+            AddDialog(new InstallAppDialog());
+            AddDialog(new LocalAdminDialog());
+            AddDialog(new ResetPasswordDialog());
+            AddDialog(new ChoicePrompt(nameof(ChoicePrompt)));
         }
 
         private async Task<DialogTurnResult> PromptForOptionsAsync(
@@ -44,7 +54,7 @@
         {
             // Prompt the user for a response using our choice prompt.
             return await stepContext.PromptAsync(
-                "options",
+                nameof(ChoicePrompt),
                 new PromptOptions()
                 {
                     Choices = HelpdeskOptions,
@@ -59,7 +69,7 @@
             CancellationToken cancellationToken = default(CancellationToken))
         {
             // string optionSelected = await userReply;
-            string optionSelected = (stepContext.Result as FoundChoice).Value;
+            var optionSelected = (stepContext.Result as FoundChoice).Value;
 
             switch (optionSelected)
             {
@@ -100,7 +110,7 @@
                 //var message = await userReply;
                 var message = stepContext.Context.Activity;
 
-                int ticketNumber = new Random().Next(0, 20000);
+                var ticketNumber = new Random().Next(0, 20000);
                 //await context.PostAsync($"Thank you for using the Helpdesk Bot. Your ticket number is {ticketNumber}.");
                 await stepContext.Context.SendActivityAsync(
                     $"Thank you for using the Helpdesk Bot. Your ticket number is {ticketNumber}.",
@@ -123,7 +133,7 @@
             // Replace on the stack the current instance of the waterfall with a new instance,
             // and start from the top.
             return await stepContext.ReplaceDialogAsync(
-                "choiceswaterfall",
+                nameof(WaterfallDialog),
                 cancellationToken: cancellationToken);
         }
     }

--- a/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Global.asax.cs
+++ b/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Global.asax.cs
@@ -1,15 +1,16 @@
-﻿using System.Configuration;
-using System.Reflection;
-using System.Web.Http;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using Autofac;
 using Autofac.Integration.WebApi;
 using ContosoHelpdeskChatBot.Bots;
 using ContosoHelpdeskChatBot.Dialogs;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.BotFramework;
-using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Integration.AspNet.WebApi;
 using Microsoft.Bot.Connector.Authentication;
+using System.Reflection;
+using System.Web.Http;
 
 namespace ContosoHelpdeskChatBot
 {
@@ -29,7 +30,7 @@ namespace ContosoHelpdeskChatBot
         {
             public static void Register(HttpConfiguration config)
             {
-                ContainerBuilder builder = new ContainerBuilder();
+                var builder = new ContainerBuilder();
                 builder.RegisterApiControllers(Assembly.GetExecutingAssembly());
 
                 // The ConfigurationCredentialProvider will retrieve the MicrosoftAppId and
@@ -45,17 +46,17 @@ namespace ContosoHelpdeskChatBot
 
                 // Create Conversation State object.
                 // The Conversation State object is where we persist anything at the conversation-scope.
-                ConversationState conversationState = new ConversationState(dataStore);
+                var conversationState = new ConversationState(dataStore);
                 builder.RegisterInstance(conversationState).As<ConversationState>().SingleInstance();
-                
+
                 // Register the main dialog, which is injected into the DialogBot class
                 builder.RegisterType<RootDialog>().SingleInstance();
 
                 // Register the DialogBot with RootDialog as the IBot interface
                 builder.RegisterType<DialogBot<RootDialog>>().As<IBot>();
 
-                IContainer container = builder.Build();
-                AutofacWebApiDependencyResolver resolver = new AutofacWebApiDependencyResolver(container);
+                var container = builder.Build();
+                var resolver = new AutofacWebApiDependencyResolver(container);
                 config.DependencyResolver = resolver;
             }
         }

--- a/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Models/AppMsi.cs
+++ b/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Models/AppMsi.cs
@@ -1,11 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace ContosoHelpdeskChatBot.Models
 {
-    using System;
-    using System.Collections.Generic;
-    using System.ComponentModel.DataAnnotations;
-    using System.ComponentModel.DataAnnotations.Schema;
-    using System.Data.Entity.Spatial;
-
     [Table("AppMsi")]
     public partial class AppMsi
     {

--- a/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Models/ContosoHelpdeskContext.cs
+++ b/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Models/ContosoHelpdeskContext.cs
@@ -1,10 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Data.Entity;
+
 namespace ContosoHelpdeskChatBot.Models
 {
-    using System;
-    using System.Data.Entity;
-    using System.ComponentModel.DataAnnotations.Schema;
-    using System.Linq;
-
     public partial class ContosoHelpdeskContext : DbContext
     {
         public ContosoHelpdeskContext()

--- a/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Models/InstallApp.cs
+++ b/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Models/InstallApp.cs
@@ -1,11 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace ContosoHelpdeskChatBot.Models
 {
-    using System;
-    using System.Collections.Generic;
-    using System.ComponentModel.DataAnnotations;
-    using System.ComponentModel.DataAnnotations.Schema;
-    using System.Data.Entity.Spatial;
-
     [Table("InstallApp")]
     public partial class InstallApp
     {

--- a/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Models/LocalAdmin.cs
+++ b/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Models/LocalAdmin.cs
@@ -1,11 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace ContosoHelpdeskChatBot.Models
 {
-    using System;
-    using System.Collections.Generic;
-    using System.ComponentModel.DataAnnotations;
-    using System.ComponentModel.DataAnnotations.Schema;
-    using System.Data.Entity.Spatial;
-
     [Table("LocalAdmin")]
     public partial class LocalAdmin
     {

--- a/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Models/LocalAdminPrompt.cs
+++ b/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Models/LocalAdminPrompt.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using Bot.Builder.Community.Dialogs.FormFlow;
 
 namespace ContosoHelpdeskChatBot.Models

--- a/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Models/Log.cs
+++ b/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Models/Log.cs
@@ -1,11 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace ContosoHelpdeskChatBot.Models
 {
-    using System;
-    using System.Collections.Generic;
-    using System.ComponentModel.DataAnnotations;
-    using System.ComponentModel.DataAnnotations.Schema;
-    using System.Data.Entity.Spatial;
-
     [Table("Log")]
     public partial class Log
     {

--- a/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Models/ResetPassword.cs
+++ b/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Models/ResetPassword.cs
@@ -1,11 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace ContosoHelpdeskChatBot.Models
 {
-    using System;
-    using System.Collections.Generic;
-    using System.ComponentModel.DataAnnotations;
-    using System.ComponentModel.DataAnnotations.Schema;
-    using System.Data.Entity.Spatial;
-
     [Table("ResetPassword")]
     public partial class ResetPassword
     {
@@ -14,7 +14,7 @@ namespace ContosoHelpdeskChatBot.Models
 
         public string EmailAddress { get; set; }
 
-        public Int64? MobileNumber { get; set; }
+        public long? MobileNumber { get; set; }
 
         public int? PassCode { get; set; }
 

--- a/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Models/ResetPasswordPrompt.cs
+++ b/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Models/ResetPasswordPrompt.cs
@@ -1,8 +1,11 @@
-﻿namespace ContosoHelpdeskChatBot.Models
-{
-    using Bot.Builder.Community.Dialogs.FormFlow;
-    using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
+using Bot.Builder.Community.Dialogs.FormFlow;
+using System;
+
+namespace ContosoHelpdeskChatBot.Models
+{
     [Serializable]
     public class ResetPasswordPrompt
     {

--- a/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Properties/AssemblyInfo.cs
+++ b/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 


### PR DESCRIPTION
- move using statements to outside namespace statement
- use `nameof(x)` construct for dialog IDs
- use var where applicable
- break long lines
- add copyright and license notices
