### PR TITLE
Use the correct language tab for C#

### DIFF
--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/CoreBot.vstemplate
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/CoreBot.vstemplate
@@ -15,7 +15,7 @@
     <Icon>CoreBot.png</Icon>
     <PreviewImage></PreviewImage>
     <Tags>C#; Windows; Azure; AI; Bots</Tags>
-    <LanguageTag>C#</LanguageTag>
+    <LanguageTag>csharp</LanguageTag>
     <PlatformTag>Windows</PlatformTag>
     <PlatformTag>macOS</PlatformTag>
     <PlatformTag>Linux</PlatformTag>

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/EchoBot.vstemplate
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/EchoBot.vstemplate
@@ -15,7 +15,7 @@
     <Icon>EchoBot.png</Icon>
     <PreviewImage></PreviewImage>
     <Tags>C#; Windows; Azure; AI; Bots</Tags>
-    <LanguageTag>C#</LanguageTag>
+    <LanguageTag>csharp</LanguageTag>
     <PlatformTag>Windows</PlatformTag>
     <PlatformTag>macOS</PlatformTag>
     <PlatformTag>Linux</PlatformTag>

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/EmptyBot.vstemplate
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/EmptyBot.vstemplate
@@ -15,7 +15,7 @@
     <Icon>EmptyBot.png</Icon>
     <PreviewImage></PreviewImage>
     <Tags>C#; Windows; Azure; AI; Bots</Tags>
-    <LanguageTag>C#</LanguageTag>
+    <LanguageTag>csharp</LanguageTag>
     <PlatformTag>Windows</PlatformTag>
     <PlatformTag>macOS</PlatformTag>
     <PlatformTag>Linux</PlatformTag>


### PR DESCRIPTION
Fixes duplicate C# language tabs in the .1 release of VS 2019

## Proposed Changes
Use the correct LanguageTag value, which in doing so, removes the duplicate C# language dropdown entries.