### PR TITLE
bump restify dependencies to ~8.3.3 in samples

### DIFF
--- a/samples/javascript_nodejs/02.echo-bot/package.json
+++ b/samples/javascript_nodejs/02.echo-bot/package.json
@@ -18,7 +18,7 @@
     "dependencies": {
         "botbuilder": "~4.4.0",
         "dotenv": "^7.0.0",
-        "restify": "^8.2.0"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "eslint": "^5.13.0",

--- a/samples/javascript_nodejs/03.welcome-users/package.json
+++ b/samples/javascript_nodejs/03.welcome-users/package.json
@@ -18,7 +18,7 @@
     "dependencies": {
         "botbuilder": "~4.4.0",
         "dotenv": "^6.1.0",
-        "restify": "^7.2.3"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "eslint": "^5.9.0",

--- a/samples/javascript_nodejs/05.multi-turn-prompt/package.json
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/package.json
@@ -20,7 +20,7 @@
         "botbuilder-dialogs": "~4.4.0",
         "dotenv": "^6.1.0",
         "path": "^0.12.7",
-        "restify": "^7.2.3"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "eslint": "^5.9.0",

--- a/samples/javascript_nodejs/06.using-cards/package.json
+++ b/samples/javascript_nodejs/06.using-cards/package.json
@@ -19,7 +19,7 @@
         "botbuilder": "~4.4.0",
         "botbuilder-dialogs": "~4.4.0",
         "dotenv": "^7.0.0",
-        "restify": "^8.3.0"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "eslint": "^5.16.0",

--- a/samples/javascript_nodejs/07.using-adaptive-cards/package.json
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/package.json
@@ -18,7 +18,7 @@
     "dependencies": {
         "botbuilder": "~4.4.0",
         "dotenv": "^6.1.0",
-        "restify": "^7.2.3"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "eslint": "^5.9.0",

--- a/samples/javascript_nodejs/08.suggested-actions/package.json
+++ b/samples/javascript_nodejs/08.suggested-actions/package.json
@@ -18,7 +18,7 @@
     "dependencies": {
         "botbuilder": "~4.4.0",
         "dotenv": "^6.1.0",
-        "restify": "^7.2.3"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "eslint": "^5.9.0",

--- a/samples/javascript_nodejs/11.qnamaker/package.json
+++ b/samples/javascript_nodejs/11.qnamaker/package.json
@@ -19,7 +19,7 @@
         "botbuilder": "~4.4.0",
         "botbuilder-ai": "~4.4.0",
         "dotenv": "^6.1.0",
-        "restify": "^7.2.3"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "eslint": "^5.9.0",

--- a/samples/javascript_nodejs/13.core-bot/package.json
+++ b/samples/javascript_nodejs/13.core-bot/package.json
@@ -21,7 +21,7 @@
         "botbuilder-ai": "~4.4.0",
         "botbuilder-dialogs": "~4.4.0",
         "dotenv": "^6.1.0",
-        "restify": "^7.2.3"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "eslint": "^5.9.0",

--- a/samples/javascript_nodejs/14.nlp-with-dispatch/package.json
+++ b/samples/javascript_nodejs/14.nlp-with-dispatch/package.json
@@ -21,7 +21,7 @@
         "botbuilder-azure": "~4.4.0",
         "botbuilder-dialogs": "~4.4.0",
         "dotenv": "^6.1.0",
-        "restify": "^7.2.3"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "eslint": "^5.9.0",

--- a/samples/javascript_nodejs/15.handling-attachments/package.json
+++ b/samples/javascript_nodejs/15.handling-attachments/package.json
@@ -19,7 +19,7 @@
         "axios": "^0.18.0",
         "botbuilder": "~4.4.0",
         "dotenv": "^6.1.0",
-        "restify": "^7.2.3"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "eslint": "^5.9.0",

--- a/samples/javascript_nodejs/16.proactive-messages/package.json
+++ b/samples/javascript_nodejs/16.proactive-messages/package.json
@@ -22,7 +22,7 @@
         "fetch-ponyfill": "^6.0.2",
         "moment": "^2.22.2",
         "path": "^0.12.7",
-        "restify": "^7.2.3"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "eslint": "^5.9.0",

--- a/samples/javascript_nodejs/17.multilingual-bot/package.json
+++ b/samples/javascript_nodejs/17.multilingual-bot/package.json
@@ -19,7 +19,7 @@
         "botbuilder": "~4.4.0",
         "dotenv": "^6.1.0",
         "node-fetch": "^2.2.1",
-        "restify": "^7.2.3"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "eslint": "^5.9.0",

--- a/samples/javascript_nodejs/18.bot-authentication/package.json
+++ b/samples/javascript_nodejs/18.bot-authentication/package.json
@@ -19,7 +19,7 @@
         "botbuilder": "~4.4.0",
         "botbuilder-dialogs": "~4.4.0",
         "dotenv": "^6.1.0",
-        "restify": "^7.2.3"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "eslint": "^5.9.0",

--- a/samples/javascript_nodejs/19.custom-dialogs/package.json
+++ b/samples/javascript_nodejs/19.custom-dialogs/package.json
@@ -19,7 +19,7 @@
         "botbuilder": "~4.4.0",
         "botbuilder-dialogs": "~4.4.0",
         "dotenv": "^6.1.0",
-        "restify": "^7.2.3"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "eslint": "^5.9.0",

--- a/samples/javascript_nodejs/23.facebook-events/package.json
+++ b/samples/javascript_nodejs/23.facebook-events/package.json
@@ -19,7 +19,7 @@
         "botbuilder": "~4.4.0",
         "botbuilder-dialogs": "~4.4.0",
         "dotenv": "^6.1.0",
-        "restify": "^7.2.3"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "eslint": "^5.9.0",

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/package.json
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/package.json
@@ -20,7 +20,7 @@
         "botbuilder": "~4.4.0",
         "botbuilder-dialogs": "~4.4.0",
         "dotenv": "^6.1.0",
-        "restify": "^7.2.3"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "eslint": "^5.9.0",

--- a/samples/javascript_nodejs/43.complex-dialog/package.json
+++ b/samples/javascript_nodejs/43.complex-dialog/package.json
@@ -15,7 +15,7 @@
         "botbuilder": "~4.4.0",
         "botbuilder-dialogs": "~4.4.0",
         "dotenv": "^6.2.0",
-        "restify": "^6.4.0"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "eslint": "^5.16.0",

--- a/samples/javascript_nodejs/44.prompt-for-user-input/package.json
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/package.json
@@ -15,7 +15,7 @@
         "@microsoft/recognizers-text-suite": "^1.1.4",
         "botbuilder": "~4.4.0",
         "dotenv": "^6.0.0",
-        "restify": "^6.3.4"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "eslint": "^5.6.0",

--- a/samples/javascript_nodejs/45.state-management/package.json
+++ b/samples/javascript_nodejs/45.state-management/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
         "botbuilder": "~4.4.0",
         "dotenv": "^6.2.0",
-        "restify": "^6.4.0"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "eslint": "^5.9.0",

--- a/samples/typescript_nodejs/00.empty-bot/package.json
+++ b/samples/typescript_nodejs/00.empty-bot/package.json
@@ -20,10 +20,10 @@
     "dependencies": {
         "botbuilder": "~4.4.0",
         "replace": "~1.1.0",
-        "restify": "8.2.0"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
-        "@types/restify": "7.2.9",
+        "@types/restify": "7.2.11",
         "nodemon": "~1.18.10",
         "tslint": "~5.14.0",
         "typescript": "~3.3.3"

--- a/samples/typescript_nodejs/02.echo-bot/package.json
+++ b/samples/typescript_nodejs/02.echo-bot/package.json
@@ -21,11 +21,11 @@
         "botbuilder": "~4.4.0",
         "dotenv": "^7.0.0",
         "replace": "~1.1.0",
-        "restify": "~8.2.0"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "@types/dotenv": "6.1.0",
-        "@types/restify": "7.2.9",
+        "@types/restify": "7.2.11",
         "nodemon": "~1.18.10",
         "tslint": "~5.14.0",
         "typescript": "~3.3.3"

--- a/samples/typescript_nodejs/13.core-bot/package.json
+++ b/samples/typescript_nodejs/13.core-bot/package.json
@@ -19,11 +19,11 @@
         "botbuilder-dialogs": "~4.4.0",
         "dotenv": "^7.0.0",
         "replace": "~1.1.0",
-        "restify": "~8.2.0"
+        "restify": "~8.3.3"
     },
     "devDependencies": {
         "@types/dotenv": "6.1.0",
-        "@types/restify": "7.2.9",
+        "@types/restify": "7.2.11",
         "nodemon": "~1.18.10",
         "tslint": "~5.14.0",
         "typescript": "~3.3.3"


### PR DESCRIPTION
## Proposed Changes
- Bump restify dependency to fix random gov-related errors when zip-deploying code 
  - Breaking changes from restify ^7.0.0 to [8.0.0](https://github.com/restify/node-restify/blob/master/CHANGELOG.md#800-2019-02-20) are dropped support for Node.js v4.x and Node.js v6.x

## Testing
Rebuilt samples, tested locally, and deployed echo, suggested actions and rich cards samples to Azure US Gov.