### PR TITLE
V3 state bot, and v4 state bot that uses Bot.Builder.Azure.V3ToV4 for UserState

### DIFF
--- a/MigrationV3V4/CSharp/V3StateBot/README.md
+++ b/MigrationV3V4/CSharp/V3StateBot/README.md
@@ -1,0 +1,57 @@
+## Overview
+
+Example demonstrating saving user scoped information (User State) into Azure Table, CosmosDb or Azure Sql using [Microsoft.Bot.Builder.Azure](https://www.nuget.org/packages/Microsoft.Bot.Builder.Azure/3.16.3.40383)
+
+## Purpose
+
+This bot will ask the user their name and city of residence.  This information is then stored in the ```IBotDataStore<BotData>``` configured by the developer in Global.asax.cs.  Two classes are stored within the UserState:
+
+```cs
+    public class GreetingState
+    {
+        public string Name { get; set; }
+        public string City { get; set; }
+    }
+```
+```cs
+    public class TestDataClass
+    {
+        public string TestStringField { get; set; }
+        public int TestIntField { get; set; }
+        public Tuple<string, string> TestTuple { get; set; }
+    }
+```
+
+If [V4StateBot](../V4StateBotFromV3Providers/V4StateBot.sln) is then connected to the same storage provider, this User State information can be automatically read using the provided [Bot.Builder.Azure.V3V4](../V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/Bot.Builder.Azure.V3V4.csproj) library.
+
+## To try this sample
+
+- Clone the repository
+
+    ```bash
+    git clone https://github.com/Microsoft/botbuilder-samples.git
+    ```
+
+  - Launch Visual Studio
+  - File -> Open -> Project/Solution
+  - Navigate to `MigrationV3V4/CSharp/V3StateBot` folder
+  - Select `V3StateBot.sln` file
+  - Edit web.config TableStorageConnectionString, BotDataContextConnectionString or CosmosDb app settings.
+  - Modify Global.asax.cs so the storage provider you are using is properly registered.
+  - Press `F5` to run the project
+  
+## Testing the bot using Bot Framework Emulator
+
+[Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
+
+- Install the Bot Framework Emulator version 4.3.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
+
+### Connect to the bot using Bot Framework Emulator
+
+- Launch Bot Framework Emulator
+- File -> Open Bot
+- Enter a Bot URL of `http://localhost:3978/api/messages`
+
+## Further reading
+
+- [Bot Framework Documentation](https://docs.botframework.com)

--- a/MigrationV3V4/CSharp/V3StateBot/V3StateBot.sln
+++ b/MigrationV3V4/CSharp/V3StateBot/V3StateBot.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.572
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "V3StateBot", "V3StateBot\V3StateBot.csproj", "{7E93C4A1-C652-420A-A509-752EE4C8012F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7E93C4A1-C652-420A-A509-752EE4C8012F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E93C4A1-C652-420A-A509-752EE4C8012F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E93C4A1-C652-420A-A509-752EE4C8012F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E93C4A1-C652-420A-A509-752EE4C8012F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A0FC24FE-52FF-4D23-A4BA-1E10B0344B68}
+	EndGlobalSection
+EndGlobal

--- a/MigrationV3V4/CSharp/V3StateBot/V3StateBot/App_Start/WebApiConfig.cs
+++ b/MigrationV3V4/CSharp/V3StateBot/V3StateBot/App_Start/WebApiConfig.cs
@@ -1,0 +1,37 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http;
+
+namespace V3StateBot
+{
+    public static class WebApiConfig
+    {
+        public static void Register(HttpConfiguration config)
+        {
+            // Json settings
+            config.Formatters.JsonFormatter.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
+            config.Formatters.JsonFormatter.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+            config.Formatters.JsonFormatter.SerializerSettings.Formatting = Formatting.Indented;
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings()
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                Formatting = Newtonsoft.Json.Formatting.Indented,
+                NullValueHandling = NullValueHandling.Ignore,
+            };
+
+            // Web API configuration and services
+
+            // Web API routes
+            config.MapHttpAttributeRoutes();
+
+            config.Routes.MapHttpRoute(
+                name: "DefaultApi",
+                routeTemplate: "api/{controller}/{id}",
+                defaults: new { id = RouteParameter.Optional }
+            );
+        }
+    }
+}

--- a/MigrationV3V4/CSharp/V3StateBot/V3StateBot/Controllers/MessagesController.cs
+++ b/MigrationV3V4/CSharp/V3StateBot/V3StateBot/Controllers/MessagesController.cs
@@ -1,0 +1,61 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Web.Http;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Connector;
+
+namespace V3StateBot
+{
+    [BotAuthentication]
+    public class MessagesController : ApiController
+    {
+        /// <summary>
+        /// POST: api/Messages
+        /// Receive a message from a user and reply to it
+        /// </summary>
+        public async Task<HttpResponseMessage> Post([FromBody]Activity activity)
+        {
+            if (activity.GetActivityType() == ActivityTypes.Message)
+            {
+                await Conversation.SendAsync(activity, () => new Dialogs.RootDialog());
+            }
+            else
+            {
+                HandleSystemMessage(activity);
+            }
+            var response = Request.CreateResponse(HttpStatusCode.OK);
+            return response;
+        }
+
+        private Activity HandleSystemMessage(Activity message)
+        {
+            string messageType = message.GetActivityType();
+            if (messageType == ActivityTypes.DeleteUserData)
+            {
+                // Implement user deletion here
+                // If we handle user deletion, return a real message
+            }
+            else if (messageType == ActivityTypes.ConversationUpdate)
+            {
+                // Handle conversation state changes, like members being added and removed
+                // Use Activity.MembersAdded and Activity.MembersRemoved and Activity.Action for info
+                // Not available in all channels
+            }
+            else if (messageType == ActivityTypes.ContactRelationUpdate)
+            {
+                // Handle add/remove from contact lists
+                // Activity.From + Activity.Action represent what happened
+            }
+            else if (messageType == ActivityTypes.Typing)
+            {
+                // Handle knowing that the user is typing
+            }
+            else if (messageType == ActivityTypes.Ping)
+            {
+            }
+
+            return null;
+        }
+    }
+}

--- a/MigrationV3V4/CSharp/V3StateBot/V3StateBot/Dialogs/RootDialog.cs
+++ b/MigrationV3V4/CSharp/V3StateBot/V3StateBot/Dialogs/RootDialog.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Connector;
+using V3StateBot.Models;
+
+namespace V3StateBot.Dialogs
+{
+    [Serializable]
+    public class RootDialog : IDialog<object>
+    {
+        // Names of properties stored in CosmosDb UserData
+        const string AskedNameProperty = "AskedName";
+        const string GreetingStateProperty = "V3TestGreeting";
+        const string TestDataClassProperty = "V3TestDataClass";
+
+        public Task StartAsync(IDialogContext context)
+        {
+            context.Wait(MessageReceivedAsync);
+            return Task.CompletedTask;
+        }
+
+        private async Task MessageReceivedAsync(IDialogContext context, IAwaitable<object> result)
+        {
+            var activity = await result as Activity;
+
+            // An example of a string value saved directly to UserData
+            context.UserData.SetValue("test", "test");
+
+            // If we have not asked the user their name, ask it now
+            var askedName = context.UserData.GetValueOrDefault<bool>(AskedNameProperty);
+            if (!askedName)
+            {
+                await context.PostAsync($"v3: Hi.  What is your name?");
+                // We've asked the user their name, so persist the information in UserData
+                context.UserData.SetValue(AskedNameProperty, true);
+            }
+            else
+            {
+                // Check if we have saved GreetingState.  If we have not, assume the text is the user's Name in 
+                // answer to the query above.
+                var greetingState = context.UserData.GetValueOrDefault<GreetingState>(GreetingStateProperty);
+                if (greetingState == null)
+                {
+                    greetingState = new GreetingState() { Name = activity.Text };
+                    context.UserData.SetValue(GreetingStateProperty, greetingState);
+
+                    await context.PostAsync($"v3: Hi {greetingState.Name}.  What city do you live in?");
+                }
+                else if (string.IsNullOrEmpty(greetingState.City))
+                {
+                    // Since greetingState.City is empty, assume the text is the user's City in response
+                    // to the query above
+                    greetingState.City = activity.Text;
+                    context.UserData.SetValue(GreetingStateProperty, greetingState);
+
+                    await context.PostAsync($"v3: Ok {greetingState.Name}.  I've got your City of residence as {greetingState.City}  Auto saving TestDataClass.");
+
+                    // Save some random data
+                    var classToSave = new TestDataClass() { TestIntField = 9,
+                                                            TestStringField = Guid.NewGuid().ToString(),
+                                                            TestTuple = new Tuple<string, string>("item 1", "item 2") };
+                    context.UserData.SetValue(TestDataClassProperty, classToSave);
+
+                }
+                else
+                {
+                    int length = (activity.Text ?? string.Empty).Length;
+                    // Return our reply to the user
+                    await context.PostAsync($"v3: Hi {greetingState.Name} from {greetingState.City}.  You sent {activity.Text} which was {length} characters");
+
+                    var testDataClass = context.UserData.GetValue<TestDataClass>(TestDataClassProperty);
+                    await context.PostAsync($"v3: askedName: {askedName} testDataClass.TestIntField: {testDataClass.TestIntField} testDataClass.TestStringField: {testDataClass.TestStringField} testDataClass.TestTuple.Item1: {testDataClass.TestTuple.Item1} testDataClass.TestTuple.Item2: {testDataClass.TestTuple.Item2}");                    
+                }
+            }
+
+            context.Wait(MessageReceivedAsync);
+        }
+    }
+}

--- a/MigrationV3V4/CSharp/V3StateBot/V3StateBot/Global.asax
+++ b/MigrationV3V4/CSharp/V3StateBot/V3StateBot/Global.asax
@@ -1,0 +1,1 @@
+﻿<%@ Application Codebehind="Global.asax.cs" Inherits="V3StateBot.WebApiApplication" Language="C#" %>

--- a/MigrationV3V4/CSharp/V3StateBot/V3StateBot/Global.asax.cs
+++ b/MigrationV3V4/CSharp/V3StateBot/V3StateBot/Global.asax.cs
@@ -1,0 +1,53 @@
+﻿using System.Web.Http;
+using Microsoft.Bot.Builder.Azure;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Internals;
+using Autofac;
+using Microsoft.Bot.Connector;
+using System.Reflection;
+using System;
+using System.Configuration;
+
+namespace V3StateBot
+{
+    public class WebApiApplication : System.Web.HttpApplication
+    {
+        protected void Application_Start()
+        {
+            GlobalConfiguration.Configure(WebApiConfig.Register);
+
+            Conversation.UpdateContainer(
+            builder =>
+            {
+                builder.RegisterModule(new AzureModule(Assembly.GetExecutingAssembly()));
+
+                // Bot Storage: Here we register the state storage for your bot. 
+                // Default store: volatile in-memory store - Only for prototyping!
+                // We provide adapters for Azure Table, CosmosDb, SQL Azure, or you can implement your own!
+                // For samples and documentation, see: [https://github.com/Microsoft/BotBuilder-Azure](https://github.com/Microsoft/BotBuilder-Azure)
+                //var store = new InMemoryDataStore();
+
+                // Other storage options
+                
+                var store = new DocumentDbBotDataStore(new Uri(ConfigurationManager.AppSettings["CosmosEndpoint"]),
+                                                        ConfigurationManager.AppSettings["CosmosKey"],
+                                                        ConfigurationManager.AppSettings["CosmosDatataseName"],
+                                                        ConfigurationManager.AppSettings["CosmosCollectionName"]);
+
+                //var sqlConnection = ConfigurationManager.ConnectionStrings["BotDataContextConnectionString"].ConnectionString;
+                //var store = new SqlBotDataStore(sqlConnection);
+                
+
+                //var tableStoreConnectionString = ConfigurationManager.ConnectionStrings["TableStorageConnectionString"].ConnectionString;
+                //var store = new TableBotDataStore(tableStoreConnectionString);
+                //var store = new TableBotDataStore2(tableStoreConnectionString);
+
+
+                builder.Register(c => store)
+                    .Keyed<IBotDataStore<BotData>>(AzureModule.Key_DataStore)
+                    .AsSelf()
+                    .SingleInstance();
+            });
+        }
+    }
+}

--- a/MigrationV3V4/CSharp/V3StateBot/V3StateBot/Models/GreetingState.cs
+++ b/MigrationV3V4/CSharp/V3StateBot/V3StateBot/Models/GreetingState.cs
@@ -1,0 +1,8 @@
+﻿namespace V3StateBot.Models
+{
+    public class GreetingState
+    {
+        public string Name { get; set; }
+        public string City { get; set; }
+    }
+}

--- a/MigrationV3V4/CSharp/V3StateBot/V3StateBot/Models/TestDataClass.cs
+++ b/MigrationV3V4/CSharp/V3StateBot/V3StateBot/Models/TestDataClass.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace V3StateBot.Models
+{
+    public class TestDataClass
+    {
+        public string TestStringField { get; set; }
+        public int TestIntField { get; set; }
+        public Tuple<string, string> TestTuple { get; set; }
+    }
+}

--- a/MigrationV3V4/CSharp/V3StateBot/V3StateBot/Properties/AssemblyInfo.cs
+++ b/MigrationV3V4/CSharp/V3StateBot/V3StateBot/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("V3StateBot")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyProduct("V3StateBot")]
+[assembly: AssemblyCopyright("Copyright © Microsoft 2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("287d6db1-a34e-44db-bbf5-e1312cd4737f")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.1")]
+[assembly: AssemblyFileVersion("1.0.0.1")]

--- a/MigrationV3V4/CSharp/V3StateBot/V3StateBot/V3StateBot.csproj
+++ b/MigrationV3V4/CSharp/V3StateBot/V3StateBot/V3StateBot.csproj
@@ -1,0 +1,220 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{7E93C4A1-C652-420A-A509-752EE4C8012F}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>V3StateBot</RootNamespace>
+    <AssemblyName>V3StateBot</AssemblyName>
+    <!--<TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>-->
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <UseIISExpress>true</UseIISExpress>
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
+    <Use64BitIISExpress />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Autofac, Version=4.6.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.6.0\lib\net45\Autofac.dll</HintPath>
+    </Reference>
+    <Reference Include="Chronic, Version=0.3.2.0, Culture=neutral, PublicKeyToken=3bd1f1ef638b0d3c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chronic.Signed.0.3.2\lib\net40\Chronic.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.22.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.DocumentDB.1.22.0\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bot.Builder, Version=3.20.1.42, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bot.Builder.3.20.1\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bot.Builder.Autofac, Version=3.20.1.42, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bot.Builder.3.20.1\lib\net46\Microsoft.Bot.Builder.Autofac.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bot.Builder.Azure, Version=3.16.3.40383, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bot.Builder.Azure.3.16.3.40383\lib\net46\Microsoft.Bot.Builder.Azure.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bot.Builder.History, Version=3.16.1.38846, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bot.Builder.History.3.16.1.38846\lib\net46\Microsoft.Bot.Builder.History.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bot.Connector, Version=3.20.1.42, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bot.Connector.3.20.1\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Data.Edm, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.Edm.5.7.0\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.OData.5.7.0\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.7.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=4.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.4.4.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=1.1.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Logging.1.1.4\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocol.Extensions, Version=1.0.40306.1554, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.4.403061554\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols, Version=2.1.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.2.1.4\lib\net451\Microsoft.IdentityModel.Protocols.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=2.1.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.OpenIdConnect.2.1.4\lib\net451\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.1.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.1.4\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.3.8\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.CoreUtility">
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=7.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsAzure.Storage.7.2.1\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.1.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.1.4\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Spatial, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Spatial.5.7.0\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.WebHost, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="default.htm" />
+    <Content Include="Global.asax" />
+    <Content Include="Web.config">
+      <SubType>Designer</SubType>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="App_Start\WebApiConfig.cs" />
+    <Compile Include="Controllers\MessagesController.cs" />
+    <Compile Include="Dialogs\RootDialog.cs" />
+    <Compile Include="Global.asax.cs">
+      <DependentUpon>Global.asax</DependentUpon>
+    </Compile>
+    <Compile Include="Models\GreetingState.cs" />
+    <Compile Include="Models\TestDataClass.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="packages.config">
+      <SubType>Designer</SubType>
+    </Content>
+    <None Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+    <None Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <EnableMSDeployAppOffline>true</EnableMSDeployAppOffline>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>3978</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:3978/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/MigrationV3V4/CSharp/V3StateBot/V3StateBot/Web.Debug.config
+++ b/MigrationV3V4/CSharp/V3StateBot/V3StateBot/Web.Debug.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/MigrationV3V4/CSharp/V3StateBot/V3StateBot/Web.Release.config
+++ b/MigrationV3V4/CSharp/V3StateBot/V3StateBot/Web.Release.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/MigrationV3V4/CSharp/V3StateBot/V3StateBot/Web.config
+++ b/MigrationV3V4/CSharp/V3StateBot/V3StateBot/Web.config
@@ -1,0 +1,135 @@
+﻿<?xml version="1.0"?>
+<!--
+  For more information on how to configure your ASP.NET application, please visit
+  http://go.microsoft.com/fwlink/?LinkId=301879
+  -->
+<configuration>
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
+  </configSections>
+  <appSettings>
+    <!-- update these with your BotId, Microsoft App Id and your Microsoft App Password-->
+    <add key="BotId" value="YourBotId"/>
+    <add key="MicrosoftAppId" value=""/>
+    <add key="MicrosoftAppPassword" value=""/>
+    <add key="CosmosEndpoint" value="https://yourcosmosdb.documents.azure.com:443/"/>
+    <add key="CosmosKey" value=""/>
+    <add key="CosmosDatataseName" value="v3botdb"/>
+    <add key="CosmosCollectionName" value="v3botcollection"/>
+  </appSettings>
+  <connectionStrings>
+    <add name="TableStorageConnectionString" connectionString="DefaultEndpointsProtocol=https;AccountName=YourAccountName;AccountKey=YourAccountKey;EndpointSuffix=core.windows.net"/>
+
+    <add name="BotDataContextConnectionString" providerName="System.Data.SqlClient" connectionString="Server=YourServerName;Initial Catalog=BotData;Persist Security Info=False;User ID=YourServerUser;Password=YourServerPassword;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;"/>
+  </connectionStrings>
+  <!--
+    For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
+
+    The following attributes can be set on the <httpRuntime> tag.
+      <system.Web>
+        <httpRuntime targetFramework="4.6" />
+      </system.Web>
+  -->
+  <system.web>
+    <customErrors mode="Off"/>
+    <compilation debug="true" targetFramework="4.6.1"/>
+    <httpRuntime targetFramework="4.6"/>
+  </system.web>
+  <system.webServer>
+    <defaultDocument>
+      <files>
+        <clear/>
+        <add value="default.htm"/>
+      </files>
+    </defaultDocument>
+    <handlers>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
+      <remove name="OPTIONSVerbHandler"/>
+      <remove name="TRACEVerbHandler"/>
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
+    </handlers>
+  </system.webServer>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Autofac" publicKeyToken="17863AF14B0044DA" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.6.0.0" newVersion="4.6.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.1.4.0" newVersion="5.1.4.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.6.0.0" newVersion="4.6.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bot.Connector" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.20.1.42" newVersion="3.20.1.42"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bot.Builder" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.20.1.42" newVersion="3.20.1.42"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.Documents.Client" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.11.0.0" newVersion="1.11.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bot.Builder.Autofac" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.20.1.42" newVersion="3.20.1.42"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bot.Builder.History" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.15.2.0" newVersion="3.15.2.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="mssqllocaldb"/>
+      </parameters>
+    </defaultConnectionFactory>
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
+    </providers>
+  </entityFramework>
+</configuration>

--- a/MigrationV3V4/CSharp/V3StateBot/V3StateBot/default.htm
+++ b/MigrationV3V4/CSharp/V3StateBot/V3StateBot/default.htm
@@ -1,0 +1,29 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+
+    <meta http-equiv="Access-Control-Allow-Origin" content="*">
+</head>
+<body>
+    <div id="webchat" />
+
+    <script src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
+    <script>
+        var convoCookie = localStorage.getItem("conversationId");
+        var token = 'Ty0qfs_eWNI.cwA.wIA.E4n8ZSDIo0b8b1Dc7PLgms0sF4YWm_jPw7CExJQJ5WI';
+        debugger;
+        
+            var chatbot = new WebChat.createDirectLine({
+                secret: token,
+                webSocket: false,
+                pollingInterval: 2000
+            });
+
+        WebChat.renderWebChat({
+            directLine: chatbot,
+            userID: 'V3UserId'
+        }, document.getElementById('webchat'));
+
+    </script>
+</body>
+</html>

--- a/MigrationV3V4/CSharp/V3StateBot/V3StateBot/default.htm
+++ b/MigrationV3V4/CSharp/V3StateBot/V3StateBot/default.htm
@@ -1,29 +1,425 @@
 ﻿<!DOCTYPE html>
-<html>
+<html lang="en">
+
 <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>V3 State Bot Sample</title>
+    <style>
+        body {
+            margin: 0px;
+            padding: 0px;
+            font-family: Segoe UI;
+        }
 
-    <meta http-equiv="Access-Control-Allow-Origin" content="*">
-</head>
-<body>
-    <div id="webchat" />
+        html,
+        body {
+            height: 100%;
+        }
 
-    <script src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
+        header {
+            background-image: url("data:image/svg+xml,%3Csvg version='1.1' id='Layer_1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' viewBox='0 0 4638.9 651.6' style='enable-background:new 0 0 4638.9 651.6;' xml:space='preserve'%3E%3Cstyle type='text/css'%3E .st0%7Bfill:%2355A0E0;%7D .st1%7Bfill:none;%7D .st2%7Bfill:%230058A8;%7D .st3%7Bfill:%23328BD8;%7D .st4%7Bfill:%23B6DCF1;%7D .st5%7Bopacity:0.2;fill:url(%23SVGID_1_);enable-background:new ;%7D%0A%3C/style%3E%3Crect y='1.1' class='st0' width='4640' height='646.3'/%3E%3Cpath class='st1' d='M3987.8,323.6L4310.3,1.1h-65.6l-460.1,460.1c-17.5,17.5-46.1,17.5-63.6,0L3260.9,1.1H0v646.3h3660.3 L3889,418.7c17.5-17.5,46.1-17.5,63.6,0l228.7,228.7h66.6l-260.2-260.2C3970.3,369.8,3970.3,341.1,3987.8,323.6z'/%3E%3Cpath class='st2' d='M3784.6,461.2L4244.7,1.1h-983.9l460.1,460.1C3738.4,478.7,3767.1,478.7,3784.6,461.2z'/%3E%3Cpath class='st3' d='M4640,1.1h-329.8l-322.5,322.5c-17.5,17.5-17.5,46.1,0,63.6l260.2,260.2H4640L4640,1.1L4640,1.1z'/%3E%3Cpath class='st4' d='M3889,418.8l-228.7,228.7h521.1l-228.7-228.7C3935.2,401.3,3906.5,401.3,3889,418.8z'/%3E%3ClinearGradient id='SVGID_1_' gradientUnits='userSpaceOnUse' x1='3713.7576' y1='438.1175' x2='3911.4084' y2='14.2535' gradientTransform='matrix(1 0 0 -1 0 641.3969)'%3E%3Cstop offset='0' style='stop-color:%23FFFFFF;stop-opacity:0.5'/%3E%3Cstop offset='1' style='stop-color:%23FFFFFF'/%3E%3C/linearGradient%3E%3Cpath class='st5' d='M3952.7,124.5c-17.5-17.5-46.1-17.5-63.6,0l-523,523h1109.6L3952.7,124.5z'/%3E%3C/svg%3E%0A");
+            background-repeat: no-repeat;
+            background-size: 100%;
+            background-position: right;
+            background-color: #55A0E0;
+            width: 100%;
+            font-size: 44px;
+            height: 120px;
+            color: white;
+            padding: 30px 0 40px 0px;
+            display: inline-block;
+        }
+
+        .header-icon {
+            background-image: url("data:image/svg+xml;utf8,%3Csvg%20version%3D%221.1%22%20id%3D%22Layer_1%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20viewBox%3D%220%200%20150.2%20125%22%20style%3D%22enable-background%3Anew%200%200%20150.2%20125%3B%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cstyle%20type%3D%22text/css%22%3E%0A%09.st0%7Bfill%3Anone%3B%7D%0A%09.st1%7Bfill%3A%23FFFFFF%3B%7D%0A%3C/style%3E%0A%3Crect%20x%3D%220.5%22%20class%3D%22st0%22%20width%3D%22149.7%22%20height%3D%22125%22/%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M59%2C102.9L21.8%2C66c-3.5-3.5-3.5-9.1%2C0-12.5l37-36.5l2.9%2C3l-37%2C36.4c-1.8%2C1.8-1.8%2C4.7%2C0%2C6.6l37.2%2C37L59%2C102.9z%22%0A%09%09/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M92.5%2C102.9l-3-3l37.2-37c0.9-0.9%2C1.4-2%2C1.4-3.3c0-1.2-0.5-2.4-1.4-3.3L89.5%2C20l2.9-3l37.2%2C36.4%0A%09%09c1.7%2C1.7%2C2.6%2C3.9%2C2.6%2C6.3s-0.9%2C4.6-2.6%2C6.3L92.5%2C102.9z%22/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M90.1%2C68.4c-4.5%2C0-8-3.5-8-8.1c0-4.5%2C3.5-8.1%2C8-8.1c4.4%2C0%2C8%2C3.7%2C8%2C8.1C98.1%2C64.7%2C94.4%2C68.4%2C90.1%2C68.4z%0A%09%09%20M90.1%2C56.5c-2.2%2C0-3.8%2C1.7-3.8%2C3.9c0%2C2.2%2C1.7%2C3.9%2C3.8%2C3.9c1.9%2C0%2C3.8-1.6%2C3.8-3.9S91.9%2C56.5%2C90.1%2C56.5z%22/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M61.4%2C68.4c-4.5%2C0-8-3.5-8-8.1c0-4.5%2C3.5-8.1%2C8-8.1c4.4%2C0%2C8%2C3.7%2C8%2C8.1C69.5%2C64.7%2C65.8%2C68.4%2C61.4%2C68.4z%0A%09%09%20M61.4%2C56.5c-2.2%2C0-3.8%2C1.7-3.8%2C3.9c0%2C2.2%2C1.7%2C3.9%2C3.8%2C3.9c1.9%2C0%2C3.8-1.6%2C3.8-3.9S63.3%2C56.5%2C61.4%2C56.5z%22/%3E%0A%3C/g%3E%0A%3C/svg%3E%0A");
+            background-repeat: no-repeat;
+            float: left;
+            height: 140px;
+            width: 140px;
+            display: inline-block;
+            vertical-align: middle;
+        }
+
+        .header-text {
+            padding-left: 1%;
+            color: #FFFFFF;
+            font-family: "Segoe UI";
+            font-size: 72px;
+            font-weight: 300;
+            letter-spacing: 0.35px;
+            line-height: 96px;
+            display: inline-block;
+            vertical-align: middle;
+        }
+
+        .header-inner-container {
+            min-width: 480px;
+            max-width: 1366px;
+            margin-left: auto;
+            margin-right: auto;
+            vertical-align: middle;
+        }
+
+            .header-inner-container::after {
+                content: "";
+                clear: both;
+                display: table;
+            }
+
+        .main-content-area {
+            padding-left: 30px;
+        }
+
+        .content-title {
+            color: #000000;
+            font-family: "Segoe UI";
+            font-size: 46px;
+            font-weight: 300;
+            line-height: 62px;
+        }
+
+        .main-text {
+            color: #808080;
+            font-size: 24px;
+            font-family: "Segoe UI";
+            font-size: 24px;
+            font-weight: 200;
+            line-height: 32px;
+        }
+
+        .main-text-p1 {
+            padding-top: 48px;
+            padding-bottom: 28px;
+        }
+
+        .endpoint {
+            height: 32px;
+            width: 571px;
+            color: #808080;
+            font-family: "Segoe UI";
+            font-size: 24px;
+            font-weight: 200;
+            line-height: 32px;
+            padding-top: 28px;
+        }
+
+        .how-to-build-section {
+            padding-top: 20px;
+            padding-left: 30px;
+        }
+
+            .how-to-build-section > h3 {
+                font-size: 16px;
+                font-weight: 600;
+                letter-spacing: 0.35px;
+                line-height: 22px;
+                margin: 0 0 24px 0;
+                text-transform: uppercase;
+            }
+
+        .step-container {
+            display: flex;
+            align-items: stretch;
+            position: relative;
+        }
+
+            .step-container dl {
+                border-left: 1px solid #A0A0A0;
+                display: block;
+                padding: 0 24px;
+                margin: 0;
+            }
+
+                .step-container dl > dt::before {
+                    background-color: white;
+                    border: 1px solid #A0A0A0;
+                    border-radius: 100%;
+                    content: '';
+                    left: 47px;
+                    height: 11px;
+                    position: absolute;
+                    width: 11px;
+                }
+
+                .step-container dl > .test-bullet::before {
+                    background-color: blue;
+                }
+
+                .step-container dl > dt {
+                    display: block;
+                    font-size: inherit;
+                    font-weight: bold;
+                    line-height: 20px;
+                }
+
+                .step-container dl > dd {
+                    font-size: inherit;
+                    line-height: 20px;
+                    margin-left: 0;
+                    padding-bottom: 32px;
+                }
+
+            .step-container:last-child dl {
+                border-left: 1px solid transparent;
+            }
+
+        .ctaLink {
+            background-color: transparent;
+            border: 1px solid transparent;
+            color: #006AB1;
+            cursor: pointer;
+            font-weight: 600;
+            padding: 0;
+            white-space: normal;
+        }
+
+            .ctaLink:focus {
+                outline: 1px solid #00bcf2;
+            }
+
+            .ctaLink:hover {
+                text-decoration: underline;
+            }
+
+        .step-icon {
+            display: flex;
+            height: 38px;
+            margin-right: 15px;
+            width: 38px;
+        }
+
+            .step-icon > div {
+                height: 30px;
+                width: 30px;
+                background-repeat: no-repeat;
+            }
+
+        .ms-logo-container {
+            min-width: 580px;
+            max-width: 980px;
+            margin-left: auto;
+            margin-right: auto;
+            left: 0;
+            right: 0;
+            transition: bottom 400ms;
+        }
+
+        .ms-logo {
+            float: right;
+            background-image: url("data:image/svg+xml;utf8,%0A%3Csvg%20version%3D%221.1%22%20id%3D%22MS-symbol%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20viewBox%3D%220%200%20400%20120%22%20style%3D%22enable-background%3Anew%200%200%20400%20120%3B%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cstyle%20type%3D%22text/css%22%3E%0A%09.st0%7Bfill%3Anone%3B%7D%0A%09.st1%7Bfill%3A%23737474%3B%7D%0A%09.st2%7Bfill%3A%23D63F26%3B%7D%0A%09.st3%7Bfill%3A%23167D3E%3B%7D%0A%09.st4%7Bfill%3A%232E76BC%3B%7D%0A%09.st5%7Bfill%3A%23FDB813%3B%7D%0A%3C/style%3E%0A%3Crect%20x%3D%220.6%22%20class%3D%22st0%22%20width%3D%22398.7%22%20height%3D%22119%22/%3E%0A%3Cpath%20class%3D%22st1%22%20d%3D%22M171.3%2C38.4v43.2h-7.5V47.7h-0.1l-13.4%2C33.9h-5l-13.7-33.9h-0.1v33.9h-6.9V38.4h10.8l12.4%2C32h0.2l13.1-32H171.3%0A%09z%20M177.6%2C41.7c0-1.2%2C0.4-2.2%2C1.3-3c0.9-0.8%2C1.9-1.2%2C3.1-1.2c1.3%2C0%2C2.4%2C0.4%2C3.2%2C1.3c0.8%2C0.8%2C1.3%2C1.8%2C1.3%2C3c0%2C1.2-0.4%2C2.2-1.3%2C3%0A%09c-0.9%2C0.8-1.9%2C1.2-3.2%2C1.2s-2.3-0.4-3.1-1.2C178%2C43.8%2C177.6%2C42.8%2C177.6%2C41.7z%20M185.7%2C50.6v31h-7.3v-31H185.7z%20M207.8%2C76.3%0A%09c1.1%2C0%2C2.3-0.3%2C3.6-0.8c1.3-0.5%2C2.5-1.2%2C3.6-2v6.8c-1.2%2C0.7-2.5%2C1.2-4%2C1.5c-1.5%2C0.3-3.1%2C0.5-4.9%2C0.5c-4.6%2C0-8.3-1.4-11.1-4.3%0A%09c-2.9-2.9-4.3-6.6-4.3-11c0-5%2C1.5-9.1%2C4.4-12.3c2.9-3.2%2C7-4.8%2C12.4-4.8c1.4%2C0%2C2.7%2C0.2%2C4.1%2C0.5c1.4%2C0.4%2C2.5%2C0.8%2C3.3%2C1.2v7%0A%09c-1.1-0.8-2.3-1.5-3.4-1.9c-1.2-0.5-2.4-0.7-3.6-0.7c-2.9%2C0-5.2%2C0.9-7%2C2.8c-1.8%2C1.9-2.7%2C4.4-2.7%2C7.6c0%2C3.1%2C0.8%2C5.6%2C2.5%2C7.3%0A%09C202.6%2C75.4%2C204.9%2C76.3%2C207.8%2C76.3z%20M235.7%2C50.1c0.6%2C0%2C1.1%2C0%2C1.6%2C0.1s0.9%2C0.2%2C1.2%2C0.3v7.4c-0.4-0.3-0.9-0.5-1.7-0.8%0A%09c-0.7-0.3-1.6-0.4-2.7-0.4c-1.8%2C0-3.3%2C0.8-4.5%2C2.3c-1.2%2C1.5-1.9%2C3.8-1.9%2C7v15.6h-7.3v-31h7.3v4.9h0.1c0.7-1.7%2C1.7-3%2C3-4%0A%09C232.2%2C50.6%2C233.8%2C50.1%2C235.7%2C50.1z%20M238.9%2C66.6c0-5.1%2C1.4-9.2%2C4.3-12.2c2.9-3%2C6.9-4.5%2C12.1-4.5c4.8%2C0%2C8.6%2C1.4%2C11.3%2C4.3%0A%09c2.7%2C2.9%2C4.1%2C6.8%2C4.1%2C11.7c0%2C5-1.4%2C9-4.3%2C12c-2.9%2C3-6.8%2C4.5-11.8%2C4.5c-4.8%2C0-8.6-1.4-11.4-4.2C240.3%2C75.3%2C238.9%2C71.4%2C238.9%2C66.6z%0A%09%20M246.5%2C66.3c0%2C3.2%2C0.7%2C5.7%2C2.2%2C7.4c1.5%2C1.7%2C3.6%2C2.6%2C6.3%2C2.6c2.7%2C0%2C4.7-0.9%2C6.1-2.6c1.4-1.7%2C2.1-4.2%2C2.1-7.6c0-3.3-0.7-5.8-2.2-7.5%0A%09c-1.4-1.7-3.4-2.5-6-2.5c-2.7%2C0-4.7%2C0.9-6.2%2C2.7C247.2%2C60.5%2C246.5%2C63%2C246.5%2C66.3z%20M281.5%2C58.8c0%2C1%2C0.3%2C1.9%2C1%2C2.5%0A%09c0.7%2C0.6%2C2.1%2C1.3%2C4.4%2C2.2c2.9%2C1.2%2C5%2C2.5%2C6.1%2C3.9c1.2%2C1.5%2C1.8%2C3.2%2C1.8%2C5.3c0%2C2.9-1.1%2C5.3-3.4%2C7c-2.2%2C1.8-5.3%2C2.7-9.1%2C2.7%0A%09c-1.3%2C0-2.7-0.2-4.3-0.5c-1.6-0.3-2.9-0.7-4-1.2v-7.2c1.3%2C0.9%2C2.8%2C1.7%2C4.3%2C2.2c1.5%2C0.5%2C2.9%2C0.8%2C4.2%2C0.8c1.6%2C0%2C2.9-0.2%2C3.6-0.7%0A%09c0.8-0.5%2C1.2-1.2%2C1.2-2.3c0-1-0.4-1.9-1.2-2.5c-0.8-0.7-2.4-1.5-4.6-2.4c-2.7-1.1-4.6-2.4-5.7-3.8c-1.1-1.4-1.7-3.2-1.7-5.4%0A%09c0-2.8%2C1.1-5.1%2C3.3-6.9c2.2-1.8%2C5.1-2.7%2C8.6-2.7c1.1%2C0%2C2.3%2C0.1%2C3.6%2C0.4c1.3%2C0.2%2C2.5%2C0.6%2C3.4%2C0.9v6.9c-1-0.6-2.1-1.2-3.4-1.7%0A%09c-1.3-0.5-2.6-0.7-3.8-0.7c-1.4%2C0-2.5%2C0.3-3.2%2C0.8C281.9%2C57.1%2C281.5%2C57.8%2C281.5%2C58.8z%20M297.9%2C66.6c0-5.1%2C1.4-9.2%2C4.3-12.2%0A%09c2.9-3%2C6.9-4.5%2C12.1-4.5c4.8%2C0%2C8.6%2C1.4%2C11.3%2C4.3c2.7%2C2.9%2C4.1%2C6.8%2C4.1%2C11.7c0%2C5-1.4%2C9-4.3%2C12c-2.9%2C3-6.8%2C4.5-11.8%2C4.5%0A%09c-4.8%2C0-8.6-1.4-11.4-4.2C299.4%2C75.3%2C297.9%2C71.4%2C297.9%2C66.6z%20M305.5%2C66.3c0%2C3.2%2C0.7%2C5.7%2C2.2%2C7.4c1.5%2C1.7%2C3.6%2C2.6%2C6.3%2C2.6%0A%09c2.7%2C0%2C4.7-0.9%2C6.1-2.6c1.4-1.7%2C2.1-4.2%2C2.1-7.6c0-3.3-0.7-5.8-2.2-7.5c-1.4-1.7-3.4-2.5-6-2.5c-2.7%2C0-4.7%2C0.9-6.2%2C2.7%0A%09C306.3%2C60.5%2C305.5%2C63%2C305.5%2C66.3z%20M353.9%2C56.6h-10.9v25h-7.4v-25h-5.2v-6h5.2v-4.3c0-3.3%2C1.1-5.9%2C3.2-8c2.1-2.1%2C4.8-3.1%2C8.1-3.1%0A%09c0.9%2C0%2C1.7%2C0%2C2.4%2C0.1c0.7%2C0.1%2C1.3%2C0.2%2C1.8%2C0.4V42c-0.2-0.1-0.7-0.3-1.3-0.5c-0.6-0.2-1.3-0.3-2.1-0.3c-1.5%2C0-2.7%2C0.5-3.5%2C1.4%0A%09s-1.2%2C2.4-1.2%2C4.2v3.7h10.9v-7l7.3-2.2v9.2h7.4v6h-7.4v14.5c0%2C1.9%2C0.3%2C3.3%2C1%2C4c0.7%2C0.8%2C1.8%2C1.2%2C3.3%2C1.2c0.4%2C0%2C0.9-0.1%2C1.5-0.3%0A%09c0.6-0.2%2C1.1-0.4%2C1.6-0.7v6c-0.5%2C0.3-1.2%2C0.5-2.3%2C0.7c-1.1%2C0.2-2.1%2C0.3-3.2%2C0.3c-3.1%2C0-5.4-0.8-6.9-2.5c-1.5-1.6-2.3-4.1-2.3-7.4%0A%09V56.6z%22/%3E%0A%3Cg%3E%0A%09%3Crect%20x%3D%2231%22%20y%3D%2224%22%20class%3D%22st2%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2268.8%22%20y%3D%2224%22%20class%3D%22st3%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2231%22%20y%3D%2261.8%22%20class%3D%22st4%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2268.8%22%20y%3D%2261.8%22%20class%3D%22st5%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%3C/g%3E%0A%3C/svg%3E%0A");
+        }
+
+        .ms-logo-container > div {
+            min-height: 60px;
+            width: 150px;
+            background-repeat: no-repeat;
+        }
+
+        .row {
+            padding: 90px 0px 0 20px;
+            min-width: 480px;
+            max-width: 1366px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        .column {
+            float: left;
+            width: 45%;
+            padding-right: 20px;
+        }
+
+        .row:after {
+            content: "";
+            display: table;
+            clear: both;
+        }
+
+        a {
+            text-decoration: none;
+        }
+
+        .download-the-emulator {
+            height: 20px;
+            color: #0063B1;
+            font-size: 15px;
+            line-height: 20px;
+            padding-bottom: 70px;
+        }
+
+        .how-to-iframe {
+            max-width: 700px !important;
+            min-width: 650px !important;
+            height: 700px !important;
+        }
+
+        .remove-frame-height {
+            height: 10px;
+        }
+
+        @media only screen and (max-width: 1300px) {
+            .ms-logo {
+                padding-top: 30px;
+            }
+
+            .header-text {
+                font-size: 40x;
+            }
+
+            .column {
+                float: none;
+                padding-top: 30px;
+                width: 100%;
+            }
+
+            .ms-logo-container {
+                padding-top: 30px;
+                min-width: 480px;
+                max-width: 650px;
+                margin-left: auto;
+                margin-right: auto;
+            }
+
+            .row {
+                padding: 20px 0px 0 20px;
+                min-width: 480px;
+                max-width: 650px;
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
+
+        @media only screen and (max-width: 1370px) {
+            header {
+                background-color: #55A0E0;
+                background-size: auto 200px;
+            }
+        }
+
+        @media only screen and (max-width: 1230px) {
+            header {
+                background-color: #55A0E0;
+                background-size: auto 200px;
+            }
+
+            .header-text {
+                font-size: 44px;
+            }
+
+            .header-icon {
+                height: 120px;
+                width: 120px;
+            }
+        }
+
+        @media only screen and (max-width: 1000px) {
+            header {
+                background-color: #55A0E0;
+                background-image: none;
+            }
+        }
+
+        @media only screen and (max-width: 632px) {
+            .header-text {
+                font-size: 32px;
+            }
+
+            .row {
+                padding: 10px 0px 0 10px;
+                max-width: 490px !important;
+                min-width: 410px !important;
+            }
+
+            .endpoint {
+                font-size: 25px;
+            }
+
+            .main-text {
+                font-size: 20px;
+            }
+
+            .step-container dl > dd {
+                font-size: 14px;
+            }
+
+            .column {
+                padding-right: 5px;
+            }
+
+            .header-icon {
+                height: 110px;
+                width: 110px;
+            }
+
+            .how-to-iframe {
+                max-width: 480px !important;
+                min-width: 400px !important;
+                height: 650px !important;
+                overflow: hidden;
+            }
+        }
+
+        .remove-frame-height {
+            max-height: 10px;
+        }
+    </style>
     <script>
-        var convoCookie = localStorage.getItem("conversationId");
-        var token = 'Ty0qfs_eWNI.cwA.wIA.E4n8ZSDIo0b8b1Dc7PLgms0sF4YWm_jPw7CExJQJ5WI';
-        debugger;
-        
-            var chatbot = new WebChat.createDirectLine({
-                secret: token,
-                webSocket: false,
-                pollingInterval: 2000
-            });
-
-        WebChat.renderWebChat({
-            directLine: chatbot,
-            userID: 'V3UserId'
-        }, document.getElementById('webchat'));
-
+        document.addEventListener('DOMContentLoaded', function () {
+            loadFrame();
+        });
+        var loadFrame = function () {
+            var iframe = document.createElement('iframe');
+            iframe.setAttribute("id", "iframe");
+            var offLineHTMLContent = "";
+            var frameElement = document.getElementById("how-to-iframe");
+            if (window.navigator.onLine) {
+                iframe.src = 'https://docs.botframework.com/static/abs/pages/f5.htm';
+                iframe.setAttribute("scrolling", "no");
+                iframe.setAttribute("frameborder", "0");
+                iframe.setAttribute("width", "100%");
+                iframe.setAttribute("height", "100%");
+                var frameDiv = document.getElementById("how-to-iframe");
+                frameDiv.appendChild(iframe);
+            } else {
+                frameElement.classList.add("remove-frame-height");
+            }
+        };
     </script>
+</head>
+
+<body>
+    <header class="header">
+        <div class="header-inner-container">
+            <div class="header-icon" style="display: inline-block"></div>
+            <div class="header-text" style="display: inline-block">V3 State Bot Sample</div>
+        </div>
+    </header>
+    <div class="row">
+        <div class="column" class="main-content-area">
+            <div class="content-title">Your bot is ready!</div>
+            <div class="main-text main-text-p1">
+                You can test your bot in the Bot Framework Emulator<br />
+                by connecting to http://localhost:3978/api/messages.
+            </div>
+            <div class="main-text download-the-emulator">
+                <a class="ctaLink" href="https://aka.ms/bot-framework-F5-download-emulator"
+                   target="_blank">Download the Emulator</a>
+            </div>
+            <div class="main-text">
+                Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home" target="_blank">
+                    Azure
+                    Bot Service
+                </a> to register your bot and add it to<br />
+                various channels. The bot's endpoint URL typically looks
+                like this:
+            </div>
+            <div class="endpoint">https://<i>your_bots_hostname</i>/api/messages</div>
+        </div>
+        <div class="column how-to-iframe" id="how-to-iframe"></div>
+    </div>
+    <div class="ms-logo-container">
+        <div class="ms-logo"></div>
+    </div>
 </body>
 </html>

--- a/MigrationV3V4/CSharp/V3StateBot/V3StateBot/packages.config
+++ b/MigrationV3V4/CSharp/V3StateBot/V3StateBot/packages.config
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Autofac" version="4.6.0" targetFramework="net46" />
+  <package id="Chronic.Signed" version="0.3.2" targetFramework="net46" />
+  <package id="EntityFramework" version="6.1.3" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.22.0" targetFramework="net46" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.20.1" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.Azure" version="3.16.3.40383" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.16.1.38846" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.20.1" targetFramework="net46" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.4" targetFramework="net46" />
+  <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net46" />
+  <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net46" />
+  <package id="Microsoft.Data.Services.Client" version="5.7.0" targetFramework="net46" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="4.4.0" targetFramework="net46" />
+  <package id="Microsoft.IdentityModel.Logging" version="1.1.4" targetFramework="net46" />
+  <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.4.403061554" targetFramework="net46" />
+  <package id="Microsoft.IdentityModel.Protocols" version="2.1.4" targetFramework="net46" />
+  <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="2.1.4" targetFramework="net46" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.1.4" targetFramework="net46" />
+  <package id="Microsoft.Net.Compilers" version="2.0.1" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.Rest.ClientRuntime" version="2.3.8" targetFramework="net46" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net46" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.1.4" targetFramework="net46" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net46" />
+  <package id="System.Spatial" version="5.7.0" targetFramework="net46" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
+  <package id="System.Web.Http.Common" version="4.0.20126.16343" targetFramework="net46" />
+  <package id="WindowsAzure.Storage" version="7.2.1" targetFramework="net46" />
+</packages>

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/AzureSql-CreateTable.sql
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/AzureSql-CreateTable.sql
@@ -1,0 +1,53 @@
+﻿﻿
+GO
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [dbo].[SqlBotDataEntities](
+	[Id] [int] IDENTITY(1,1) NOT NULL,
+	[BotStoreType] [int] NOT NULL,
+	[BotId] [nvarchar](max) NULL,
+	[ChannelId] [nvarchar](200) NULL,
+	[ConversationId] [nvarchar](200) NULL,
+	[UserId] [nvarchar](200) NULL,
+	[Data] [varbinary](max) NULL,
+	[ETag] [nvarchar](max) NULL,
+	[ServiceUrl] [nvarchar](max) NULL,
+	[Timestamp] [datetimeoffset](7) NOT NULL,
+ CONSTRAINT [PK_dbo.SqlBotDataEntities] PRIMARY KEY CLUSTERED 
+(
+	[Id] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON)
+)
+GO
+SET ANSI_PADDING ON
+GO
+CREATE NONCLUSTERED INDEX [idxStoreChannelConversation] ON [dbo].[SqlBotDataEntities]
+(
+	[BotStoreType] ASC,
+	[ChannelId] ASC,
+	[ConversationId] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON)
+GO
+SET ANSI_PADDING ON
+GO
+CREATE NONCLUSTERED INDEX [idxStoreChannelConversationUser] ON [dbo].[SqlBotDataEntities]
+(
+	[BotStoreType] ASC,
+	[ChannelId] ASC,
+	[ConversationId] ASC,
+	[UserId] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON)
+GO
+SET ANSI_PADDING ON
+GO
+CREATE NONCLUSTERED INDEX [idxStoreChannelUser] ON [dbo].[SqlBotDataEntities]
+(
+	[BotStoreType] ASC,
+	[ChannelId] ASC,
+	[UserId] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON)
+GO
+ALTER TABLE [dbo].[SqlBotDataEntities] ADD  DEFAULT (getutcdate()) FOR [Timestamp]
+GO

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/AzureSql/SqlBotDataContext.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/AzureSql/SqlBotDataContext.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+using Microsoft.EntityFrameworkCore;
+
+namespace Bot.Builder.Azure.V3V4.AzureSql
+{
+    /// <summary>
+    /// THe Microsoft.EntityFrameworkCore DbContext for <see cref="SqlBotDataEntity"/> also <see cref="SqlBotDataStore"/>. 
+    /// From https://github.com/microsoft/BotBuilder-Azure
+    /// </summary>
+    internal class SqlBotDataContext : DbContext
+    {
+        string _connectionString;
+        public SqlBotDataContext(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+                optionsBuilder.UseSqlServer(_connectionString);
+            }
+            base.OnConfiguring(optionsBuilder);
+        }
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<SqlBotDataEntity>()
+                .ToTable("SqlBotDataEntities");
+
+            modelBuilder.Entity<SqlBotDataEntity>()
+                .HasIndex(p => new { p.BotStoreType, p.ChannelId, p.UserId })
+                .HasName("idxStoreChannelUser");
+
+            modelBuilder.Entity<SqlBotDataEntity>()
+                .HasIndex(p => new { p.BotStoreType, p.ChannelId, p.ConversationId })
+                .HasName("idxStoreChannelConversation");
+
+            modelBuilder.Entity<SqlBotDataEntity>()
+                .HasIndex(p => new { p.BotStoreType, p.ChannelId, p.ConversationId, p.UserId })
+                .HasName("idxStoreChannelConversationUser");
+        }
+
+        public virtual DbSet<SqlBotDataEntity> BotData { get; set; }
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/AzureSql/SqlBotDataEntity.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/AzureSql/SqlBotDataEntity.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Bot.Builder.Azure.V3V4.AzureSql
+{
+    /// <summary>
+    /// This is the entity stored by <see cref="SqlBotDataStore"/>. 
+    /// From https://github.com/microsoft/BotBuilder-Azure
+    /// </summary>
+    internal class SqlBotDataEntity : IAddress
+    {
+        private static readonly JsonSerializerSettings serializationSettings = new JsonSerializerSettings()
+        {
+            Formatting = Formatting.None,
+            NullValueHandling = NullValueHandling.Ignore
+        };
+
+        internal SqlBotDataEntity() { Timestamp = DateTimeOffset.UtcNow; }
+        internal SqlBotDataEntity(BotStoreType botStoreType, string botId, string channelId, string conversationId, string userId, object data)
+        {
+            this.BotStoreType = botStoreType;
+            this.BotId = botId;
+            this.ChannelId = channelId;
+            this.ConversationId = conversationId;
+            this.UserId = userId;
+            this.Data = Serialize(data);
+            Timestamp = DateTimeOffset.UtcNow;
+        }
+
+
+        #region Fields
+
+        // Indexes are now configured in SqlBotDataContext.OnModelCreating
+
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+        //[Index("idxStoreChannelUser", 1)]
+        //[Index("idxStoreChannelConversation", 1)]
+        //[Index("idxStoreChannelConversationUser", 1)]
+        public BotStoreType BotStoreType { get; set; }
+        public string BotId { get; set; }
+        //[Index("idxStoreChannelConversation", 2)]
+        //[Index("idxStoreChannelUser", 2)]
+        //[Index("idxStoreChannelConversationUser", 2)]
+        [MaxLength(200)]
+        public string ChannelId { get; set; }
+        //[Index("idxStoreChannelConversation", 3)]
+        //[Index("idxStoreChannelConversationUser", 3)]
+        [MaxLength(200)]
+        public string ConversationId { get; set; }
+        //[Index("idxStoreChannelUser", 3)]
+        //[Index("idxStoreChannelConversationUser", 4)]
+        [MaxLength(200)]
+        public string UserId { get; set; }
+        public byte[] Data { get; set; }
+        public string ETag { get; set; }
+        public string ServiceUrl { get; set; }
+        [Required]
+        public DateTimeOffset Timestamp { get; set; }
+
+        #endregion Fields
+
+        #region Methods
+
+        private static byte[] Serialize(object data)
+        {
+            using (var cmpStream = new MemoryStream())
+            using (var stream = new GZipStream(cmpStream, CompressionMode.Compress))
+            using (var streamWriter = new StreamWriter(stream))
+            {
+                var serializedJSon = JsonConvert.SerializeObject(data, serializationSettings);
+                streamWriter.Write(serializedJSon);
+                streamWriter.Close();
+                stream.Close();
+                return cmpStream.ToArray();
+            }
+        }
+
+        private static object Deserialize(byte[] bytes)
+        {
+            using (var stream = new MemoryStream(bytes))
+            using (var gz = new GZipStream(stream, CompressionMode.Decompress))
+            using (var streamReader = new StreamReader(gz))
+            {
+                return JsonConvert.DeserializeObject(streamReader.ReadToEnd());
+            }
+        }
+
+        internal ObjectT GetData<ObjectT>()
+        {
+            return ((JObject)Deserialize(this.Data)).ToObject<ObjectT>();
+        }
+
+        internal object GetData()
+        {
+            return Deserialize(this.Data);
+        }
+
+        internal static async Task<SqlBotDataEntity> GetSqlBotDataEntity(IAddress key, BotStoreType botStoreType, SqlBotDataContext context)
+        {
+            SqlBotDataEntity entity = null;
+            var query = context.BotData.OrderByDescending(d => d.Timestamp);
+            switch (botStoreType)
+            {
+                case BotStoreType.BotConversationData:
+                    entity = await query.FirstOrDefaultAsync(d => d.BotStoreType == botStoreType
+                                                    && d.ChannelId == key.ChannelId
+                                                    && d.ConversationId == key.ConversationId);
+                    break;
+                case BotStoreType.BotUserData:
+                    entity = await query.FirstOrDefaultAsync(d => d.BotStoreType == botStoreType
+                                                    && d.ChannelId == key.ChannelId
+                                                    && d.UserId == key.UserId);
+                    break;
+                case BotStoreType.BotPrivateConversationData:
+                    entity = await query.FirstOrDefaultAsync(d => d.BotStoreType == botStoreType
+                                                    && d.ChannelId == key.ChannelId
+                                                    && d.ConversationId == key.ConversationId
+                                                    && d.UserId == key.UserId);
+                    break;
+                default:
+                    throw new ArgumentException("Unsupported bot store type!");
+            }
+
+            return entity;
+        }
+        #endregion
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/AzureSql/SqlBotDataStore.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/AzureSql/SqlBotDataStore.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bot.Builder.Azure.V3V4.AzureSql
+{
+    /// <summary>
+    /// <see cref="IBotDataStore{BotData}"/> Implementation using Azure SQL 
+    /// From https://github.com/microsoft/BotBuilder-Azure
+    /// </summary>
+    public class SqlBotDataStore : IBotDataStore<BotData>
+    {
+        string _connectionString { get; set; }
+
+        /// <summary>
+        /// Creates an instance of the <see cref="IBotDataStore{BotData}"/> that uses the azure sql storage.
+        /// </summary>
+        /// <param name="connectionString">The storage connection string.</param>
+        public SqlBotDataStore(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
+        async Task<BotData> IBotDataStore<BotData>.LoadAsync(IAddress key, BotStoreType botStoreType, CancellationToken cancellationToken)
+        {
+            using (var context = new SqlBotDataContext(_connectionString))
+            {
+                    SqlBotDataEntity entity = await SqlBotDataEntity.GetSqlBotDataEntity(key, botStoreType, context);
+
+                    if (entity == null)
+                        // empty record ready to be saved
+                        return new BotData(eTag: String.Empty, data: new Dictionary<string, object>());
+
+                    // return botdata 
+                    return new BotData(entity.ETag, entity.GetData());
+            }
+        }
+
+        async Task IBotDataStore<BotData>.SaveAsync(IAddress key, BotStoreType botStoreType, BotData botData, CancellationToken cancellationToken)
+        {
+            SqlBotDataEntity entity = new SqlBotDataEntity(botStoreType, key.BotId, key.ChannelId, key.ConversationId, key.UserId, botData.Data)
+            {
+                ETag = botData.ETag,
+                ServiceUrl = key.ServiceUrl
+            };
+
+            using (var context = new SqlBotDataContext(_connectionString))
+            {
+                    if (string.IsNullOrEmpty(botData.ETag))
+                    {
+                        entity.ETag = Guid.NewGuid().ToString();
+                        context.BotData.Add(entity);
+                    }
+                    else if (entity.ETag == "*")
+                    {
+                        var foundData = await SqlBotDataEntity.GetSqlBotDataEntity(key, botStoreType, context);
+                        if (botData.Data != null)
+                        {
+                            if (foundData == null)
+                                context.BotData.Add(entity);
+                            else
+                            {
+                                foundData.Data = entity.Data;
+                                foundData.ServiceUrl = entity.ServiceUrl;
+                            }
+                        }
+                        else
+                        {
+                            if (foundData != null)
+                                context.BotData.Remove(foundData);
+                        }
+                    }
+                    else
+                    {
+                        var foundData = await SqlBotDataEntity.GetSqlBotDataEntity(key, botStoreType, context);
+                        if (botData.Data != null)
+                        {
+                            if (foundData == null)
+                                context.BotData.Add(entity);
+                            else
+                            {
+                                foundData.Data = entity.Data;
+                                foundData.ServiceUrl = entity.ServiceUrl;
+                                foundData.ETag = entity.ETag;
+                            }
+                        }
+                        else
+                        {
+                            if (foundData != null)
+                                context.BotData.Remove(foundData);
+                        }
+                    }
+                    await context.SaveChangesAsync();
+            }
+        }
+
+        Task<bool> IBotDataStore<BotData>.FlushAsync(IAddress key, CancellationToken cancellationToken)
+        {
+            // Everything is saved. Flush is no-op
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/AzureTable/BotDataEntity.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/AzureTable/BotDataEntity.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using Newtonsoft.Json;
+using System.IO;
+using System.IO.Compression;
+using Newtonsoft.Json.Linq;
+using Microsoft.Azure.Cosmos.Table;
+
+namespace Bot.Builder.Azure.V3V4.AzureTable
+{
+    /// <summary>
+    /// This is the entity stored by <see cref="TableBotDataStore2"/>. 
+    /// From https://github.com/microsoft/BotBuilder-Azure
+    /// </summary>
+    internal class BotDataEntity : TableEntity
+    {
+        private static readonly JsonSerializerSettings serializationSettings = new JsonSerializerSettings()
+        {
+            Formatting = Formatting.None,
+            NullValueHandling = NullValueHandling.Ignore
+        };
+
+        public BotDataEntity()
+        {
+        }
+
+        internal BotDataEntity(string botId, string channelId, string conversationId, string userId, object data)
+        {
+            this.BotId = botId;
+            this.ChannelId = channelId;
+            this.ConversationId = conversationId;
+            this.UserId = userId;
+            this.Data = Serialize(data);
+        }
+
+        private byte[] Serialize(object data)
+        {
+            using (var cmpStream = new MemoryStream())
+            using (var stream = new GZipStream(cmpStream, CompressionMode.Compress))
+            using (var streamWriter = new StreamWriter(stream))
+            {
+                var serializedJSon = JsonConvert.SerializeObject(data, serializationSettings);
+                streamWriter.Write(serializedJSon);
+                streamWriter.Close();
+                stream.Close();
+                return cmpStream.ToArray();
+            }
+        }
+
+        private object Deserialize(byte[] bytes)
+        {
+            using (var stream = new MemoryStream(bytes))
+            using (var gz = new GZipStream(stream, CompressionMode.Decompress))
+            using (var streamReader = new StreamReader(gz))
+            {
+                return JsonConvert.DeserializeObject(streamReader.ReadToEnd());
+            }
+        }
+
+
+        internal static EntityKey GetEntityKey(IAddress key, BotStoreType botStoreType)
+        {
+            switch (botStoreType)
+            {
+                case BotStoreType.BotConversationData:
+                    return new EntityKey($"{key.ChannelId}:conversation", key.ConversationId.SanitizeForAzureKeys());
+
+                case BotStoreType.BotUserData:
+                    return new EntityKey($"{key.ChannelId}:user", key.UserId.SanitizeForAzureKeys());
+
+                case BotStoreType.BotPrivateConversationData:
+                    return new EntityKey($"{key.ChannelId}:private", $"{key.ConversationId.SanitizeForAzureKeys()}:{key.UserId.SanitizeForAzureKeys()}");
+
+                default:
+                    throw new ArgumentException("Unsupported bot store type!");
+            }
+        }
+
+        internal ObjectT GetData<ObjectT>()
+        {
+            return ((JObject)Deserialize(this.Data)).ToObject<ObjectT>();
+        }
+
+        internal object GetData()
+        {
+            return Deserialize(this.Data);
+        }
+
+        public string BotId { get; set; }
+
+        public string ChannelId { get; set; }
+
+        public string ConversationId { get; set; }
+
+        public string UserId { get; set; }
+
+        public byte[] Data { get; set; }
+    }
+
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/AzureTable/EntityKey.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/AzureTable/EntityKey.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+namespace Bot.Builder.Azure.V3V4.AzureTable
+{
+    /// <summary>
+    /// This is the key of the record stored by <see cref="TableBotDataStore2"/>. 
+    /// From https://github.com/microsoft/BotBuilder-Azure
+    /// </summary>
+    internal class EntityKey
+    {
+        public EntityKey(string partition, string row)
+        {
+            PartitionKey = partition.SanitizeForAzureKeys();
+            RowKey = row.SanitizeForAzureKeys();
+        }
+
+        public string PartitionKey { get; private set; }
+        public string RowKey { get; private set; }
+
+    }
+
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/AzureTable/TableBotDataStore.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/AzureTable/TableBotDataStore.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Threading;
+using Microsoft.Azure.Cosmos.Table;
+using storage = global::Microsoft.Azure.Cosmos.Table;
+
+namespace Bot.Builder.Azure.V3V4.AzureTable
+{
+    /// <summary>
+    /// <see cref="IBotDataStore{T}"/> Implementation using Azure Storage Table
+    /// From https://github.com/microsoft/BotBuilder-Azure
+    /// </summary>
+    /// <notes>
+    /// This implementation stores all conversation data in one partition which will not scale for heavy use.  If you think
+    /// you will have high traffic load you should use TableBotDataStore2 which splits data between multiple tables with fine grained partitionkeys.
+    /// If you have need for geo-distributed datacenters and or deeper queries (like for supporting GDPR requirements) then you are strongly encouraged 
+    /// to use the DocumentDbBotDataStore (aka CosmosDB) 
+    /// </notes>
+    public class TableBotDataStore : IBotDataStore<BotData>
+    {
+        private static HashSet<string> checkedTables = new HashSet<string>();
+
+        /// <summary>
+        /// Creates an instance of the <see cref="IBotDataStore{T}"/> that uses the azure table storage.
+        /// </summary>
+        /// <param name="connectionString">The storage connection string.</param>
+        /// <param name="tableName">The name of table.</param>
+        public TableBotDataStore(string connectionString, string tableName = "botdata")
+            : this(storage.CloudStorageAccount.Parse(connectionString), tableName)
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance of the <see cref="IBotDataStore{T}"/> that uses the azure table storage.
+        /// </summary>
+        /// <param name="storageAccount">The storage account.</param>
+        /// <param name="tableName">The name of table.</param>
+        public TableBotDataStore(storage.CloudStorageAccount storageAccount, string tableName = "botdata")
+        {
+            var tableClient = storageAccount.CreateCloudTableClient();
+            this.Table = tableClient.GetTableReference(tableName);
+
+            lock (checkedTables)
+            {
+                if (!checkedTables.Contains(tableName))
+                {
+                    this.Table.CreateIfNotExists();
+                    checkedTables.Add(tableName);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates an instance of the <see cref="IBotDataStore{T}"/> that uses the azure table storage.
+        /// </summary>
+        /// <param name="table">The cloud table.</param>
+        public TableBotDataStore(CloudTable table)
+        {
+            this.Table = table;
+        }
+
+        /// <summary>
+        /// The <see cref="CloudTable"/>.
+        /// </summary>
+        public CloudTable Table { get; private set; }
+
+        async Task<BotData> IBotDataStore<BotData>.LoadAsync(IAddress key, BotStoreType botStoreType, CancellationToken cancellationToken)
+        {
+            var entityKey = BotDataEntity.GetEntityKey(key, botStoreType);
+            var result = await this.Table.ExecuteAsync(TableOperation.Retrieve<BotDataEntity>(entityKey.PartitionKey, entityKey.RowKey));
+            BotDataEntity entity = (BotDataEntity)result.Result;
+            if (entity == null)
+                // empty record ready to be saved
+                return new BotData(eTag: String.Empty, data: null);
+
+            // return botdata 
+            return new BotData(entity.ETag, entity.GetData());
+
+        }
+
+        async Task IBotDataStore<BotData>.SaveAsync(IAddress key, BotStoreType botStoreType, BotData botData, CancellationToken cancellationToken)
+        {
+            var entityKey = BotDataEntity.GetEntityKey(key, botStoreType);
+            BotDataEntity entity = new BotDataEntity(key.BotId, key.ChannelId, key.ConversationId, key.UserId, botData.Data)
+            {
+                ETag = botData.ETag
+            };
+            entity.PartitionKey = entityKey.PartitionKey;
+            entity.RowKey = entityKey.RowKey;
+
+            if (String.IsNullOrEmpty(entity.ETag))
+                await this.Table.ExecuteAsync(TableOperation.Insert(entity));
+            else if (entity.ETag == "*")
+            {
+                if (botData.Data != null)
+                    await this.Table.ExecuteAsync(TableOperation.InsertOrReplace(entity));
+                else
+                    await this.Table.ExecuteAsync(TableOperation.Delete(entity));
+            }
+            else
+            {
+                if (botData.Data != null)
+                    await this.Table.ExecuteAsync(TableOperation.Replace(entity));
+                else
+                    await this.Table.ExecuteAsync(TableOperation.Delete(entity));
+            }
+        }
+
+        Task<bool> IBotDataStore<BotData>.FlushAsync(IAddress key, CancellationToken cancellationToken)
+        {
+            // Everything is saved. Flush is no-op
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/AzureTable/TableBotDataStore2.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/AzureTable/TableBotDataStore2.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Threading;
+using Microsoft.Azure.Cosmos.Table;
+using storage = global::Microsoft.Azure.Cosmos.Table;
+
+namespace Bot.Builder.Azure.V3V4.AzureTable
+{
+    /// <summary>
+    /// <see cref="IBotDataStore{T}"/> Implementation using Azure Table Storage,
+    /// From https://github.com/microsoft/BotBuilder-Azure
+    /// </summary>
+    /// <notes>
+    /// The original TableBotDataStore put all conversation data in 1 partition in 1 table which severely limited the scalability of it. 
+    /// The TableBotDataStore2 implementaion uses multiple tables, and the UserId or ConversationId as the PartitionKey within those tables to 
+    /// achieve much higher scalability charateristics.
+    /// 
+    /// tableName="{BotId}{ChannelId}"
+    /// BotStoreType             | PartitionKey      | RowKey         |
+    /// ---------------------------------------------------------------
+    /// UserData                 | {UserId}          | "user"         |
+    /// ConverationData          | {ConversationId}  | "conversation" |
+    /// PrivateConverationData   | {ConversationId}  | {UserId}       |
+    /// ---------------------------------------------------------------
+    /// </notes>
+    public class TableBotDataStore2 : IBotDataStore<BotData>
+    {
+        private static Dictionary<string, CloudTable> tables = new Dictionary<string, CloudTable>();
+        private CloudTableClient tableClient;
+
+        /// <summary>
+        /// Creates an instance of the <see cref="IBotDataStore{T}"/> that uses the azure table storage.
+        /// </summary>
+        /// <param name="connectionString">The storage connection string.</param>
+        /// <param name="tableName">The name of table.</param>
+        public TableBotDataStore2(string connectionString)
+            : this(storage.CloudStorageAccount.Parse(connectionString))
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance of the <see cref="IBotDataStore{T}"/> that uses the azure table storage.
+        /// </summary>
+        /// <param name="storageAccount">The storage account.</param>
+        /// <param name="tableName">The name of table.</param>
+        public TableBotDataStore2(storage.CloudStorageAccount storageAccount)
+        {
+            tableClient = storageAccount.CreateCloudTableClient();
+        }
+
+        public IEnumerable<CloudTable> Tables { get { return tables.Values; } }
+
+        private CloudTable GetTable(IAddress key)
+        {
+            string tableName = $"bd{key.BotId}{key.ChannelId}".SanitizeTableName();
+            lock (tables)
+            {
+                CloudTable table;
+                if (tables.TryGetValue(tableName, out table))
+                    return table;
+
+                table = tableClient.GetTableReference(tableName);
+                table.CreateIfNotExists();
+                tables.Add(tableName, table);
+                return table;
+            }
+        }
+
+        internal static EntityKey GetEntityKey(IAddress key, BotStoreType botStoreType)
+        {
+            switch (botStoreType)
+            {
+                case BotStoreType.BotUserData:
+                    return new EntityKey(key.UserId, "user");
+
+                case BotStoreType.BotConversationData:
+                    return new EntityKey(key.ConversationId, "conversation");
+
+                case BotStoreType.BotPrivateConversationData:
+                    return new EntityKey(key.ConversationId, key.UserId);
+
+                default:
+                    throw new ArgumentException("Unsupported bot store type!");
+            }
+        }
+
+
+        async Task<BotData> IBotDataStore<BotData>.LoadAsync(IAddress address, BotStoreType botStoreType, CancellationToken cancellationToken)
+        {
+            var table = this.GetTable(address);
+            var entityKey = GetEntityKey(address, botStoreType);
+
+            var result = await table.ExecuteAsync(TableOperation.Retrieve<BotDataEntity>(entityKey.PartitionKey, entityKey.RowKey));
+            BotDataEntity entity = (BotDataEntity)result.Result;
+            if (entity == null)
+                // empty record ready to be saved
+                return new BotData(eTag: String.Empty, data: null);
+
+            // return botdata 
+            return new BotData(entity.ETag, entity.GetData());
+        }
+
+        async Task IBotDataStore<BotData>.SaveAsync(IAddress address, BotStoreType botStoreType, BotData botData, CancellationToken cancellationToken)
+        {
+            var table = this.GetTable(address);
+            var entityKey = GetEntityKey(address, botStoreType);
+            BotDataEntity entity = new BotDataEntity(address.BotId, address.ChannelId, address.ConversationId, address.UserId, botData.Data)
+            {
+                ETag = botData.ETag
+            };
+            entity.PartitionKey = entityKey.PartitionKey;
+            entity.RowKey = entityKey.RowKey;
+
+            if (String.IsNullOrEmpty(entity.ETag))
+                await table.ExecuteAsync(TableOperation.Insert(entity));
+            else if (entity.ETag == "*")
+            {
+                if (botData.Data != null)
+                    await table.ExecuteAsync(TableOperation.InsertOrReplace(entity));
+                else
+                    await table.ExecuteAsync(TableOperation.Delete(entity));
+            }
+            else
+            {
+                if (botData.Data != null)
+                    await table.ExecuteAsync(TableOperation.Replace(entity));
+                else
+                    await table.ExecuteAsync(TableOperation.Delete(entity));
+            }
+        }
+
+        Task<bool> IBotDataStore<BotData>.FlushAsync(IAddress key, CancellationToken cancellationToken)
+        {
+            // Everything is saved. Flush is no-op
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/Bot.Builder.Azure.V3V4.csproj
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/Bot.Builder.Azure.V3V4.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.4.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.11" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/CosmosDb/BotDataDocDbKey.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/CosmosDb/BotDataDocDbKey.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+namespace Bot.Builder.Azure.V3V4.CosmosDb
+{    
+    /// <summary>
+    /// This is the key of the record stored by <see cref="DocumentDbBotDataStore"/>. 
+    /// From https://github.com/microsoft/BotBuilder-Azure
+    /// </summary>
+    internal class BotDataDocDbKey
+    {
+        public BotDataDocDbKey(string partition, string row)
+        {
+            PartitionKey = partition;
+            RowKey = row;
+        }
+
+        public string PartitionKey { get; private set; }
+        public string RowKey { get; private set; }
+
+    }
+}
+
+
+

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/CosmosDb/DocDbBotDataEntity.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/CosmosDb/DocDbBotDataEntity.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using Newtonsoft.Json;
+
+namespace Bot.Builder.Azure.V3V4.CosmosDb
+{
+    /// <summary>
+    /// This is the key of the record stored by <see cref="DocumentDbBotDataStore"/>. 
+    /// From https://github.com/microsoft/BotBuilder-Azure
+    /// </summary>
+    internal class DocDbBotDataEntity
+    {
+        internal const int MAX_KEY_LENGTH = 254;
+        public DocDbBotDataEntity() { }
+
+        internal DocDbBotDataEntity(IAddress key, BotStoreType botStoreType, BotData botData)
+        {
+            this.Id = GetEntityKey(key, botStoreType);
+            this.BotId = key.BotId;
+            this.ChannelId = key.ChannelId;
+            this.ConversationId = key.ConversationId;
+            this.UserId = key.UserId;
+            this.Data = botData.Data;
+        }
+
+        public static string GetEntityKey(IAddress key, BotStoreType botStoreType)
+        {
+            string entityKey;
+            switch (botStoreType)
+            {
+                case BotStoreType.BotConversationData:
+                    entityKey = $"{key.ChannelId}:conversation{key.ConversationId.SanitizeForAzureKeys()}";
+                    return TruncateEntityKey(entityKey);
+
+                case BotStoreType.BotUserData:
+                    entityKey = $"{key.ChannelId}:user{key.UserId.SanitizeForAzureKeys()}";
+                    return TruncateEntityKey(entityKey);
+
+                case BotStoreType.BotPrivateConversationData:
+                    entityKey = $"{key.ChannelId}:private{key.ConversationId.SanitizeForAzureKeys()}:{key.UserId.SanitizeForAzureKeys()}";
+                    return TruncateEntityKey(entityKey);
+
+                default:
+                    throw new ArgumentException("Unsupported bot store type!");
+            }
+        }
+
+        private static string TruncateEntityKey(string entityKey)
+        {
+            if (entityKey.Length > MAX_KEY_LENGTH)
+            {
+                var hash = entityKey.GetHashCode().ToString("x");
+                entityKey = entityKey.Substring(0, MAX_KEY_LENGTH - hash.Length) + hash;
+            }
+
+            return entityKey;
+        }
+
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; }
+
+        [JsonProperty(PropertyName = "botId")]
+        public string BotId { get; set; }
+
+        [JsonProperty(PropertyName = "channelId")]
+        public string ChannelId { get; set; }
+
+        [JsonProperty(PropertyName = "conversationId")]
+        public string ConversationId { get; set; }
+
+        [JsonProperty(PropertyName = "userId")]
+        public string UserId { get; set; }
+
+        [JsonProperty(PropertyName = "data")]
+        public object Data { get; set; }
+    }
+}
+
+
+

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/CosmosDb/DocumentDbBotDataStore.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/CosmosDb/DocumentDbBotDataStore.cs
@@ -1,0 +1,218 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+using Microsoft.Azure.Documents.Linq;
+
+namespace Bot.Builder.Azure.V3V4.CosmosDb
+{
+    /// <summary>
+    /// <see cref="IBotDataStore{T}"/> Implementation using Azure DocumentDb
+    /// From https://github.com/microsoft/BotBuilder-Azure
+    /// </summary>
+    public class DocumentDbBotDataStore : IBotDataStore<BotData>
+    {
+        private const string entityKeyParameterName = "@entityKey";
+
+        private static readonly TimeSpan MaxInitTime = TimeSpan.FromSeconds(5);
+
+        private readonly IDocumentClient documentClient;
+        private readonly string databaseId;
+        private readonly string collectionId;
+        private readonly bool enableCrossPartitionQuery;
+
+        /// <summary>
+        /// Creates an instance of the <see cref="IBotDataStore{T}"/> that uses the Azure DocumentDb.
+        /// </summary>
+        /// <param name="documentClient">The DocumentDb client to use.</param>
+        /// <param name="databaseId">The name of the DocumentDb database to use.</param>
+        /// <param name="collectionId">The name of the DocumentDb collection to use.</param>
+        /// <param name="enableCrossPartitionQuery">The query param to execute a cross partition query.</param>
+        public DocumentDbBotDataStore(IDocumentClient documentClient, string databaseId = "botdb", string collectionId = "botcollection", bool enableCrossPartitionQuery = false)
+        {
+            this.databaseId = databaseId ?? throw new ArgumentNullException(nameof(databaseId));
+            this.collectionId = collectionId ?? throw new ArgumentNullException(nameof(collectionId));
+
+            this.documentClient = documentClient;
+            this.databaseId = databaseId;
+            this.collectionId = collectionId;
+            this.enableCrossPartitionQuery = enableCrossPartitionQuery;
+
+            CreateDatabaseIfNotExistsAsync().GetAwaiter().GetResult();
+            CreateCollectionIfNotExistsAsync().GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Creates an instance of the <see cref="IBotDataStore{T}"/> that uses the Azure DocumentDb.
+        /// </summary>
+        /// <param name="serviceEndpoint">The service endpoint to use to create the client.</param>
+        /// <param name="authKey">The authorization key or resource token to use to create the client.</param>
+        /// <param name="databaseId">The name of the DocumentDb database to use.</param>
+        /// <param name="collectionId">The name of the DocumentDb collection to use.</param>
+        /// <param name="enableCrossPartitionQuery">The query param to execute a cross partition query.</param>
+        /// <remarks>The service endpoint can be obtained from the Azure Management Portal. If you
+        /// are connecting using one of the Master Keys, these can be obtained along with
+        /// the endpoint from the Azure Management Portal If however you are connecting as
+        /// a specific DocumentDB User, the value passed to authKeyOrResourceToken is the
+        /// ResourceToken obtained from the permission feed for the user.
+        /// Using Direct connectivity, wherever possible, is recommended.</remarks>
+        public DocumentDbBotDataStore(Uri serviceEndpoint, string authKey, string databaseId = "botdb", string collectionId = "botcollection", bool enableCrossPartitionQuery = false)
+            : this(new DocumentClient(serviceEndpoint, authKey), databaseId, collectionId, enableCrossPartitionQuery) { }
+
+        async Task<BotData> IBotDataStore<BotData>.LoadAsync(IAddress key, BotStoreType botStoreType,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                var entityKey = DocDbBotDataEntity.GetEntityKey(key, botStoreType);
+
+                // query to retrieve the document if it exists
+                SqlQuerySpec querySpec = new SqlQuerySpec(
+                                                queryText: $"SELECT * FROM {collectionId} b WHERE (b.id = {entityKeyParameterName})",
+                                                parameters: new SqlParameterCollection()
+                                                {
+                                                    new SqlParameter(entityKeyParameterName, entityKey)
+                                                });
+                var collectionUri = UriFactory.CreateDocumentCollectionUri(databaseId, collectionId);
+                // execute the cross partition query if enableCrossPartitionQuery is true
+                var feedOption = new FeedOptions { EnableCrossPartitionQuery = enableCrossPartitionQuery };
+                var query = documentClient.CreateDocumentQuery(collectionUri, querySpec, feedOption)
+                                          .AsDocumentQuery();
+                var feedResponse = await query.ExecuteNextAsync<Document>(CancellationToken.None);
+                Document document = feedResponse.FirstOrDefault();
+
+                if (document != null)
+                {
+                    // The document, of type IDynamicMetaObjectProvider, has a dynamic nature, 
+                    // similar to DynamicTableEntity in Azure storage. When casting to a static type, properties that exist in the static type will be 
+                    // populated from the dynamic type.
+                    DocDbBotDataEntity entity = (dynamic)document;
+                    return new BotData(document?.ETag, entity?.Data);
+                }
+                else
+                {
+                    // the document does not exist in the database, return an empty BotData object
+                    return new BotData(string.Empty, null);
+                }
+            }
+            catch (DocumentClientException e)
+            {
+                if (e.StatusCode.HasValue && e.StatusCode.Value == HttpStatusCode.NotFound)
+                {
+                    return new BotData(string.Empty, null);
+                }
+
+                //throw new HttpException(e.StatusCode.HasValue ? (int)e.StatusCode.Value : 0, e.Message, e);
+                throw;
+            }
+        }
+
+        async Task IBotDataStore<BotData>.SaveAsync(IAddress key, BotStoreType botStoreType, BotData botData,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                var requestOptions = new RequestOptions()
+                {
+                    AccessCondition = new AccessCondition()
+                    {
+                        Type = AccessConditionType.IfMatch,
+                        Condition = botData.ETag
+                    }
+                };
+
+                var entity = new DocDbBotDataEntity(key, botStoreType, botData);
+                var entityKey = DocDbBotDataEntity.GetEntityKey(key, botStoreType);
+
+                if (string.IsNullOrEmpty(botData.ETag))
+                {
+                    await documentClient.CreateDocumentAsync(UriFactory.CreateDocumentCollectionUri(databaseId, collectionId), entity, requestOptions);
+                }
+                else if (botData.ETag == "*")
+                {
+                    if (botData.Data != null)
+                    {
+                        await documentClient.UpsertDocumentAsync(UriFactory.CreateDocumentCollectionUri(databaseId, collectionId), entity, requestOptions);
+                    }
+                    else
+                    {
+                        await documentClient.DeleteDocumentAsync(UriFactory.CreateDocumentUri(databaseId, collectionId, entityKey), requestOptions);
+                    }
+                }
+                else
+                {
+                    if (botData.Data != null)
+                    {
+                        await documentClient.ReplaceDocumentAsync(UriFactory.CreateDocumentUri(databaseId, collectionId, entityKey), entity, requestOptions);
+                    }
+                    else
+                    {
+                        await documentClient.DeleteDocumentAsync(UriFactory.CreateDocumentUri(databaseId, collectionId, entityKey), requestOptions);
+                    }
+                }
+            }
+            catch (DocumentClientException e)
+            {
+                //if (e.StatusCode.HasValue && e.StatusCode.Value == HttpStatusCode.Conflict)
+                //{
+                //    throw new HttpException((int)HttpStatusCode.PreconditionFailed, e.Message, e);
+                //}
+
+                //throw new HttpException(e.StatusCode.HasValue ? (int)e.StatusCode.Value : 0, e.Message, e);
+
+                throw;
+            }
+        }
+
+        Task<bool> IBotDataStore<BotData>.FlushAsync(IAddress key, CancellationToken cancellationToken)
+        {
+            // Everything is saved. Flush is no-op
+            return Task.FromResult(true);
+        }
+
+        private async Task CreateDatabaseIfNotExistsAsync()
+        {
+            try
+            {
+                await documentClient.ReadDatabaseAsync(UriFactory.CreateDatabaseUri(databaseId));
+            }
+            catch (DocumentClientException e)
+            {
+                if (e.StatusCode == HttpStatusCode.NotFound)
+                {
+                    await documentClient.CreateDatabaseAsync(new Database { Id = databaseId });
+                }
+                else
+                {
+                    throw;
+                }
+            }
+        }
+
+        private async Task CreateCollectionIfNotExistsAsync()
+        {
+            try
+            {
+                await documentClient.ReadDocumentCollectionAsync(UriFactory.CreateDocumentCollectionUri(databaseId, collectionId));
+            }
+            catch (DocumentClientException e)
+            {
+                if (e.StatusCode == System.Net.HttpStatusCode.NotFound)
+                {
+                    await documentClient.CreateDocumentCollectionAsync(
+                        UriFactory.CreateDatabaseUri(databaseId),
+                        new DocumentCollection { Id = collectionId });
+                }
+                else
+                {
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/KeyExtensions.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/KeyExtensions.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Bot.Builder.Azure.V3V4
+{
+    /// <summary>
+    /// Extension methods brought from Bot Builder V3 Azure.
+    /// From https://github.com/microsoft/BotBuilder-Azure
+    /// </summary>
+    internal static class KeyExtensions
+    {
+        private static readonly Dictionary<string, string> _DefaultReplacementsForCharactersDisallowedByAzure = new Dictionary<string, string>() { { "/", "|s|" }, { @"\", "|b|" }, { "#", "|h|" }, { "?", "|q|" } };
+
+        /// <summary>
+        /// Replaces the four characters disallowed in Azure keys with something more palatable.  You can provide your own mapping if you don't like the defaults.
+        /// </summary>
+        internal static string SanitizeForAzureKeys(this string input, Dictionary<string, string> replacements = null)
+        {
+            var repmap = replacements ?? _DefaultReplacementsForCharactersDisallowedByAzure;
+            return input.Trim().Replace("/", repmap["/"]).Replace(@"\", repmap[@"\"]).Replace("#", repmap["#"]).Replace("?", repmap["?"]);
+        }
+
+        private static string TruncateEntityKey(string entityKey)
+        {
+            const int MAX_KEY_LENGTH = 254;
+            if (entityKey.Length > MAX_KEY_LENGTH)
+            {
+                var hash = entityKey.GetHashCode().ToString("x");
+                entityKey = entityKey.Substring(0, MAX_KEY_LENGTH - hash.Length) + hash;
+            }
+
+            return entityKey;
+        }
+
+        internal static string SanitizeTableName(this string input)
+        {
+            if (input.Length > 63)
+            {
+                input = input.Substring(0, 63);
+            }
+            input = Regex.Replace(input, @"[^a-zA-Z0-9]+", "");
+            return input;
+        }
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/V3/Address.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/V3/Address.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+using Microsoft.Bot.Schema;
+
+namespace Bot.Builder.Azure.V3V4
+{
+    /// <summary>
+    /// This class existed in Bot Builder SDK V3, but was not brought forward to SDK V4.
+    /// From https://github.com/microsoft/BotBuilder-Azure
+    /// </summary>
+    internal class Address : IAddress
+    {
+        public Address() { }
+
+        public Address(IActivity activity)
+        {
+            this.BotId = activity.Recipient.Id;
+            this.ChannelId = activity.ChannelId;
+            this.UserId = activity.From.Id;
+            this.ConversationId = activity.Conversation.Id;
+            this.ServiceUrl = activity.ServiceUrl;
+        }
+
+        public string BotId { get; set; } = string.Empty;
+        public string ChannelId { get; set; } = string.Empty;
+        public string UserId { get; set; } = string.Empty;
+        public string ConversationId { get; set; } = string.Empty;
+        public string ServiceUrl { get; set; } = string.Empty;
+    }    
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/V3/BotData.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/V3/BotData.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+
+namespace Bot.Builder.Azure.V3V4
+{
+    /// <summary>
+    /// From https://github.com/microsoft/BotBuilder-Azure
+    /// </summary>
+    public partial class BotData
+    {
+        public BotData()
+        {
+            CustomInit();
+        }
+
+        public BotData(string eTag = default(string), object data = default(object))
+        {
+            if(data is JObject jobj)
+            {
+                Data = jobj.ToObject<IDictionary<string, object>>();
+            }
+            else if(data == null)
+            {
+                Data = new Dictionary<string, object>();
+            }
+            else
+            {
+                Data = data;
+            }
+            ETag = eTag;
+            CustomInit();
+        }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
+
+        /// <summary>
+        /// </summary>
+        [JsonProperty(PropertyName = "data")]
+        public object Data { get; set; }
+
+        /// <summary>
+        /// </summary>
+        [JsonProperty(PropertyName = "eTag")]
+        public string ETag { get; set; }
+
+        /// <summary>
+        /// Get a property from a BotData recorded retrieved using the REST API
+        /// </summary>
+        /// <param name="property">property name to change</param>
+        /// <returns>property requested or default for type</returns>
+        public TypeT GetProperty<TypeT>(string property)
+        {
+            if (this.Data == null)
+                this.Data = new JObject();
+
+            dynamic data = this.Data;
+            try
+            {
+                if (data[property] == null)
+                    return default(TypeT);
+            }
+            catch (System.Collections.Generic.KeyNotFoundException)
+            {
+                // Property doesn't exist
+                return default(TypeT);
+            }
+
+            var propValue = data[property];
+            if (propValue is TypeT)
+            {
+                return propValue;
+            }
+
+            // convert jToken (JArray or JObject) to the given typeT
+            return (TypeT)(data[property].ToObject(typeof(TypeT)));
+        }
+
+
+        /// <summary>
+        /// Set a property on a BotData record retrieved using the REST API
+        /// </summary>
+        /// <param name="property">property name to change</param>
+        /// <param name="data">new data</param>
+        public void SetProperty<TypeT>(string property, TypeT data)
+        {
+            if (this.Data == null)
+                this.Data = new JObject();
+
+            // convert (object or array) to JToken (JObject/JArray)
+            if (data == null)
+                ((IDictionary<string,object>)this.Data)[property] = null;
+            else
+                ((IDictionary<string, object>)this.Data)[property] = JToken.FromObject(data);
+        }
+
+        /// <summary>
+        /// Remove a property from the BotData record
+        /// </summary>
+        /// <param name="property">property name to remove</param>
+        public void RemoveProperty(string property)
+        {
+            if (this.Data == null)
+                this.Data = new JObject();
+
+            ((IDictionary<string, object>)this.Data).Remove(property);
+        }
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/V3/BotStoreType.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/V3/BotStoreType.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+namespace Bot.Builder.Azure.V3V4
+{
+    /// <summary>
+    /// From https://github.com/microsoft/BotBuilder-Azure
+    /// </summary>
+    public enum BotStoreType
+    {
+        BotConversationData = 0,
+        BotPrivateConversationData = 1,
+        BotUserData = 2
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/V3/IAddress.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/V3/IAddress.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+namespace Bot.Builder.Azure.V3V4
+{
+    /// <summary>
+    /// This interface existed in Bot Builder SDK V3, but was not brought forward to SDK V4.
+    /// From https://github.com/microsoft/BotBuilder-Azure
+    /// </summary>
+    public interface IAddress
+    {
+        string BotId { get; }
+        string ChannelId { get; }
+        string UserId { get; }
+        string ConversationId { get; }
+        string ServiceUrl { get; }
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/V3/IBotDataStore.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/V3/IBotDataStore.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bot.Builder.Azure.V3V4
+{
+    /// <summary>
+    /// From https://github.com/microsoft/BotBuilder-Azure
+    /// </summary>
+    /// <typeparam name="T"><see cref="BotData"/></typeparam>
+    public interface IBotDataStore<T>
+    {
+        Task<bool> FlushAsync(IAddress key, CancellationToken cancellationToken);
+        //
+        // Summary:
+        //     Return BotData with Data pointing to a JObject or an empty BotData() record with
+        //     ETag:""
+        //
+        // Parameters:
+        //   key:
+        //     The key.
+        //
+        //   botStoreType:
+        //     The bot store type.
+        //
+        //   cancellationToken:
+        //     The cancellation token.
+        //
+        // Returns:
+        //     Bot record that is stored for this key, or "empty" bot record ready to be stored
+        Task<T> LoadAsync(IAddress key, BotStoreType botStoreType, CancellationToken cancellationToken);
+        //
+        // Summary:
+        //     Save a BotData using the ETag. Etag consistency checks If ETag is null or empty,
+        //     this will set the value if nobody has set it yet If ETag is "*" then this will
+        //     unconditionally set the value If ETag matches then this will update the value
+        //     if it is unchanged. If Data is null this removes record, otherwise it stores
+        //
+        // Parameters:
+        //   key:
+        //     The key.
+        //
+        //   botStoreType:
+        //     The bot store type.
+        //
+        //   data:
+        //     The data that should be saved.
+        //
+        //   cancellationToken:
+        //     The cancellation token.
+        //
+        // Returns:
+        //     throw HttpException(HttpStatusCode.PreconditionFailed) if update fails
+        Task SaveAsync(IAddress key, BotStoreType botStoreType, T data, CancellationToken cancellationToken);
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/V3V4State.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/V3V4State.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+using Microsoft.Bot.Builder;
+using Newtonsoft.Json;
+
+namespace Bot.Builder.Azure.V3V4
+{
+    /// <summary>
+    /// This class inherits from the Bot Builer SDK V4 <see cref="BotState"/> 
+    /// and provides an SDK V3 storage key implementation which can be used by the 
+    /// SDK V3 storage provider when creating <see cref="V3V4Storage"/>
+    /// Keys are based on <see cref="Address"/> which is serialized and returned from
+    /// GetStorageKey.  This Address is then used wtihin <see cref="V3V4Storage"/> to
+    /// create the actual storage key.
+    /// </summary>
+    public class V3V4State : BotState
+    {
+        //// <summary>
+        /// Initializes a new instance of the <see cref="V3V4State"/> class.
+        /// </summary>
+        /// <param name="storage">The V3V4UserDataStorage storage provider to use.</param>
+        public V3V4State(V3V4Storage storage)
+            : base(storage, nameof(V3V4State))
+        {
+        }
+
+
+        /// <summary>
+        /// Gets the key to use when reading and writing state to and from storage.
+        /// </summary>
+        /// <param name="turnContext">The context object for this turn.</param>
+        /// <returns>The storage key.</returns>
+        protected override string GetStorageKey(ITurnContext turnContext)
+        {
+            var address = new Address(turnContext.Activity);
+            return JsonConvert.SerializeObject(address);
+        }
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/V3V4Storage.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/Bot.Builder.Azure.V3ToV4/V3V4Storage.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Newtonsoft.Json;
+
+namespace Bot.Builder.Azure.V3V4
+{
+    /// <summary>
+    /// This is a Bot Builder SDK V4 <see cref="IStorage"/> implementation
+    /// which wraps an SDK V3 storage provider <see cref="IBotDataStore"/> 
+    /// This enables SDK V3 UserData to be written and read from within an SDK V4 bot.
+    /// </summary>
+    public class V3V4Storage : IStorage
+    {
+        private readonly IBotDataStore<BotData> _v3DataStore;
+        private readonly BotStoreType _botStoreType;
+        private string _statePropertyName;
+
+        /// <summary>
+        /// Constructs a new <see cref="V3V4Storage"/>
+        /// </summary>
+        /// <param name="v3DataStore">A Bot Builder SDK V3 <see cref="IBotDataStore"/> (required)</param>
+        /// <param name="botStoreType">THe Type of Data Storage (UserData, ConversationData, PrivateConversationData)
+        /// <see cref="BotStoreType"/>Type of storage</param>
+        /// <param name="statePropertyName">This is only relavent in code.  The name of the BotState property,
+        /// retrieved and accessed through a property accessor created from an instance of <see cref="V3V4State"/>.</param>
+        public V3V4Storage(IBotDataStore<BotData> v3DataStore, 
+            BotStoreType botStoreType = BotStoreType.BotUserData,
+            string statePropertyName = "V3State")
+        {
+            _v3DataStore = v3DataStore ?? throw new ArgumentNullException(nameof(v3DataStore));
+            _botStoreType = botStoreType;
+            _statePropertyName = statePropertyName;
+        }
+
+        /// <summary>
+        /// Delete records from the underlying storage.
+        /// </summary>
+        /// <param name="keys">Json serialized array of <see cref="Address"/> objects.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public async Task DeleteAsync(string[] keys, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            foreach (var key in keys)
+            {
+                var asAddress = JsonConvert.DeserializeObject<Address>(key);
+
+                // Sending a null data, with an eTag, should ensure the object is deleted
+                var botData = new BotData(eTag: "delete", data: null);
+
+                await _v3DataStore.SaveAsync(asAddress, _botStoreType, botData, cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Retrieve records from the underlying storage.
+        /// </summary>
+        /// <param name="keys">Json serialized array of <see cref="Address"/> objects.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A dictionary of string and object.  The key within the dictionary will be a serialized <see cref="Address"/>
+        /// and the object will be a <see cref="BotData"/> containing the data field as a Dictionary.</returns>
+        public async Task<IDictionary<string, object>> ReadAsync(string[] keys, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (keys.Length > 1)
+            {
+                throw new InvalidOperationException("V3V4Storage is only setup for single retrieval");
+            }
+
+            var results = new Dictionary<string, object>(1);
+            var asAddress = JsonConvert.DeserializeObject<Address>(keys[0]);
+            var foundData = await _v3DataStore.LoadAsync(asAddress, _botStoreType, cancellationToken);
+
+            // return the first one found (V3State will not retrieve more than one)
+            var inner = new Dictionary<string, object>();
+            inner.Add(_statePropertyName, foundData);
+            results.Add(keys[0], inner);
+
+            return results;
+        }
+
+        /// <summary>
+        /// Save records into the underlying storage.
+        /// </summary>
+        /// <param name="changes">A dictionary of keys and BotData object's representing changes to the data.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public async Task WriteAsync(IDictionary<string, object> changes, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            foreach (var change in changes)
+            {
+                var asAddress = JsonConvert.DeserializeObject<Address>(change.Key);
+                var firstElement = ((IDictionary<string, object>)change.Value).FirstOrDefault();
+
+                // If the data is null, the record should be removed.  Sending a null data, with an eTag, 
+                // should ensure the object is deleted
+                var botData = firstElement.Value == null
+                            ? new BotData(eTag: "delete", data: null)
+                            : firstElement.Value as BotData;
+                
+                await _v3DataStore.SaveAsync(asAddress, _botStoreType, botData, cancellationToken);
+            }
+        }
+    }
+
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/README.md
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/README.md
@@ -1,0 +1,58 @@
+## Overview
+
+The V4StateBot solution is a demonstration of how to use a Bot Builder V3 ```IBotDataStore<BotData>``` copied from [Microsoft.Bot.Builder.Azure](https://www.nuget.org/packages/Microsoft.Bot.Builder.Azure/3.16.3.40383) and shimmed into a Bot Builder V4 solution for User State.  This example demonstrates retrieving previoulsy stored User State, as well as saving new User State into Azure Table, CosmosDb or Azure Sql using copied code from [Microsoft.Bot.Builder.Azure](https://www.nuget.org/packages/Microsoft.Bot.Builder.Azure/3.16.3.40383)
+
+## Purpose
+
+If the corresponding [V3StateBot](..\V3StateBot\V3StateBot.sln) was previously run against the same data store, User State should be automatically loaded into the V4StateBot.  If this bot is run against a clean store, then it will ask the user their name and city of residence.  This information is then stored in the ```IBotDataStore<BotData>``` configured by the developer in appsettings.json.  Two classes are stored within the UserState:
+
+```cs
+    public class GreetingState
+    {
+        public string Name { get; set; }
+        public string City { get; set; }
+    }
+```
+```cs
+    public class TestDataClass
+    {
+        public string TestStringField { get; set; }
+        public int TestIntField { get; set; }
+        public Tuple<string, string> TestTuple { get; set; }
+    }
+```
+
+
+## To try this sample
+
+- Clone the repository
+
+    ```bash
+    git clone https://github.com/Microsoft/botbuilder-samples.git
+    ```
+
+  - Launch Visual Studio
+  - File -> Open -> Project/Solution
+  - Navigate to `MigrationV3V4/CSharp/V4StateBot` folder
+  - Select `V4StateBot.sln` file
+  - Edit appsettings.json ConnectionStrings.SqlBotData, ConnectionStrings.AzureTable or CosmosDb app settings.
+  - Modify Startup.cs so the storage provider you are using is properly registered.
+  - Press `F5` to run the project
+  
+## Testing the bot using Bot Framework Emulator
+
+[Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
+
+- Install the Bot Framework Emulator version 4.3.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
+
+### Connect to the bot using Bot Framework Emulator
+
+- Launch Bot Framework Emulator
+- File -> Open Bot
+- Enter a Bot URL of `http://localhost:3978/api/messages`
+
+## Further reading
+
+- [Differences between the v3 and v4 .NET SDK](https://docs.microsoft.com/en-us/azure/bot-service/migration/migration-about)
+- [.NET migration quick reference](https://docs.microsoft.com/en-us/azure/bot-service/migration/net-migration-quickreference)
+- [Migrate a .NET v3 bot to a Framework v4 bot](https://docs.microsoft.com/en-us/azure/bot-service/migration/conversion-framework)

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4StateBot.sln
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4StateBot.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.572
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bot.Builder.Azure.V3V4", "Bot.Builder.Azure.V3ToV4\Bot.Builder.Azure.V3V4.csproj", "{C9962F06-4ECC-4629-AD9F-D76FC7103A96}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "V4StateBot", "V4V3StateBot\V4StateBot.csproj", "{E32C200E-769E-445E-8575-B96DF4A7073B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C9962F06-4ECC-4629-AD9F-D76FC7103A96}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C9962F06-4ECC-4629-AD9F-D76FC7103A96}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C9962F06-4ECC-4629-AD9F-D76FC7103A96}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C9962F06-4ECC-4629-AD9F-D76FC7103A96}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E32C200E-769E-445E-8575-B96DF4A7073B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E32C200E-769E-445E-8575-B96DF4A7073B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E32C200E-769E-445E-8575-B96DF4A7073B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E32C200E-769E-445E-8575-B96DF4A7073B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DC665DC9-F554-4C93-B407-BCBF141E43F3}
+	EndGlobalSection
+EndGlobal

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/AdapterWithErrorHandler.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/AdapterWithErrorHandler.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Extensions.Logging;
+
+namespace V4StateBot
+{
+    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    {
+        public AdapterWithErrorHandler(ICredentialProvider credentialProvider, ILogger<BotFrameworkHttpAdapter> logger, ConversationState conversationState = null)
+            : base(credentialProvider)
+        {
+            OnTurnError = async (turnContext, exception) =>
+            {
+                // Log any leaked exception from the application.
+                logger.LogError($"Exception caught : {exception.Message}");
+
+                // Send a catch-all apology to the user.
+                await turnContext.SendActivityAsync("Sorry, it looks like something went wrong.");
+
+                if (conversationState != null)
+                {
+                    try
+                    {
+                        // Delete the conversationState for the current conversation to prevent the
+                        // bot from getting stuck in a error-loop caused by being in a bad state.
+                        // ConversationState should be thought of as similar to "cookie-state" in a Web pages.
+                        await conversationState.DeleteAsync(turnContext);
+                    }
+                    catch (Exception e)
+                    {
+                        logger.LogError($"Exception caught on attempting to Delete ConversationState : {e.Message}");
+                    }
+                }
+            };
+        }
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/Bots/EchoBot.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/Bots/EchoBot.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Bot.Builder.Azure.V3V4;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
+
+namespace V4StateBot.Bots
+{
+    public class EchoBot<T> : ActivityHandler where T : Dialog
+    {
+        private readonly V3V4State _userState;
+        private readonly ConversationState _conversationState;
+        private readonly Dialog Dialog;
+
+        public EchoBot(V3V4State userState, ConversationState conversationState, T dialog)
+        {
+            _userState = userState;
+            _conversationState = conversationState;
+            Dialog = dialog;
+        }
+
+        public async override Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await base.OnTurnAsync(turnContext, cancellationToken);
+
+            // Save any state changes that might have occured during the turn.
+            await _userState.SaveChangesAsync(turnContext, false, cancellationToken);
+            await _conversationState.SaveChangesAsync(turnContext, false, cancellationToken);
+        }
+
+        protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
+        {
+            // Run the Dialog with the new message Activity.
+            await Dialog.Run(turnContext, _conversationState.CreateProperty<DialogState>("DialogState"), cancellationToken);
+        }
+
+        //protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
+        //{
+        //    var v3State = await _v3State.GetAsync(turnContext, () => new BotData("", new Dictionary<string, object>()));
+        //    var greetingState = v3State.GetProperty<GreetingState>("V3TestGreeting");
+
+        //    if (greetingState != null && !string.IsNullOrEmpty(greetingState.Name))
+        //    {
+        //        object changingNameObj = false;
+        //        bool changingName = v3State.GetProperty<bool>("ChangingName");
+
+        //        if (changingName)
+        //        {
+        //            greetingState.Name = turnContext.Activity.Text;
+        //            v3State.SetProperty<bool>("ChangingName", false);
+        //            v3State.SetProperty<GreetingState>("V3TestGreeting", greetingState);
+        //        }
+        //        else if(turnContext.Activity.Text.Equals("change name", StringComparison.InvariantCultureIgnoreCase))
+        //        {
+        //            v3State.SetProperty<bool>("ChangingName", true);
+
+        //            await turnContext.SendActivityAsync("v4: Okay, what would you like to change your name to?");
+        //            await _userState.SaveChangesAsync(turnContext);
+        //            return;
+        //        }
+
+        //        await turnContext.SendActivityAsync(MessageFactory.Text($"v4: Hi {greetingState.Name} from {greetingState.City}. You said: {turnContext.Activity.Text}"), cancellationToken);
+        //    }
+        //    else
+        //    {
+        //        v3State.SetProperty<GreetingState>("V3TestGreeting",  new GreetingState() { Name = "Eric auto", City = "Seattle (auto)" });
+        //        v3State.SetProperty<TestDataClass>("V3TestDataClass", new TestDataClass()
+        //        {
+        //            TestIntField = 11,
+        //            TestStringField = "auto string field",
+        //            TestTuple = new Tuple<string, string>("item 1 auto", "item 2 auto"),
+        //        });
+        //        v3State.SetProperty<bool>("AskedName", true);
+        //        v3State.SetProperty<bool>("Test", true);
+
+        //        await turnContext.SendActivityAsync(MessageFactory.Text($"v4: (greetingState was NOT present...auto saved) Echo: {turnContext.Activity.Text}"), cancellationToken);
+        //    }
+
+        //    await _userState.SaveChangesAsync(turnContext);
+        //}
+
+        protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            foreach (var member in membersAdded)
+            {
+                if (member.Id != turnContext.Activity.Recipient.Id)
+                {
+                    await turnContext.SendActivityAsync(MessageFactory.Text($"Hello and Welcome!"), cancellationToken);
+                }
+            }
+        }
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/Controllers/BotController.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/Controllers/BotController.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// Generated with Bot Builder V4 SDK Template for Visual Studio EchoBot v4.3.0
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+
+namespace V4StateBot.Controllers
+{
+    // This ASP Controller is created to handle a request. Dependency Injection will provide the Adapter and IBot
+    // implementation at runtime. Multiple different IBot implementations running at different endpoints can be
+    // achieved by specifying a more specific type for the bot constructor argument.
+    [Route("api/messages")]
+    [ApiController]
+    public class BotController : ControllerBase
+    {
+        private readonly IBotFrameworkHttpAdapter Adapter;
+        private readonly IBot Bot;
+
+        public BotController(IBotFrameworkHttpAdapter adapter, IBot bot)
+        {
+            Adapter = adapter;
+            Bot = bot;
+        }
+
+        [HttpPost]
+        public async Task PostAsync()
+        {
+            // Delegate the processing of the HTTP POST to the adapter.
+            // The adapter will invoke the bot.
+            await Adapter.ProcessAsync(Request, Response, Bot);
+        }
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/DialogExtensions.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/DialogExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+
+namespace V4StateBot
+{
+    public static class DialogExtensions
+    {
+        public static async Task Run(this Dialog dialog, ITurnContext turnContext, IStatePropertyAccessor<DialogState> accessor, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var dialogSet = new DialogSet(accessor);
+            dialogSet.Add(dialog);
+
+            var dialogContext = await dialogSet.CreateContextAsync(turnContext, cancellationToken);
+            var results = await dialogContext.ContinueDialogAsync(cancellationToken);
+            if (results.Status == DialogTurnStatus.Empty)
+            {
+                await dialogContext.BeginDialogAsync(dialog.Id, null, cancellationToken);
+            }
+        }
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/Dialogs/MainDialog.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/Dialogs/MainDialog.cs
@@ -1,0 +1,96 @@
+﻿using Bot.Builder.Azure.V3V4;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using V4StateBot.Models;
+
+namespace V4StateBot.Dialogs
+{
+    public class MainDialog : ComponentDialog
+    {
+        private const string V3GreetingPropertyName = "V3TestGreeting";
+        private const string ChangingNamePropertyName = "ChangingName";
+        private const string V3StatePropertyName = "V3State";
+
+        private V3V4State _userState;
+        private readonly IStatePropertyAccessor<BotData> _v3State;
+
+        public MainDialog(V3V4State userState)
+            : base(nameof(MainDialog))
+        {
+            _userState = userState;
+            _v3State = userState.CreateProperty<BotData>("V3State");
+
+            AddDialog(new TextPrompt(nameof(TextPrompt)));
+            AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[]
+            {
+                IntroStepAsync,
+                NameStep,
+                CityStep,
+            }));
+
+            // The initial child Dialog to run.
+            InitialDialogId = nameof(WaterfallDialog);
+        }
+
+        private async Task<DialogTurnResult> IntroStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            var v3State = await _v3State.GetAsync(stepContext.Context, () => new BotData("", new Dictionary<string, object>()));
+            var greetingState = v3State.GetProperty<GreetingState>(V3GreetingPropertyName);
+
+            if (greetingState != null && !string.IsNullOrEmpty(greetingState.Name))
+            {
+                if (stepContext.Context.Activity.Text.Equals("change name", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    v3State.SetProperty<bool>(ChangingNamePropertyName, true);
+
+                    await stepContext.Context.SendActivityAsync("v4: Okay, what would you like to change your name to?");
+                    await _userState.SaveChangesAsync(stepContext.Context);
+                    return new DialogTurnResult(DialogTurnStatus.Waiting);
+                }
+
+                await stepContext.Context.SendActivityAsync(MessageFactory.Text($"v4: Hi {greetingState.Name} from {greetingState.City}. You said: {stepContext.Context.Activity.Text}"), cancellationToken);
+                return new DialogTurnResult(DialogTurnStatus.Complete);
+            }
+            else
+            {
+                return await stepContext.PromptAsync(nameof(TextPrompt), new PromptOptions { Prompt = MessageFactory.Text("v4: Hi, what is your name?") }, cancellationToken);
+            }
+        }
+
+        private async Task<DialogTurnResult> NameStep(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            var v3State = await _v3State.GetAsync(stepContext.Context, () => new BotData("", new Dictionary<string, object>()));
+            var greetingState = v3State.GetProperty<GreetingState>(V3GreetingPropertyName) ?? new GreetingState();
+
+            greetingState.Name = stepContext.Context.Activity.Text;
+            v3State.SetProperty<GreetingState>(V3GreetingPropertyName, greetingState);
+
+            bool changingName = v3State.GetProperty<bool>(ChangingNamePropertyName);
+
+            if (changingName)
+            {
+                v3State.SetProperty<bool>(ChangingNamePropertyName, false);
+                await stepContext.Context.SendActivityAsync($"v4: Okay, your name is now stored as {greetingState.Name}");
+                return new DialogTurnResult(DialogTurnStatus.Complete);
+            }
+
+            return await stepContext.PromptAsync(nameof(TextPrompt), new PromptOptions { Prompt = MessageFactory.Text($"v4: Ok, I've got your name as {greetingState.Name}.  What city do you live in?") }, cancellationToken);
+        }
+
+        private async Task<DialogTurnResult> CityStep(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            var v3State = await _v3State.GetAsync(stepContext.Context, () => new BotData("", new Dictionary<string, object>()));
+            var greetingState = v3State.GetProperty<GreetingState>(V3GreetingPropertyName);
+            greetingState.City = stepContext.Context.Activity.Text;
+            v3State.SetProperty<GreetingState>(V3GreetingPropertyName, greetingState);
+
+            await stepContext.Context.SendActivityAsync(MessageFactory.Text($"v4: Hi {greetingState.Name} from {greetingState.City}."), cancellationToken);
+            return await stepContext.EndDialogAsync(cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/Models/GreetingState.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/Models/GreetingState.cs
@@ -1,0 +1,8 @@
+﻿namespace V4StateBot.Models
+{
+    public class GreetingState
+    {
+        public string Name { get; set; }
+        public string City { get; set; }
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/Models/TestDataClass.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/Models/TestDataClass.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace V4StateBot.Models
+{
+    public class TestDataClass
+    {
+        public string TestStringField { get; set; }
+        public int TestIntField { get; set; }
+        public Tuple<string, string> TestTuple { get; set; }
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/Program.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/Program.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// Generated with Bot Builder V4 SDK Template for Visual Studio EchoBot v4.3.0
+
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+namespace V4StateBot
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>();
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/Properties/launchSettings.json
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:3978/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "V4StateBot": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:3978/"
+    }
+  }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/README.md
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/README.md
@@ -1,0 +1,69 @@
+﻿# V4StateBot
+
+Bot Framework v4 echo bot sample.
+
+This bot has been created using [Bot Framework](https://dev.botframework.com), it shows how to create a simple bot that accepts input from the user and echoes it back.
+
+## Prerequisites
+
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 2.1
+
+  ```bash
+  # determine dotnet version
+  dotnet --version
+  ```
+
+## To try this sample
+
+- In a terminal, navigate to `V4StateBot`
+
+    ```bash
+    # change into project folder
+    cd # V4StateBot
+    ```
+
+- Run the bot from a terminal or from Visual Studio, choose option A or B.
+
+  A) From a terminal
+
+  ```bash
+  # run the bot
+  dotnet run
+  ```
+
+  B) Or from Visual Studio
+
+  - Launch Visual Studio
+  - File -> Open -> Project/Solution
+  - Navigate to `V4StateBot` folder
+  - Select `V4StateBot.csproj` file
+  - Press `F5` to run the project
+
+## Testing the bot using Bot Framework Emulator
+
+[Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
+
+- Install the Bot Framework Emulator version 4.3.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
+
+### Connect to the bot using Bot Framework Emulator
+
+- Launch Bot Framework Emulator
+- File -> Open Bot
+- Enter a Bot URL of `http://localhost:3978/api/messages`
+
+## Deploy the bot to Azure
+
+To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.
+
+## Further reading
+
+- [Bot Framework Documentation](https://docs.botframework.com)
+- [Bot Basics](https://docs.microsoft.com/azure/bot-service/bot-builder-basics?view=azure-bot-service-4.0)
+- [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
+- [Azure Bot Service Introduction](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
+- [Azure Bot Service Documentation](https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0)
+- [.NET Core CLI tools](https://docs.microsoft.com/en-us/dotnet/core/tools/?tabs=netcore2x)
+- [Azure CLI](https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
+- [Azure Portal](https://portal.azure.com)
+- [Language Understanding using LUIS](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/)
+- [Channels and Bot Connector Service](https://docs.microsoft.com/en-us/azure/bot-service/bot-concepts?view=azure-bot-service-4.0)

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/Startup.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/Startup.cs
@@ -56,15 +56,15 @@ namespace V4StateBot
                         collectionId: Configuration["v3CosmosCollectionName"]);
 
             // SqlBotDataStore for V3V4 User State
-            var sqlConnectionString = Configuration.GetConnectionString("SqlBotData");
-            var sqlBotDataStore = new SqlBotDataStore(sqlConnectionString);
+            //var sqlConnectionString = Configuration.GetConnectionString("SqlBotData");
+            //var sqlBotDataStore = new SqlBotDataStore(sqlConnectionString);
 
             // TableBotDataStore for V3V4 User State
-            var tableConnectionString = Configuration.GetConnectionString("AzureTable");
-            var tableBotDataStore = new TableBotDataStore(tableConnectionString);
+            //var tableConnectionString = Configuration.GetConnectionString("AzureTable");
+            //var tableBotDataStore = new TableBotDataStore(tableConnectionString);
 
             // TableBotDataStore2 for V3V4 User State            
-            var tableBotDataStore2 = new TableBotDataStore2(tableConnectionString);
+            //var tableBotDataStore2 = new TableBotDataStore2(tableConnectionString);
 
 
             // Create the V3V4Storage layer bridge, providing a V3 storage.

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/Startup.cs
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/Startup.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// Generated with Bot Builder V4 SDK Template for Visual Studio EchoBot v4.3.0
+
+using Bot.Builder.Azure.V3V4;
+using Bot.Builder.Azure.V3V4.AzureSql;
+using Bot.Builder.Azure.V3V4.AzureTable;
+using Bot.Builder.Azure.V3V4.CosmosDb;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Azure;
+using Microsoft.Bot.Builder.BotFramework;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.WindowsAzure.Storage;
+using Newtonsoft.Json;
+using System;
+using V4StateBot.Bots;
+using V4StateBot.Dialogs;
+
+namespace V4StateBot
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+
+            // Create Conversation State using MemoryStorage (conversations will be reset on server restart)
+            IStorage conversationStorage = new MemoryStorage();
+            var conversationState = new ConversationState(conversationStorage);
+            services.AddSingleton<ConversationState>(conversationState);
+
+
+            //Uri docDbEmulatorUri = new Uri("https://localhost:8081");
+            //const string docDbEmulatorKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+
+            // DocumentDbBotDataStore for V3V4 User State
+            Uri docDbEmulatorUri = new Uri(Configuration["v3CosmosEndpoint"]);
+            var documentDbBotDataStore = new DocumentDbBotDataStore(docDbEmulatorUri,
+                        Configuration["v3CosmosKey"],
+                        databaseId: Configuration["v3CosmosDatataseName"],
+                        collectionId: Configuration["v3CosmosCollectionName"]);
+
+            // SqlBotDataStore for V3V4 User State
+            var sqlConnectionString = Configuration.GetConnectionString("SqlBotData");
+            var sqlBotDataStore = new SqlBotDataStore(sqlConnectionString);
+
+            // TableBotDataStore for V3V4 User State
+            var tableConnectionString = Configuration.GetConnectionString("AzureTable");
+            var tableBotDataStore = new TableBotDataStore(tableConnectionString);
+
+            // TableBotDataStore2 for V3V4 User State            
+            var tableBotDataStore2 = new TableBotDataStore2(tableConnectionString);
+
+
+            // Create the V3V4Storage layer bridge, providing a V3 storage.
+            // Then use that storage to create a V3V4State, and inject as a singleton
+            var v3v4Storage = new V3V4Storage(documentDbBotDataStore);
+            //var v3v4Storage = new V3V4Storage(sqlBotDataStore);
+            //var v3v4Storage = new V3V4Storage(tableBotDataStore);
+            //var v3v4Storage = new V3V4Storage(tableBotDataStore2);
+            services.AddSingleton<V3V4State>(new V3V4State(v3v4Storage));
+            
+            // Create the credential provider to be used with the Bot Framework Adapter.
+            services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();
+            services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
+
+            services.AddSingleton<MainDialog>();
+            // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
+            services.AddTransient<IBot, EchoBot<MainDialog>>();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseHsts();
+            }
+
+            app.UseDefaultFiles();
+            app.UseStaticFiles();
+
+            //app.UseHttpsRedirection();
+            app.UseMvc();
+        }
+    }
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/V4StateBot.csproj
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/V4StateBot.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="V3State\**" />
+    <Content Remove="V3State\**" />
+    <EmbeddedResource Remove="V3State\**" />
+    <None Remove="V3State\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.4.4" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.4.4" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.4.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.11" />
+    <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
+  </ItemGroup>
+
+    <ItemGroup>
+    <Content Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Bot.Builder.Azure.V3ToV4\Bot.Builder.Azure.V3V4.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/appsettings.Development.json
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+    "Logging": {
+      "LogLevel": {
+        "Default": "Debug",
+        "System": "Information",
+        "Microsoft": "Information"
+      }
+    }
+  }

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/appsettings.json
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "MicrosoftAppId": "",
+  "MicrosoftAppPassword": "",
+
+  "v3CosmosEndpoint": "https://yourcosmosdb.documents.azure.com:443/",
+  "v3CosmosKey": "",
+  "v3CosmosDatataseName": "v3botdb",
+  "v3CosmosCollectionName": "v3botcollection",
+
+  "ConnectionStrings": {
+    "SqlBotData": "Server=YourServer;Initial Catalog=BotData;Persist Security Info=False;User ID=YourUserName;Password=YourUserPassword;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;",
+    "AzureTable": "DefaultEndpointsProtocol=https;AccountName=YourAccountName;AccountKey=YourAccountKey;EndpointSuffix=core.windows.net"
+  },
+}

--- a/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/wwwroot/default.htm
+++ b/MigrationV3V4/CSharp/V4StateBotFromV3Providers/V4V3StateBot/wwwroot/default.htm
@@ -1,0 +1,420 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>V4StateBot</title>
+    <style>
+        body {
+            margin: 0px;
+            padding: 0px;
+            font-family: Segoe UI;
+        }
+
+        html,
+        body {
+            height: 100%;
+        }
+
+        header {
+            background-image: url("data:image/svg+xml,%3Csvg version='1.1' id='Layer_1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' viewBox='0 0 4638.9 651.6' style='enable-background:new 0 0 4638.9 651.6;' xml:space='preserve'%3E%3Cstyle type='text/css'%3E .st0%7Bfill:%2355A0E0;%7D .st1%7Bfill:none;%7D .st2%7Bfill:%230058A8;%7D .st3%7Bfill:%23328BD8;%7D .st4%7Bfill:%23B6DCF1;%7D .st5%7Bopacity:0.2;fill:url(%23SVGID_1_);enable-background:new ;%7D%0A%3C/style%3E%3Crect y='1.1' class='st0' width='4640' height='646.3'/%3E%3Cpath class='st1' d='M3987.8,323.6L4310.3,1.1h-65.6l-460.1,460.1c-17.5,17.5-46.1,17.5-63.6,0L3260.9,1.1H0v646.3h3660.3 L3889,418.7c17.5-17.5,46.1-17.5,63.6,0l228.7,228.7h66.6l-260.2-260.2C3970.3,369.8,3970.3,341.1,3987.8,323.6z'/%3E%3Cpath class='st2' d='M3784.6,461.2L4244.7,1.1h-983.9l460.1,460.1C3738.4,478.7,3767.1,478.7,3784.6,461.2z'/%3E%3Cpath class='st3' d='M4640,1.1h-329.8l-322.5,322.5c-17.5,17.5-17.5,46.1,0,63.6l260.2,260.2H4640L4640,1.1L4640,1.1z'/%3E%3Cpath class='st4' d='M3889,418.8l-228.7,228.7h521.1l-228.7-228.7C3935.2,401.3,3906.5,401.3,3889,418.8z'/%3E%3ClinearGradient id='SVGID_1_' gradientUnits='userSpaceOnUse' x1='3713.7576' y1='438.1175' x2='3911.4084' y2='14.2535' gradientTransform='matrix(1 0 0 -1 0 641.3969)'%3E%3Cstop offset='0' style='stop-color:%23FFFFFF;stop-opacity:0.5'/%3E%3Cstop offset='1' style='stop-color:%23FFFFFF'/%3E%3C/linearGradient%3E%3Cpath class='st5' d='M3952.7,124.5c-17.5-17.5-46.1-17.5-63.6,0l-523,523h1109.6L3952.7,124.5z'/%3E%3C/svg%3E%0A");
+            background-repeat: no-repeat;
+            background-size: 100%;
+            background-position: right;
+            background-color: #55A0E0;
+            width: 100%;
+            font-size: 44px;
+            height: 120px;
+            color: white;
+            padding: 30px 0 40px 0px;
+            display: inline-block;
+        }
+
+        .header-icon {
+            background-image: url("data:image/svg+xml;utf8,%3Csvg%20version%3D%221.1%22%20id%3D%22Layer_1%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20viewBox%3D%220%200%20150.2%20125%22%20style%3D%22enable-background%3Anew%200%200%20150.2%20125%3B%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cstyle%20type%3D%22text/css%22%3E%0A%09.st0%7Bfill%3Anone%3B%7D%0A%09.st1%7Bfill%3A%23FFFFFF%3B%7D%0A%3C/style%3E%0A%3Crect%20x%3D%220.5%22%20class%3D%22st0%22%20width%3D%22149.7%22%20height%3D%22125%22/%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M59%2C102.9L21.8%2C66c-3.5-3.5-3.5-9.1%2C0-12.5l37-36.5l2.9%2C3l-37%2C36.4c-1.8%2C1.8-1.8%2C4.7%2C0%2C6.6l37.2%2C37L59%2C102.9z%22%0A%09%09/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M92.5%2C102.9l-3-3l37.2-37c0.9-0.9%2C1.4-2%2C1.4-3.3c0-1.2-0.5-2.4-1.4-3.3L89.5%2C20l2.9-3l37.2%2C36.4%0A%09%09c1.7%2C1.7%2C2.6%2C3.9%2C2.6%2C6.3s-0.9%2C4.6-2.6%2C6.3L92.5%2C102.9z%22/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M90.1%2C68.4c-4.5%2C0-8-3.5-8-8.1c0-4.5%2C3.5-8.1%2C8-8.1c4.4%2C0%2C8%2C3.7%2C8%2C8.1C98.1%2C64.7%2C94.4%2C68.4%2C90.1%2C68.4z%0A%09%09%20M90.1%2C56.5c-2.2%2C0-3.8%2C1.7-3.8%2C3.9c0%2C2.2%2C1.7%2C3.9%2C3.8%2C3.9c1.9%2C0%2C3.8-1.6%2C3.8-3.9S91.9%2C56.5%2C90.1%2C56.5z%22/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M61.4%2C68.4c-4.5%2C0-8-3.5-8-8.1c0-4.5%2C3.5-8.1%2C8-8.1c4.4%2C0%2C8%2C3.7%2C8%2C8.1C69.5%2C64.7%2C65.8%2C68.4%2C61.4%2C68.4z%0A%09%09%20M61.4%2C56.5c-2.2%2C0-3.8%2C1.7-3.8%2C3.9c0%2C2.2%2C1.7%2C3.9%2C3.8%2C3.9c1.9%2C0%2C3.8-1.6%2C3.8-3.9S63.3%2C56.5%2C61.4%2C56.5z%22/%3E%0A%3C/g%3E%0A%3C/svg%3E%0A");
+            background-repeat: no-repeat;
+            float: left;
+            height: 140px;
+            width: 140px;
+            display: inline-block;
+            vertical-align: middle;
+        }
+
+        .header-text {
+            padding-left: 1%;
+            color: #FFFFFF;
+            font-family: "Segoe UI";
+            font-size: 72px;
+            font-weight: 300;
+            letter-spacing: 0.35px;
+            line-height: 96px;
+            display: inline-block;
+            vertical-align: middle;
+        }
+
+        .header-inner-container {
+            min-width: 480px;
+            max-width: 1366px;
+            margin-left: auto;
+            margin-right: auto;
+            vertical-align: middle;
+        }
+
+        .header-inner-container::after {
+            content: "";
+            clear: both;
+            display: table;
+        }
+
+        .main-content-area {
+            padding-left: 30px;
+        }
+
+        .content-title {
+            color: #000000;
+            font-family: "Segoe UI";
+            font-size: 46px;
+            font-weight: 300;
+            line-height: 62px;
+        }
+
+        .main-text {
+            color: #808080;
+            font-size: 24px;
+            font-family: "Segoe UI";
+            font-size: 24px;
+            font-weight: 200;
+            line-height: 32px;
+        }
+
+        .main-text-p1 {
+            padding-top: 48px;
+            padding-bottom: 28px;
+        }
+
+        .endpoint {
+            height: 32px;
+            width: 571px;
+            color: #808080;
+            font-family: "Segoe UI";
+            font-size: 24px;
+            font-weight: 200;
+            line-height: 32px;
+            padding-top: 28px;
+        }
+
+        .how-to-build-section {
+            padding-top: 20px;
+            padding-left: 30px;
+        }
+
+        .how-to-build-section>h3 {
+            font-size: 16px;
+            font-weight: 600;
+            letter-spacing: 0.35px;
+            line-height: 22px;
+            margin: 0 0 24px 0;
+            text-transform: uppercase;
+        }
+
+        .step-container {
+            display: flex;
+            align-items: stretch;
+            position: relative;
+        }
+
+        .step-container dl {
+            border-left: 1px solid #A0A0A0;
+            display: block;
+            padding: 0 24px;
+            margin: 0;
+        }
+
+        .step-container dl>dt::before {
+            background-color: white;
+            border: 1px solid #A0A0A0;
+            border-radius: 100%;
+            content: '';
+            left: 47px;
+            height: 11px;
+            position: absolute;
+            width: 11px;
+        }
+
+        .step-container dl>.test-bullet::before {
+            background-color: blue;
+        }
+
+        .step-container dl>dt {
+            display: block;
+            font-size: inherit;
+            font-weight: bold;
+            line-height: 20px;
+        }
+
+        .step-container dl>dd {
+            font-size: inherit;
+            line-height: 20px;
+            margin-left: 0;
+            padding-bottom: 32px;
+        }
+
+        .step-container:last-child dl {
+            border-left: 1px solid transparent;
+        }
+
+        .ctaLink {
+            background-color: transparent;
+            border: 1px solid transparent;
+            color: #006AB1;
+            cursor: pointer;
+            font-weight: 600;
+            padding: 0;
+            white-space: normal;
+        }
+
+        .ctaLink:focus {
+            outline: 1px solid #00bcf2;
+        }
+
+        .ctaLink:hover {
+            text-decoration: underline;
+        }
+
+        .step-icon {
+            display: flex;
+            height: 38px;
+            margin-right: 15px;
+            width: 38px;
+        }
+
+        .step-icon>div {
+            height: 30px;
+            width: 30px;
+            background-repeat: no-repeat;
+        }
+
+        .ms-logo-container {
+            min-width: 580px;
+            max-width: 980px;
+            margin-left: auto;
+            margin-right: auto;
+            left: 0;
+            right: 0;
+            transition: bottom 400ms;
+        }
+
+        .ms-logo {
+            float: right;
+            background-image: url("data:image/svg+xml;utf8,%0A%3Csvg%20version%3D%221.1%22%20id%3D%22MS-symbol%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20viewBox%3D%220%200%20400%20120%22%20style%3D%22enable-background%3Anew%200%200%20400%20120%3B%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cstyle%20type%3D%22text/css%22%3E%0A%09.st0%7Bfill%3Anone%3B%7D%0A%09.st1%7Bfill%3A%23737474%3B%7D%0A%09.st2%7Bfill%3A%23D63F26%3B%7D%0A%09.st3%7Bfill%3A%23167D3E%3B%7D%0A%09.st4%7Bfill%3A%232E76BC%3B%7D%0A%09.st5%7Bfill%3A%23FDB813%3B%7D%0A%3C/style%3E%0A%3Crect%20x%3D%220.6%22%20class%3D%22st0%22%20width%3D%22398.7%22%20height%3D%22119%22/%3E%0A%3Cpath%20class%3D%22st1%22%20d%3D%22M171.3%2C38.4v43.2h-7.5V47.7h-0.1l-13.4%2C33.9h-5l-13.7-33.9h-0.1v33.9h-6.9V38.4h10.8l12.4%2C32h0.2l13.1-32H171.3%0A%09z%20M177.6%2C41.7c0-1.2%2C0.4-2.2%2C1.3-3c0.9-0.8%2C1.9-1.2%2C3.1-1.2c1.3%2C0%2C2.4%2C0.4%2C3.2%2C1.3c0.8%2C0.8%2C1.3%2C1.8%2C1.3%2C3c0%2C1.2-0.4%2C2.2-1.3%2C3%0A%09c-0.9%2C0.8-1.9%2C1.2-3.2%2C1.2s-2.3-0.4-3.1-1.2C178%2C43.8%2C177.6%2C42.8%2C177.6%2C41.7z%20M185.7%2C50.6v31h-7.3v-31H185.7z%20M207.8%2C76.3%0A%09c1.1%2C0%2C2.3-0.3%2C3.6-0.8c1.3-0.5%2C2.5-1.2%2C3.6-2v6.8c-1.2%2C0.7-2.5%2C1.2-4%2C1.5c-1.5%2C0.3-3.1%2C0.5-4.9%2C0.5c-4.6%2C0-8.3-1.4-11.1-4.3%0A%09c-2.9-2.9-4.3-6.6-4.3-11c0-5%2C1.5-9.1%2C4.4-12.3c2.9-3.2%2C7-4.8%2C12.4-4.8c1.4%2C0%2C2.7%2C0.2%2C4.1%2C0.5c1.4%2C0.4%2C2.5%2C0.8%2C3.3%2C1.2v7%0A%09c-1.1-0.8-2.3-1.5-3.4-1.9c-1.2-0.5-2.4-0.7-3.6-0.7c-2.9%2C0-5.2%2C0.9-7%2C2.8c-1.8%2C1.9-2.7%2C4.4-2.7%2C7.6c0%2C3.1%2C0.8%2C5.6%2C2.5%2C7.3%0A%09C202.6%2C75.4%2C204.9%2C76.3%2C207.8%2C76.3z%20M235.7%2C50.1c0.6%2C0%2C1.1%2C0%2C1.6%2C0.1s0.9%2C0.2%2C1.2%2C0.3v7.4c-0.4-0.3-0.9-0.5-1.7-0.8%0A%09c-0.7-0.3-1.6-0.4-2.7-0.4c-1.8%2C0-3.3%2C0.8-4.5%2C2.3c-1.2%2C1.5-1.9%2C3.8-1.9%2C7v15.6h-7.3v-31h7.3v4.9h0.1c0.7-1.7%2C1.7-3%2C3-4%0A%09C232.2%2C50.6%2C233.8%2C50.1%2C235.7%2C50.1z%20M238.9%2C66.6c0-5.1%2C1.4-9.2%2C4.3-12.2c2.9-3%2C6.9-4.5%2C12.1-4.5c4.8%2C0%2C8.6%2C1.4%2C11.3%2C4.3%0A%09c2.7%2C2.9%2C4.1%2C6.8%2C4.1%2C11.7c0%2C5-1.4%2C9-4.3%2C12c-2.9%2C3-6.8%2C4.5-11.8%2C4.5c-4.8%2C0-8.6-1.4-11.4-4.2C240.3%2C75.3%2C238.9%2C71.4%2C238.9%2C66.6z%0A%09%20M246.5%2C66.3c0%2C3.2%2C0.7%2C5.7%2C2.2%2C7.4c1.5%2C1.7%2C3.6%2C2.6%2C6.3%2C2.6c2.7%2C0%2C4.7-0.9%2C6.1-2.6c1.4-1.7%2C2.1-4.2%2C2.1-7.6c0-3.3-0.7-5.8-2.2-7.5%0A%09c-1.4-1.7-3.4-2.5-6-2.5c-2.7%2C0-4.7%2C0.9-6.2%2C2.7C247.2%2C60.5%2C246.5%2C63%2C246.5%2C66.3z%20M281.5%2C58.8c0%2C1%2C0.3%2C1.9%2C1%2C2.5%0A%09c0.7%2C0.6%2C2.1%2C1.3%2C4.4%2C2.2c2.9%2C1.2%2C5%2C2.5%2C6.1%2C3.9c1.2%2C1.5%2C1.8%2C3.2%2C1.8%2C5.3c0%2C2.9-1.1%2C5.3-3.4%2C7c-2.2%2C1.8-5.3%2C2.7-9.1%2C2.7%0A%09c-1.3%2C0-2.7-0.2-4.3-0.5c-1.6-0.3-2.9-0.7-4-1.2v-7.2c1.3%2C0.9%2C2.8%2C1.7%2C4.3%2C2.2c1.5%2C0.5%2C2.9%2C0.8%2C4.2%2C0.8c1.6%2C0%2C2.9-0.2%2C3.6-0.7%0A%09c0.8-0.5%2C1.2-1.2%2C1.2-2.3c0-1-0.4-1.9-1.2-2.5c-0.8-0.7-2.4-1.5-4.6-2.4c-2.7-1.1-4.6-2.4-5.7-3.8c-1.1-1.4-1.7-3.2-1.7-5.4%0A%09c0-2.8%2C1.1-5.1%2C3.3-6.9c2.2-1.8%2C5.1-2.7%2C8.6-2.7c1.1%2C0%2C2.3%2C0.1%2C3.6%2C0.4c1.3%2C0.2%2C2.5%2C0.6%2C3.4%2C0.9v6.9c-1-0.6-2.1-1.2-3.4-1.7%0A%09c-1.3-0.5-2.6-0.7-3.8-0.7c-1.4%2C0-2.5%2C0.3-3.2%2C0.8C281.9%2C57.1%2C281.5%2C57.8%2C281.5%2C58.8z%20M297.9%2C66.6c0-5.1%2C1.4-9.2%2C4.3-12.2%0A%09c2.9-3%2C6.9-4.5%2C12.1-4.5c4.8%2C0%2C8.6%2C1.4%2C11.3%2C4.3c2.7%2C2.9%2C4.1%2C6.8%2C4.1%2C11.7c0%2C5-1.4%2C9-4.3%2C12c-2.9%2C3-6.8%2C4.5-11.8%2C4.5%0A%09c-4.8%2C0-8.6-1.4-11.4-4.2C299.4%2C75.3%2C297.9%2C71.4%2C297.9%2C66.6z%20M305.5%2C66.3c0%2C3.2%2C0.7%2C5.7%2C2.2%2C7.4c1.5%2C1.7%2C3.6%2C2.6%2C6.3%2C2.6%0A%09c2.7%2C0%2C4.7-0.9%2C6.1-2.6c1.4-1.7%2C2.1-4.2%2C2.1-7.6c0-3.3-0.7-5.8-2.2-7.5c-1.4-1.7-3.4-2.5-6-2.5c-2.7%2C0-4.7%2C0.9-6.2%2C2.7%0A%09C306.3%2C60.5%2C305.5%2C63%2C305.5%2C66.3z%20M353.9%2C56.6h-10.9v25h-7.4v-25h-5.2v-6h5.2v-4.3c0-3.3%2C1.1-5.9%2C3.2-8c2.1-2.1%2C4.8-3.1%2C8.1-3.1%0A%09c0.9%2C0%2C1.7%2C0%2C2.4%2C0.1c0.7%2C0.1%2C1.3%2C0.2%2C1.8%2C0.4V42c-0.2-0.1-0.7-0.3-1.3-0.5c-0.6-0.2-1.3-0.3-2.1-0.3c-1.5%2C0-2.7%2C0.5-3.5%2C1.4%0A%09s-1.2%2C2.4-1.2%2C4.2v3.7h10.9v-7l7.3-2.2v9.2h7.4v6h-7.4v14.5c0%2C1.9%2C0.3%2C3.3%2C1%2C4c0.7%2C0.8%2C1.8%2C1.2%2C3.3%2C1.2c0.4%2C0%2C0.9-0.1%2C1.5-0.3%0A%09c0.6-0.2%2C1.1-0.4%2C1.6-0.7v6c-0.5%2C0.3-1.2%2C0.5-2.3%2C0.7c-1.1%2C0.2-2.1%2C0.3-3.2%2C0.3c-3.1%2C0-5.4-0.8-6.9-2.5c-1.5-1.6-2.3-4.1-2.3-7.4%0A%09V56.6z%22/%3E%0A%3Cg%3E%0A%09%3Crect%20x%3D%2231%22%20y%3D%2224%22%20class%3D%22st2%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2268.8%22%20y%3D%2224%22%20class%3D%22st3%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2231%22%20y%3D%2261.8%22%20class%3D%22st4%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2268.8%22%20y%3D%2261.8%22%20class%3D%22st5%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%3C/g%3E%0A%3C/svg%3E%0A");
+        }
+
+        .ms-logo-container>div {
+            min-height: 60px;
+            width: 150px;
+            background-repeat: no-repeat;
+        }
+
+        .row {
+            padding: 90px 0px 0 20px;
+            min-width: 480px;
+            max-width: 1366px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        .column {
+            float: left;
+            width: 45%;
+            padding-right: 20px;
+        }
+
+        .row:after {
+            content: "";
+            display: table;
+            clear: both;
+        }
+
+        a {
+            text-decoration: none;
+        }
+
+        .download-the-emulator {
+            height: 20px;
+            color: #0063B1;
+            font-size: 15px;
+            line-height: 20px;
+            padding-bottom: 70px;
+        }
+
+        .how-to-iframe {
+            max-width: 700px !important;
+            min-width: 650px !important;
+            height: 700px !important;
+        }
+
+        .remove-frame-height {
+            height: 10px;
+        }
+
+        @media only screen and (max-width: 1300px) {
+            .ms-logo {
+                padding-top: 30px;
+            }
+
+            .header-text {
+                font-size: 40x;
+            }
+
+            .column {
+                float: none;
+                padding-top: 30px;
+                width: 100%;
+            }
+
+            .ms-logo-container {
+                padding-top: 30px;
+                min-width: 480px;
+                max-width: 650px;
+                margin-left: auto;
+                margin-right: auto;
+            }
+
+            .row {
+                padding: 20px 0px 0 20px;
+                min-width: 480px;
+                max-width: 650px;
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
+
+        @media only screen and (max-width: 1370px) {
+            header {
+                background-color: #55A0E0;
+                background-size: auto 200px;
+            }
+        }
+
+        @media only screen and (max-width: 1230px) {
+            header {
+                background-color: #55A0E0;
+                background-size: auto 200px;
+            }
+
+            .header-text {
+                font-size: 44px;
+            }
+
+            .header-icon {
+                height: 120px;
+                width: 120px;
+            }
+        }
+
+        @media only screen and (max-width: 1000px) {
+            header {
+                background-color: #55A0E0;
+                background-image: none;
+            }
+        }
+
+        @media only screen and (max-width: 632px) {
+            .header-text {
+                font-size: 32px;
+            }
+
+            .row {
+                padding: 10px 0px 0 10px;
+                max-width: 490px !important;
+                min-width: 410px !important;
+            }
+
+            .endpoint {
+                font-size: 25px;
+            }
+
+            .main-text {
+                font-size: 20px;
+            }
+
+            .step-container dl>dd {
+                font-size: 14px;
+            }
+
+            .column {
+                padding-right: 5px;
+            }
+
+            .header-icon {
+                height: 110px;
+                width: 110px;
+            }
+
+            .how-to-iframe {
+                max-width: 480px !important;
+                min-width: 400px !important;
+                height: 650px !important;
+                overflow: hidden;
+            }
+        }
+
+        .remove-frame-height {
+            max-height: 10px;
+        }
+    </style>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            loadFrame();
+        });
+        var loadFrame = function () {
+            var iframe = document.createElement('iframe');
+            iframe.setAttribute("id", "iframe");
+            var offLineHTMLContent = "";
+            var frameElement = document.getElementById("how-to-iframe");
+            if (window.navigator.onLine) {
+                iframe.src = 'https://docs.botframework.com/static/abs/pages/f5.htm';
+                iframe.setAttribute("scrolling", "no");
+                iframe.setAttribute("frameborder", "0");
+                iframe.setAttribute("width", "100%");
+                iframe.setAttribute("height", "100%");
+                var frameDiv = document.getElementById("how-to-iframe");
+                frameDiv.appendChild(iframe);
+            } else {
+                frameElement.classList.add("remove-frame-height");
+            }
+        };
+    </script>
+</head>
+
+<body>
+    <header class="header">
+        <div class="header-inner-container">
+            <div class="header-icon" style="display: inline-block"></div>
+            <div class="header-text" style="display: inline-block">V4StateBot Bot</div>
+        </div>
+    </header>
+    <div class="row">
+        <div class="column" class="main-content-area">
+            <div class="content-title">Your bot is ready!</div>
+            <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
+                by connecting to http://localhost:3978/api/messages.</div>
+            <div class="main-text download-the-emulator"><a class="ctaLink"
+                    href="https://aka.ms/bot-framework-F5-download-emulator" target="_blank">Download the Emulator</a>
+            </div>
+            <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home"
+                    target="_blank">Azure
+                    Bot Service</a> to register your bot and add it to<br />
+                various channels. The bot's endpoint URL typically looks
+                like this:</div>
+            <div class="endpoint">https://<i>your_bots_hostname</i>/api/messages</div>
+        </div>
+        <div class="column how-to-iframe" id="how-to-iframe"></div>
+    </div>
+    <div class="ms-logo-container">
+        <div class="ms-logo"></div>
+    </div>
+</body>
+
+</html>

--- a/MigrationV3V4/README.md
+++ b/MigrationV3V4/README.md
@@ -3,13 +3,48 @@
 
 ## Overview
 
-This branch contains samples for migration workflows from **Bot Framework V3 SDK** to  **Microsoft Bot Framework V4 SDK** for [.NET](https://github.com/Microsoft/botbuilder-dotnet) and [JS](https://github.com//microsoft/botbuilder-js). 
+This area contains samples for migration workflows from **Bot Framework V3 SDK** to  **Bot Framework V4 SDK** for [.NET](https://github.com/Microsoft/botbuilder-dotnet) and [JS](https://github.com//microsoft/botbuilder-js). 
 
 ## Goals of this work
 
 In some cases, since the V4 SDK contains substantial improvements that are not compatible with V3, some migration may require potential re-write or substantial effort. This section contains examples and best practices to support [Migration][1] documentation.
 
 ## Samples
-Not Ready Yet.
+
+### CSharp
+
+- [ContosoHelpdeskChatBot-V3](cs#1)
+    - This V3 bot was taken from the [Azure with Intelligent Apps](https://github.com/Microsoft/intelligent-apps/tree/master/ContosoHelpdeskChatBot/ContosoHelpdeskChatBot) example.  This is the bot we've used to demonstrate migration concepts.  The V3 source code is here for reference.
+
+- [ContosoHelpdeskChatBot-V4NetFramework](cs#3)
+    - Example of ContosoHelpdeskChatBot migrated to use Bot Builder V4 targeting netframework.
+
+- [ContosoHelpdeskChatBot-V4NetCore](cs#2)
+    - Example of ContosoHelpdeskChatBot migrated to use Bot Builder V4 targeting netcoreapp2.1.
+
+- [V3StateBot](cs#4)
+    - Example demonstrating saving user scoped information (User State) into Azure Table, CosmosDb and Azure Sql using [Microsoft.Bot.Builder.Azure](https://www.nuget.org/packages/Microsoft.Bot.Builder.Azure/3.16.3.40383)
+
+- [V4StateBotFromV3Providers](cs#5)
+    - The V4StateBot solution contains to projects:
+        - Bot.Builder.Azure.V3V4 library contains code ported from [Microsoft.Bot.Builder.Azure](https://github.com/microsoft/BotBuilder-Azure/tree/master/CSharp/Library/Microsoft.Bot.Builder.Azure) but targeting netcoreapp2.1 This library can be used to create a v4 storage provider that wraps a v3 store.
+        - V4StateBot is an example demonstrating using the Bot.Builder.Azure.V3V4 library to connect to v3 storage providers.
+
+### Node
+
+- [core-MultiDialogs-v3](js#1)
+    - This V3 bot was taken from the [v3-sdk-samples](https://github.com/microsoft/BotBuilder-Samples/tree/v3-sdk-samples/Node/core-MultiDialogs) branch.  This is the bot we've used to demonstrate migration concepts.  The V3 source code is here for reference.
+
+- [core-MultiDialogs-v3](js#2)
+    - Example of core-MultiDialogs migrated to use Bot Builder V4.
+
+[cs#1]:csharp/ContosoHelpdeskChatBot-V3
+[cs#2]:csharp/ContosoHelpdeskChatBot-V4NetCore
+[cs#3]:csharp/ContosoHelpdeskChatBot-V4NetFramework
+[cs#4]:csharp/V3StateBot
+[cs#5]:csharp/V4StateBotFromV3Providers
+
+[js#1]:node/core-MultiDialogs-v3
+[js#2]:node/core-MultiDialogs-v4
 
 [1]: https://docs.microsoft.com/en-us/azure/bot-service/migration/conversion-framework?view=azure-bot-service-4.0


### PR DESCRIPTION
## Proposed Changes
This PR has three projects:

**V3StateBot**: sample project demonstrating saving user scoped information into Azure Table, CosmosDb and Azure Sql using https://www.nuget.org/packages/Microsoft.Bot.Builder.Azure/3.16.3.40383

**Bot.Builder.Azure.V3V4**: library containing ported code from https://github.com/microsoft/BotBuilder-Azure/tree/master/CSharp/Library/Microsoft.Bot.Builder.Azure but targeting netcoreapp2.1  This library can be used to create a v4 storage provider that wraps a v3 store.

**V4StateBot**: sample project demonstrating using the Bot.Builder.Azure.V3V4 library to connect to v3 storage providers.

## Testing
I've manually tested the following scenarios:
DocumentDbBotDataStore
✅ -new v4 user (no existing v3 record)
✅ -existing v3 teams/webchat users

SqlBotDataStore
✅ -new v4 user (no existing v3 record)
✅ -existing v3 teams/webchat users

TableBotDataStore
✅ -new v4 user (no existing v3 record)
✅ -existing v3 teams/webchat users

TableBotDataStore2
✅ -new v4 user (no existing v3 record)
✅ -existing v3 teams/webchat users
