### PR TITLE
Fix "language" typo and linting in experimental/language-generation/README.md

### DIFF
--- a/experimental/adaptive-dialog/csharp_dotnetcore/04.core-bot/README.md
+++ b/experimental/adaptive-dialog/csharp_dotnetcore/04.core-bot/README.md
@@ -63,7 +63,7 @@ This bot has been created using [Bot Framework][1], it shows how to:
 
 ## LUIS Setup
 ### Using LUIS portal
-- Navigate and sign in to [Luis.ai][5]
+- Navigate and sign in to [Luis.ai][11]
 - Under "My apps", click on "Import new app"
 - Click on "Choose app file (JSON format) ..."
 - Select `botbuilder-samples/experimental/adaptive-dialog/csharp_dotnetcore/13.core-bot/CognitiveModels/CoreBot.luis.json
@@ -75,8 +75,8 @@ This bot has been created using [Bot Framework][1], it shows how to:
     - You can get your application id and endpoint region by following instructions [here][10]
 
 ### Using CLI
-- Install [nodejs][8] version 8.5 or higher
-- Install [botbuilder-tools][7] CLI
+- Install [nodejs][2] version 8.5 or higher
+- Install [botbuilder-tools][3] CLI
 ```bash
 > npm i -g ludown luis-apis
 ```
@@ -97,13 +97,10 @@ This bot has been created using [Bot Framework][1], it shows how to:
 ```
 
 [1]: https://dev.botframework.com
-[2]: https://azure.microsoft.com/free/
+[2]: https://nodejs.org/en/download/
 [3]: https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest
 [4]: https://dotnet.microsoft.com/download
-[5]: https://github.com/microsoft/botframework-emulator
 [6]: https://github.com/Microsoft/BotFramework-Emulator/releases
-[7]: https://docs.microsoft.com/cli/azure/?view=azure-cli-latest
-[8]: https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest
 [9]: https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-how-to-account-settings
 [10]: https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-reference-regions
 [11]: https://www.luis.ai

--- a/experimental/language-generation/README.md
+++ b/experimental/language-generation/README.md
@@ -1,11 +1,13 @@
 # Language Generation ***_[PREVIEW]_***
+
 Learning from our customers experiences and bringing together capabilities first implemented by Cortana and Cognition teams, we are introducing Language Generation; which allows the developer to extract the embedded strings from their code and resource files and manage them through a Language Generation runtime and file format.  Language Generation enable customers to define multiple variations on a phrase, execute simple expressions based on context, refer to conversational memory, and over time will enable us to bring additional capabilities all leading to a more natural conversational experience.
 
 At the core of language generation lies template expansion and entity substitution. You can provide one-of variation for expansion as well as conditionally expand a template. The output from language generation can be a simple text string or multi-line response or a complex object payload that a layer above language generation will use to construct a full blown [activity][1].
 
-Language generation is achieved through 
+Language generation is achieved through:
+
 - markdown based .lg file that describes the templates and their composition. See [here][3] for the .lg file format.
-- full access to current bots memory so you can data bind langauge to the state of memory.
+- full access to current bots memory so you can data bind language to the state of memory.
 - parser and runtime libraries that help achieve runtime resolution. See [here][2] for API-reference.
 
 ```markdown
@@ -15,17 +17,19 @@ Language generation is achieved through
 - Good day {user.name}. What can I do for you today?
 ```
 
-You can use language generation to 
+You can use language generation to:
+
 - achieve a coherent personality, tone of voice for your bot
 - separate business logic from presentation
 - include variations and sophisticated composition based resolution for any of your bot's replies
 - construct speak .vs. display adaptations
-- construct cards, suggested actions and attachments. 
+- construct cards, suggested actions and attachments.
 
 ## Speak .vs. display adaptation
-By design, the .lg file format does not explicitly support the ability to provide speak .vs. display adaptation. The file format supports simple constructs that are composable and supports resolution on multi-line text and so you can have syntax and semantics for speak .vs. display adaptation, cards, suggested actions etc that can be interpreted as simple text and transformed into the Bot Framework [activity][1] by a layer above language generation. 
 
-Bot Builder SDK supports a short hand notation that can parse and transform a piece of text separated by `displayText`||`spokenText` into speak and display text. 
+By design, the .lg file format does not explicitly support the ability to provide speak .vs. display adaptation. The file format supports simple constructs that are composable and supports resolution on multi-line text and so you can have syntax and semantics for speak .vs. display adaptation, cards, suggested actions etc that can be interpreted as simple text and transformed into the Bot Framework [activity][1] by a layer above language generation.
+
+Bot Builder SDK supports a short hand notation that can parse and transform a piece of text separated by `displayText`||`spokenText` into speak and display text.
 
 ```markdown
 # greetingTemplate
@@ -39,16 +43,16 @@ You can use the `TextMessageActivityGenerator.CreateActityFromText` method to tr
 
 [Chatdown][6] introduced a simple markdown based way to write mock conversations. Also introduced as part of the [.chat][7] file format was the ability to express different [message commands][9] via simple text representation. Message commands include [cards][10], [Attachments][11] and suggested actions.
 
-You can include message commands via multi-line text in the .lg file format and use the `TextMessageActivityGenerator.CreateActityFromText` method to transform the command into a Bot Framework activity to post back to the user. 
+You can include message commands via multi-line text in the .lg file format and use the `TextMessageActivityGenerator.CreateActityFromText` method to transform the command into a Bot Framework activity to post back to the user.
 
-See [here][8] for examples of how different card types are represented in .chat file format. 
+See [here][8] for examples of how different card types are represented in .chat file format.
 
 Here is an example of a card definition.
 
 ```markdown
     # HeroCardTemplate(buttonsCollection)
     - ```
-    [Herocard   
+    [Herocard
         title=@{[TitleText]}
         subtitle=@{[SubText]}
         text=@{[DescriptionText]}
@@ -65,10 +69,10 @@ Here is an example of a card definition.
     - nice snaps
 
     # SubText
-    - What is your favorite? 
+    - What is your favorite?
     - Don't they all look great?
     - sorry, some of them are repeats
-    
+
     # DescriptionText
     - This is description for the hero card
 
@@ -79,56 +83,63 @@ Here is an example of a card definition.
 ```
 
 ## Language Generation in action
-When building a bot, you can use language generation in several different ways. To start with, examine your current bot's code (or the new bot you plan to write) and create [.lg file][3] to cover all possible scenarios where you would like to use the language generation sub-system with your bot's replies to user. 
 
-Then make sure you include the platform specific language generation library. 
+When building a bot, you can use language generation in several different ways. To start with, examine your current bot's code (or the new bot you plan to write) and create [.lg file][3] to cover all possible scenarios where you would like to use the language generation sub-system with your bot's replies to user.
 
-For C#, add Microsoft.Bot.Builder.LanguageGeneration. 
+Then make sure you include the platform specific language generation library.
+
+For C#, add Microsoft.Bot.Builder.LanguageGeneration.
 For NodeJS, add botbuilder-lg
 
 Load the template manager with your .lg file(s)
 
 For C#
-```
-    TemplateEngine lgEngine = TemplateEngine.FromFiles(pathToLGFile); 
+
+```c#
+    TemplateEngine lgEngine = TemplateEngine.FromFiles(pathToLGFile);
 ```
 
 For NodeJS
-```
+
+```node
     let lgEngine = templateEngine.fromFiles(pathToLGFile);
 ```
 
 When you need template expansion, call the templateEngine and pass in the relevant template name
 
 For C#
-```
+
+```c#
     await turnContext.SendActivityAsync(lgEngine.EvaluateTemplate("<TemplateName>", entitiesCollection));
 ```
 
 For NodeJS
-```
+
+```node
     await turnContext.sendActivity(lgEngine.evaluateTemplate("<TemplateName>", entitiesCollection));
 ```
 
 If your template needs specific entity values to be passed for resolution/ expansion, you can pass them in on the call to `evaluateTemplate`
 
 For C#
-```
+
+```c#
     await turnContext.SendActivityAsync(lgEngine.EvaluateTemplate("WordGameReply", new { GameName = "MarcoPolo" } ));
 
 ```
 
 For NodeJS
-```
+
+```node
     await turnContext.sendActivity(lgEngine.evaluateTemplate("WordGameReply", { GameName = "MarcoPolo" } ));
 ```
 
-
-
 ## Grammar check and correction
-The current library does not include any capabilities for grammar check or correction. 
+
+The current library does not include any capabilities for grammar check or correction.
 
 ## Packages
+
 Packages for C# are available under the [BotBuilder MyGet feed][12]
 
 [1]:https://github.com/Microsoft/BotBuilder/blob/master/specs/botframework-activity/botframework-activity.md


### PR DESCRIPTION
Fixes #1598 