### PR TITLE
Change QnAAuthKey to QnAEndpointKey

### DIFF
--- a/experimental/qnamaker-prompting/csharp_dotnetcore/Helpers/QnAService.cs
+++ b/experimental/qnamaker-prompting/csharp_dotnetcore/Helpers/QnAService.cs
@@ -72,7 +72,7 @@ namespace QnAPrompting.Helpers
             var endpoint = new QnAMakerEndpoint
             {
                 KnowledgeBaseId = configuration["QnAKnowledgebaseId"],
-                EndpointKey = configuration["QnAAuthKey"],
+                EndpointKey = configuration["QnAEndpointKey"],
                 Host = hostname
             };
 

--- a/experimental/qnamaker-prompting/csharp_dotnetcore/README.md
+++ b/experimental/qnamaker-prompting/csharp_dotnetcore/README.md
@@ -11,7 +11,7 @@ In this sample, we demonstrate how to a create a multi-turn dialog to interact w
 
 #To try this sample
 - Clone the samples repository
-- Update [appsettings.json](appsettings.json) in the sample with your QnA Maker endpoint details (QnAEndpointHostName, QnAAuthKey and QnAKnowledgebaseId). You can find this
+- Update [appsettings.json](appsettings.json) in the sample with your QnA Maker endpoint details (QnAEndpointHostName, QnAEndpointKey and QnAKnowledgebaseId). You can find this
 information under "Settings" tab of your QnA Maker Knowledge Base at [QnAMaker.ai](https://www.qnamaker.ai)
 
 # Running Locally

--- a/experimental/qnamaker-prompting/csharp_dotnetcore/appsettings.json
+++ b/experimental/qnamaker-prompting/csharp_dotnetcore/appsettings.json
@@ -2,6 +2,6 @@
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
   "QnAEndpointHostName": "",
-  "QnAAuthKey": "",
+  "QnAEndpointKey": "",
   "QnAKnowledgebaseId": ""
 }

--- a/experimental/qnamaker-prompting/javascript_nodejs/.env
+++ b/experimental/qnamaker-prompting/javascript_nodejs/.env
@@ -1,5 +1,5 @@
 MicrosoftAppId=
 MicrosoftAppPassword=
 QnAEndpointHostName=
-QnAAuthKey=
+QnAEndpointKey=
 QnAKnowledgebaseId=

--- a/experimental/qnamaker-prompting/javascript_nodejs/README.md
+++ b/experimental/qnamaker-prompting/javascript_nodejs/README.md
@@ -11,7 +11,7 @@ In this sample, we demonstrate how to a create a multi-turn dialog to interact w
 
 #To try this sample
 - Clone the samples repository
-- Update [.env](.env) in the sample with your QnA Maker endpoint details (QnAEndpointHostName, QnAAuthKey and QnAKnowledgebaseId). You can find this
+- Update [.env](.env) in the sample with your QnA Maker endpoint details (QnAEndpointHostName, QnAEndpointKey and QnAKnowledgebaseId). You can find this
 information under "Settings" tab of your QnA Maker Knowledge Base at [QnAMaker.ai](https://www.qnamaker.ai)
 
 # Running Locally

--- a/experimental/qnamaker-prompting/javascript_nodejs/helpers/qnAServiceHelper.js
+++ b/experimental/qnamaker-prompting/javascript_nodejs/helpers/qnAServiceHelper.js
@@ -8,7 +8,7 @@ class QnAServiceHelper {
 
         const endpoint = process.env.QnAEndpointHostName;
         const kbId = process.env.QnAKnowledgebaseId;
-        const key = process.env.QnAAuthKey;
+        const key = process.env.QnAEndpointKey;
 
         const url =  `${ endpoint }/qnamaker/knowledgebases/${ kbId }/generateanswer`;
         const headers = {

--- a/samples/csharp_dotnetcore/11.qnamaker/Bots/QnABot.cs
+++ b/samples/csharp_dotnetcore/11.qnamaker/Bots/QnABot.cs
@@ -32,7 +32,7 @@ namespace Microsoft.BotBuilderSamples
             var qnaMaker = new QnAMaker(new QnAMakerEndpoint
             {
                 KnowledgeBaseId = _configuration["QnAKnowledgebaseId"],
-                EndpointKey = _configuration["QnAAuthKey"],
+                EndpointKey = _configuration["QnAEndpointKey"],
                 Host = _configuration["QnAEndpointHostName"]
             },
             null,

--- a/samples/csharp_dotnetcore/11.qnamaker/appsettings.json
+++ b/samples/csharp_dotnetcore/11.qnamaker/appsettings.json
@@ -2,6 +2,6 @@
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
   "QnAKnowledgebaseId": "",
-  "QnAAuthKey": "",
+  "QnAEndpointKey": "",
   "QnAEndpointHostName": ""
 }

--- a/samples/csharp_dotnetcore/14.nlp-with-dispatch/BotServices.cs
+++ b/samples/csharp_dotnetcore/14.nlp-with-dispatch/BotServices.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples
             SampleQnA = new QnAMaker(new QnAMakerEndpoint
             {
                 KnowledgeBaseId = configuration["QnAKnowledgebaseId"],
-                EndpointKey = configuration["QnAAuthKey"],
+                EndpointKey = configuration["QnAEndpointKey"],
                 Host = configuration["QnAEndpointHostName"]
             });
         }

--- a/samples/csharp_dotnetcore/14.nlp-with-dispatch/appsettings.json
+++ b/samples/csharp_dotnetcore/14.nlp-with-dispatch/appsettings.json
@@ -9,7 +9,7 @@
   "MicrosoftAppPassword": "",
  
   "QnAKnowledgebaseId": "",
-  "QnAAuthKey": "",
+  "QnAEndpointKey": "",
   "QnAEndpointHostName": "",
 
   "LuisAppId": "",

--- a/samples/javascript_nodejs/11.qnamaker/.env
+++ b/samples/javascript_nodejs/11.qnamaker/.env
@@ -1,5 +1,5 @@
 MicrosoftAppId=
 MicrosoftAppPassword=
 QnAKnowledgebaseId=
-QnAAuthKey=
+QnAEndpointKey=
 QnAEndpointHostName=

--- a/samples/javascript_nodejs/11.qnamaker/bots/QnABot.js
+++ b/samples/javascript_nodejs/11.qnamaker/bots/QnABot.js
@@ -18,7 +18,7 @@ class QnABot extends ActivityHandler {
         try {
             this.qnaMaker = new QnAMaker({
                 knowledgeBaseId: process.env.QnAKnowledgebaseId,
-                endpointKey: process.env.QnAAuthKey,
+                endpointKey: process.env.QnAEndpointKey,
                 host: process.env.QnAEndpointHostName
             });
         } catch (err) {

--- a/samples/javascript_nodejs/14.nlp-with-dispatch/.env
+++ b/samples/javascript_nodejs/14.nlp-with-dispatch/.env
@@ -2,7 +2,7 @@ MicrosoftAppId=
 MicrosoftAppPassword=
 
 QnAKnowledgebaseId=
-QnAAuthKey=
+QnAEndpointKey=
 QnAEndpointHostName=
 
 LuisAppId=

--- a/samples/javascript_nodejs/14.nlp-with-dispatch/bots/dispatchBot.js
+++ b/samples/javascript_nodejs/14.nlp-with-dispatch/bots/dispatchBot.js
@@ -26,7 +26,7 @@ class DispatchBot extends ActivityHandler {
 
         const qnaMaker = new QnAMaker({
             knowledgeBaseId: process.env.QnAKnowledgebaseId,
-            endpointKey: process.env.QnAAuthKey,
+            endpointKey: process.env.QnAEndpointKey,
             host: process.env.QnAEndpointHostName
         });
 


### PR DESCRIPTION


## Proposed Changes
The property is misnamed and leads the user to think they need a QnA key for authoring - which won't work. Changes are made to both documentation and code files. 

## Testing
Didn't find any test files to change - is there an automated test system?  
