### PR TITLE
Encourage best practice by always forwarding available cancellation token to awaitable calls

### DIFF
--- a/samples/csharp_dotnetcore/01.console-echo/ConsoleAdapter.cs
+++ b/samples/csharp_dotnetcore/01.console-echo/ConsoleAdapter.cs
@@ -115,7 +115,7 @@ namespace Console_EchoBot
                             // The Activity Schema doesn't have a delay type build in, so it's simulated
                             // here in the Bot. This matches the behavior in the Node connector.
                             int delayMs = (int)((Activity)activity).Value;
-                            await Task.Delay(delayMs).ConfigureAwait(false);
+                            await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
                         }
 
                         break;

--- a/samples/csharp_dotnetcore/01.console-echo/EchoBot.cs
+++ b/samples/csharp_dotnetcore/01.console-echo/EchoBot.cs
@@ -21,11 +21,11 @@ namespace Console_EchoBot
             if (turnContext.Activity.Type == ActivityTypes.Message)
             {
                 // Echo back to the user whatever they typed.
-                await turnContext.SendActivityAsync($"You sent '{turnContext.Activity.Text}'");
+                await turnContext.SendActivityAsync($"You sent '{turnContext.Activity.Text}'", cancellationToken: cancellationToken);
             }
             else
             {
-                await turnContext.SendActivityAsync($"{turnContext.Activity.Type} event detected");
+                await turnContext.SendActivityAsync($"{turnContext.Activity.Type} event detected", cancellationToken: cancellationToken);
             }
         }
     }

--- a/samples/csharp_dotnetcore/01.console-echo/Program.cs
+++ b/samples/csharp_dotnetcore/01.console-echo/Program.cs
@@ -20,7 +20,7 @@ namespace Console_EchoBot
 
             // Connect the Console Adapter to the Bot.
             adapter.ProcessActivityAsync(
-                async (turnContext, cancellationToken) => await echoBot.OnTurnAsync(turnContext)).Wait();
+                async (turnContext, cancellationToken) => await echoBot.OnTurnAsync(turnContext, cancellationToken)).Wait();
         }
     }
 }

--- a/samples/csharp_dotnetcore/03.welcome-user/Bots/WelcomeUserBot.cs
+++ b/samples/csharp_dotnetcore/03.welcome-user/Bots/WelcomeUserBot.cs
@@ -68,7 +68,7 @@ namespace Microsoft.BotBuilderSamples
         protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
             var welcomeUserStateAccessor = _userState.CreateProperty<WelcomeUserState>(nameof(WelcomeUserState));
-            var didBotWelcomeUser = await welcomeUserStateAccessor.GetAsync(turnContext, () => new WelcomeUserState());
+            var didBotWelcomeUser = await welcomeUserStateAccessor.GetAsync(turnContext, () => new WelcomeUserState(), cancellationToken);
 
             if (didBotWelcomeUser.DidBotWelcomeUser == false)
             {
@@ -101,7 +101,7 @@ namespace Microsoft.BotBuilderSamples
             }
 
             // Save any state changes.
-            await _userState.SaveChangesAsync(turnContext);
+            await _userState.SaveChangesAsync(turnContext, cancellationToken: cancellationToken);
         }
 
         private static async Task SendIntroCardAsync(ITurnContext turnContext, CancellationToken cancellationToken)

--- a/samples/csharp_dotnetcore/06.using-cards/Dialogs/MainDialog.cs
+++ b/samples/csharp_dotnetcore/06.using-cards/Dialogs/MainDialog.cs
@@ -120,7 +120,7 @@ namespace Microsoft.BotBuilderSamples
             // Give the user instructions about what to do next
             await stepContext.Context.SendActivityAsync(MessageFactory.Text("Type anything to see another card."), cancellationToken);
 
-            return await stepContext.EndDialogAsync();
+            return await stepContext.EndDialogAsync(cancellationToken: cancellationToken);
         }
 
         private IList<Choice> GetChoices()

--- a/samples/csharp_dotnetcore/13.core-bot/Dialogs/CancelAndHelpDialog.cs
+++ b/samples/csharp_dotnetcore/13.core-bot/Dialogs/CancelAndHelpDialog.cs
@@ -53,7 +53,7 @@ namespace Microsoft.BotBuilderSamples.Dialogs
                     case "cancel":
                     case "quit":
                         await innerDc.Context.SendActivityAsync($"Cancelling", cancellationToken: cancellationToken);
-                        return await innerDc.CancelAllDialogsAsync();
+                        return await innerDc.CancelAllDialogsAsync(cancellationToken);
                 }
             }
 

--- a/samples/csharp_dotnetcore/15.handling-attachments/Bots/AttachmentsBot.cs
+++ b/samples/csharp_dotnetcore/15.handling-attachments/Bots/AttachmentsBot.cs
@@ -30,7 +30,7 @@ namespace Microsoft.BotBuilderSamples
         protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
             var reply = ProcessInput(turnContext);
-            await turnContext.SendActivityAsync("HI");
+            await turnContext.SendActivityAsync("HI", cancellationToken: cancellationToken);
             // Respond to the user.
             await turnContext.SendActivityAsync(reply, cancellationToken);
             await DisplayOptionsAsync(turnContext, cancellationToken);

--- a/samples/csharp_dotnetcore/16.proactive-messages/Controllers/NotifyController.cs
+++ b/samples/csharp_dotnetcore/16.proactive-messages/Controllers/NotifyController.cs
@@ -55,7 +55,7 @@ namespace ProactiveBot.Controllers
 
         private async Task BotCallback(ITurnContext turnContext, CancellationToken cancellationToken)
         {
-            await turnContext.SendActivityAsync("proactive hello");
+            await turnContext.SendActivityAsync("proactive hello", cancellationToken: cancellationToken);
         }
     }
 }

--- a/samples/csharp_dotnetcore/17.multilingual-bot/Translation/TranslationMiddleware.cs
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/Translation/TranslationMiddleware.cs
@@ -62,7 +62,7 @@ namespace Microsoft.BotBuilderSamples.Translation
 
             turnContext.OnSendActivities(async (newContext, activities, nextSend) =>
             {
-                string userLanguage = await _languageStateProperty.GetAsync(turnContext, () => TranslationSettings.DefaultLanguage) ?? TranslationSettings.DefaultLanguage;
+                string userLanguage = await _languageStateProperty.GetAsync(turnContext, () => TranslationSettings.DefaultLanguage, cancellationToken) ?? TranslationSettings.DefaultLanguage;
                 bool shouldTranslate = userLanguage != TranslationSettings.DefaultLanguage;
 
                 // Translate messages sent to the user to user language
@@ -71,7 +71,7 @@ namespace Microsoft.BotBuilderSamples.Translation
                     List<Task> tasks = new List<Task>();
                     foreach (Activity currentActivity in activities.Where(a => a.Type == ActivityTypes.Message))
                     {
-                        tasks.Add(TranslateMessageActivityAsync(currentActivity.AsMessageActivity(), userLanguage));
+                        tasks.Add(TranslateMessageActivityAsync(currentActivity.AsMessageActivity(), userLanguage, cancellationToken));
                     }
 
                     if (tasks.Any())
@@ -85,7 +85,7 @@ namespace Microsoft.BotBuilderSamples.Translation
 
             turnContext.OnUpdateActivity(async (newContext, activity, nextUpdate) =>
             {
-                string userLanguage = await _languageStateProperty.GetAsync(turnContext, () => TranslationSettings.DefaultLanguage) ?? TranslationSettings.DefaultLanguage;
+                string userLanguage = await _languageStateProperty.GetAsync(turnContext, () => TranslationSettings.DefaultLanguage, cancellationToken) ?? TranslationSettings.DefaultLanguage;
                 bool shouldTranslate = userLanguage != TranslationSettings.DefaultLanguage;
 
                 // Translate messages sent to the user to user language
@@ -93,7 +93,7 @@ namespace Microsoft.BotBuilderSamples.Translation
                 {
                     if (shouldTranslate)
                     {
-                        await TranslateMessageActivityAsync(activity.AsMessageActivity(), userLanguage);
+                        await TranslateMessageActivityAsync(activity.AsMessageActivity(), userLanguage, cancellationToken);
                     }
                 }
 
@@ -107,7 +107,7 @@ namespace Microsoft.BotBuilderSamples.Translation
         {
             if (activity.Type == ActivityTypes.Message)
             {
-                activity.Text = await _translator.TranslateAsync(activity.Text, targetLocale);
+                activity.Text = await _translator.TranslateAsync(activity.Text, targetLocale, cancellationToken);
             }
         }
 

--- a/samples/csharp_dotnetcore/19.custom-dialogs/Dialogs/RootDialog.cs
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/Dialogs/RootDialog.cs
@@ -99,7 +99,7 @@ namespace Microsoft.BotBuilderSamples
                 var address = (IDictionary<string, object>)result["address"];
 
                 // Now the waterfall is complete, save the data we have gathered into UserState. 
-                var obj = await _userStateAccessor.GetAsync(stepContext.Context, () => new JObject());
+                var obj = await _userStateAccessor.GetAsync(stepContext.Context, () => new JObject(), cancellationToken);
                 obj["data"] = new JObject
                 {
                     { "fullname",  $"{fullname["first"]} {fullname["last"]}" },
@@ -113,7 +113,7 @@ namespace Microsoft.BotBuilderSamples
             }
 
             // Remember to call EndAsync to indicate to the runtime that this is the end of our waterfall.
-            return await stepContext.EndDialogAsync();
+            return await stepContext.EndDialogAsync(cancellationToken: cancellationToken);
         }
     }
 }

--- a/samples/csharp_dotnetcore/19.custom-dialogs/Dialogs/SlotFillingDialog.cs
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/Dialogs/SlotFillingDialog.cs
@@ -53,7 +53,7 @@ namespace Microsoft.BotBuilderSamples
             // Don't do anything for non-message activities.
             if (dialogContext.Context.Activity.Type != ActivityTypes.Message)
             {
-                return await dialogContext.EndDialogAsync(new Dictionary<string, object>());
+                return await dialogContext.EndDialogAsync(new Dictionary<string, object>(), cancellationToken);
             }
 
             // Run prompt
@@ -152,7 +152,7 @@ namespace Microsoft.BotBuilderSamples
             else
             {
                 // No more slots to fill so end the dialog.
-                return dialogContext.EndDialogAsync(state);
+                return dialogContext.EndDialogAsync(state, cancellationToken);
             }
         }
     }

--- a/samples/csharp_dotnetcore/23.facebook-events/Bots/FacebookBot.cs
+++ b/samples/csharp_dotnetcore/23.facebook-events/Bots/FacebookBot.cs
@@ -103,7 +103,7 @@ namespace Microsoft.BotBuilderSamples.Bots
             {
                 if (turnContext.Activity.ChannelId != Bot.Connector.Channels.Facebook)
                 {
-                    await turnContext.SendActivityAsync("This sample is intended to be used with a Facebook bot.");
+                    await turnContext.SendActivityAsync("This sample is intended to be used with a Facebook bot.", cancellationToken: cancellationToken);
                 }
                 else
                 {

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/Dialogs/LogoutDialog.cs
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/Dialogs/LogoutDialog.cs
@@ -53,7 +53,7 @@ namespace Microsoft.BotBuilderSamples
                     var botAdapter = (BotFrameworkAdapter)innerDc.Context.Adapter;
                     await botAdapter.SignOutUserAsync(innerDc.Context, ConnectionName, null, cancellationToken);
                     await innerDc.Context.SendActivityAsync(MessageFactory.Text("You have been signed out."), cancellationToken);
-                    return await innerDc.CancelAllDialogsAsync();
+                    return await innerDc.CancelAllDialogsAsync(cancellationToken);
                 }
             }
             return null;

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/Dialogs/MainDialog.cs
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/Dialogs/MainDialog.cs
@@ -62,7 +62,7 @@ namespace Microsoft.BotBuilderSamples
             }
 
             await stepContext.Context.SendActivityAsync(MessageFactory.Text("Login was not successful please try again."), cancellationToken);
-            return await stepContext.EndDialogAsync();
+            return await stepContext.EndDialogAsync(cancellationToken: cancellationToken);
         }
 
         private async Task<DialogTurnResult> CommandStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)

--- a/samples/csharp_dotnetcore/42.scaleout/Bots/ScaleoutBot.cs
+++ b/samples/csharp_dotnetcore/42.scaleout/Bots/ScaleoutBot.cs
@@ -63,7 +63,7 @@ namespace Microsoft.BotBuilderSamples
                     if (activities.Any())
                     {
                         // This is an actual send on the TurnContext we were given and so will actual do a send this time.
-                        await turnContext.SendActivitiesAsync(activities);
+                        await turnContext.SendActivitiesAsync(activities, cancellationToken);
                     }
 
                     break;

--- a/samples/csharp_dotnetcore/42.scaleout/Dialogs/RootDialog.cs
+++ b/samples/csharp_dotnetcore/42.scaleout/Dialogs/RootDialog.cs
@@ -44,7 +44,7 @@ namespace Microsoft.BotBuilderSamples
             var first = (long)stepContext.Values["first"];
             var second = (long)stepContext.Result;
             await stepContext.Context.SendActivityAsync(MessageFactory.Text($"The result of the first minus the second is {first - second}."), cancellationToken);
-            return await stepContext.EndDialogAsync(cancellationToken);
+            return await stepContext.EndDialogAsync(cancellationToken, cancellationToken);
         }
     }
 }

--- a/samples/csharp_dotnetcore/43.complex-dialog/Dialogs/MainDialog.cs
+++ b/samples/csharp_dotnetcore/43.complex-dialog/Dialogs/MainDialog.cs
@@ -41,7 +41,7 @@ namespace Microsoft.BotBuilderSamples
                 + (userInfo.CompaniesToReview.Count is 0 ? "no companies" : string.Join(" and ", userInfo.CompaniesToReview))
                 + ".";
 
-            await stepContext.Context.SendActivityAsync(status);
+            await stepContext.Context.SendActivityAsync(status, cancellationToken: cancellationToken);
 
             var accessor = _userState.CreateProperty<UserProfile>(nameof(UserProfile));
             await accessor.SetAsync(stepContext.Context, userInfo, cancellationToken);

--- a/samples/csharp_dotnetcore/44.prompt-users-for-input/Bots/CustomPromptBot.cs
+++ b/samples/csharp_dotnetcore/44.prompt-users-for-input/Bots/CustomPromptBot.cs
@@ -31,16 +31,16 @@ namespace Microsoft.BotBuilderSamples
         {
            
             var conversationStateAccessors = _conversationState.CreateProperty<ConversationFlow>(nameof(ConversationFlow));
-            var flow = await conversationStateAccessors.GetAsync(turnContext, () => new ConversationFlow());
+            var flow = await conversationStateAccessors.GetAsync(turnContext, () => new ConversationFlow(), cancellationToken);
 
             var userStateAccessors = _userState.CreateProperty<UserProfile>(nameof(UserProfile));
-            var profile = await userStateAccessors.GetAsync(turnContext, () => new UserProfile());
+            var profile = await userStateAccessors.GetAsync(turnContext, () => new UserProfile(), cancellationToken);
 
             await FillOutUserProfileAsync(flow, profile, turnContext);
 
             // Save changes.
-            await _conversationState.SaveChangesAsync(turnContext);
-            await _userState.SaveChangesAsync(turnContext);
+            await _conversationState.SaveChangesAsync(turnContext, cancellationToken: cancellationToken);
+            await _userState.SaveChangesAsync(turnContext, cancellationToken: cancellationToken);
         }
 
         private static async Task FillOutUserProfileAsync(ConversationFlow flow, UserProfile profile, ITurnContext turnContext)

--- a/samples/csharp_dotnetcore/45.state-management/Bots/StateManagementBot.cs
+++ b/samples/csharp_dotnetcore/45.state-management/Bots/StateManagementBot.cs
@@ -32,7 +32,7 @@ namespace Microsoft.BotBuilderSamples
 
         protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
         {
-            await turnContext.SendActivityAsync("Welcome to State Bot Sample. Type anything to get started.");
+            await turnContext.SendActivityAsync("Welcome to State Bot Sample. Type anything to get started.", cancellationToken: cancellationToken);
         }
 
         protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
@@ -40,10 +40,10 @@ namespace Microsoft.BotBuilderSamples
             // Get the state properties from the turn context.
 
             var conversationStateAccessors =  _conversationState.CreateProperty<ConversationData>(nameof(ConversationData));
-            var conversationData = await conversationStateAccessors.GetAsync(turnContext, () => new ConversationData());
+            var conversationData = await conversationStateAccessors.GetAsync(turnContext, () => new ConversationData(), cancellationToken);
 
             var userStateAccessors = _userState.CreateProperty<UserProfile>(nameof(UserProfile));
-            var userProfile = await userStateAccessors.GetAsync(turnContext, () => new UserProfile());
+            var userProfile = await userStateAccessors.GetAsync(turnContext, () => new UserProfile(), cancellationToken);
 
             if (string.IsNullOrEmpty(userProfile.Name))
             {
@@ -54,7 +54,7 @@ namespace Microsoft.BotBuilderSamples
                     userProfile.Name = turnContext.Activity.Text?.Trim();
 
                     // Acknowledge that we got their name.
-                    await turnContext.SendActivityAsync($"Thanks {userProfile.Name}. To see conversation data, type anything.");
+                    await turnContext.SendActivityAsync($"Thanks {userProfile.Name}. To see conversation data, type anything.", cancellationToken: cancellationToken);
 
                     // Reset the flag to allow the bot to go though the cycle again.
                     conversationData.PromptedUserForName = false;
@@ -62,7 +62,7 @@ namespace Microsoft.BotBuilderSamples
                 else
                 {
                     // Prompt the user for their name.
-                    await turnContext.SendActivityAsync($"What is your name?");
+                    await turnContext.SendActivityAsync($"What is your name?", cancellationToken: cancellationToken);
 
                     // Set the flag to true, so we don't prompt in the next turn.
                     conversationData.PromptedUserForName = true;
@@ -78,9 +78,9 @@ namespace Microsoft.BotBuilderSamples
                 conversationData.ChannelId = turnContext.Activity.ChannelId.ToString();
 
                 // Display state data.
-                await turnContext.SendActivityAsync($"{userProfile.Name} sent: {turnContext.Activity.Text}");
-                await turnContext.SendActivityAsync($"Message received at: {conversationData.Timestamp}");
-                await turnContext.SendActivityAsync($"Message received from: {conversationData.ChannelId}");
+                await turnContext.SendActivityAsync($"{userProfile.Name} sent: {turnContext.Activity.Text}", cancellationToken: cancellationToken);
+                await turnContext.SendActivityAsync($"Message received at: {conversationData.Timestamp}", cancellationToken: cancellationToken);
+                await turnContext.SendActivityAsync($"Message received from: {conversationData.ChannelId}", cancellationToken: cancellationToken);
             }
         }
     }


### PR DESCRIPTION
## Proposed Changes
Make samples more complete by always passing down available cancellation tokens to any awaitable calls.