### PR TITLE
Fix formatting in .NET Framework migration walkthrough

### DIFF
--- a/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Dialogs/InstallAppDialog.cs
+++ b/MigrationV3V4/CSharp/ContosoHelpdeskChatBot-V4NetFramework/ContosoHelpdeskChatBot/Dialogs/InstallAppDialog.cs
@@ -50,8 +50,8 @@ namespace ContosoHelpdeskChatBot.Dialogs
         }
 
         private async Task<DialogTurnResult> ResolveAppNameAsync(
-    WaterfallStepContext stepContext,
-    CancellationToken cancellationToken = default(CancellationToken))
+            WaterfallStepContext stepContext,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             // Get the result from the text prompt.
             var appname = stepContext.Result as string;


### PR DESCRIPTION
Somehow, I missed wonky indentation for two lines of code. Now fixed in this PR.