### PR TITLE
Add Experimental AdaptiveCardPrompt Sample

### DIFF
--- a/experimental/adaptive-card-prompt-sample/dotnet/AdapterWithErrorHandler.cs
+++ b/experimental/adaptive-card-prompt-sample/dotnet/AdapterWithErrorHandler.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.BotBuilderSamples
+{
+    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    {
+        public AdapterWithErrorHandler(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger, ConversationState conversationState = null)
+            : base(configuration, logger)
+        {
+            OnTurnError = async (turnContext, exception) =>
+            {
+                // Log any leaked exception from the application.
+                logger.LogError($"Exception caught : {exception.Message}");
+
+                // Send a catch-all apology to the user.
+                await turnContext.SendActivityAsync("Sorry, it looks like something went wrong.");
+
+                if (conversationState != null)
+                {
+                    try
+                    {
+                        // Delete the conversationState for the current conversation to prevent the
+                        // bot from getting stuck in a error-loop caused by being in a bad state.
+                        // ConversationState should be thought of as similar to "cookie-state" in a Web pages.
+                        await conversationState.DeleteAsync(turnContext);
+                    }
+                    catch (Exception e)
+                    {
+                        logger.LogError($"Exception caught on attempting to Delete ConversationState : {e.Message}");
+                    }
+                }
+            };
+        }
+    }
+}

--- a/experimental/adaptive-card-prompt-sample/dotnet/AdaptiveCardPrompt.cs
+++ b/experimental/adaptive-card-prompt-sample/dotnet/AdaptiveCardPrompt.cs
@@ -1,0 +1,294 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Bot.Builder.Dialogs
+{
+    /// <summary>
+    /// Waits for Adaptive Card Input to be received.
+    /// </summary>
+    /// <remarks>
+    /// This prompt is similar to ActivityPrompt but provides features specific to Adaptive Cards:
+    ///   * Card can be passed in constructor or as prompt/reprompt activity attachment
+    ///   * Includes validation for specified required input fields
+    ///   * Displays custom message if user replies via text and not card input
+    ///   * Ensures input is only valid if it comes from the appropriate card (not one shown previous to prompt)
+    /// DO NOT USE WITH CHANNELS THAT DON'T SUPPORT ADAPTIVE CARDS.
+    /// </remarks>
+    public class AdaptiveCardPrompt : Dialog
+    {
+        private const string PersistedOptions = "options";
+        private const string PersistedState = "state";
+        private bool usesCustomPromptId = false;
+
+        private PromptValidator<object> _validator;
+        private string _promptId;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AdaptiveCardPrompt"/> class.
+        /// </summary>
+        /// <param name="dialogId">Unique ID of the dialog within its parent `DialogSet` or `ComponentDialog`.</param>
+        /// <param name="validator">(optional) Validator that will be called each time a new activity is received.</param>
+        /// <param name="settings">(optional) Additional settings for AdaptiveCardPrompt behavior.</param>
+        public AdaptiveCardPrompt(string dialogId, PromptValidator<object> validator = null, AdaptiveCardPromptSettings settings = null)
+            : base(dialogId)
+        {
+            if (settings == null)
+            {
+                settings = new AdaptiveCardPromptSettings();
+            }
+
+            this._validator = validator;
+            InputFailMessage = settings.InputFailMessage ?? "Please fill out the Adaptive Card";
+
+            RequiredInputIds = settings.RequiredInputIds ?? new List<string>();
+            MissingRequiredInputsMessage = settings.MissingRequiredInputsMessage ?? "The following inputs are required";
+
+            AttemptsBeforeCardRedisplayed = settings.AttemptsBeforeCardRedisplayed ?? 3;
+
+            Card = settings.Card;
+
+            if (!string.IsNullOrEmpty(settings.PromptId))
+            {
+                _promptId = settings.PromptId;
+                usesCustomPromptId = true;
+            }
+        }
+
+        public string PromptId
+        {
+            get
+            {
+                return _promptId;
+            }
+
+            set
+            {
+                usesCustomPromptId = true;
+                _promptId = value;
+            }
+        }
+
+        private string InputFailMessage { get; set; }
+
+        private List<string> RequiredInputIds { get; set; }
+
+        private string MissingRequiredInputsMessage { get; set; }
+
+        private int? AttemptsBeforeCardRedisplayed { get; set; }
+
+        private Attachment Card { get; set; }
+
+        public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Initialize prompt state
+            var state = dc.ActiveDialog.State;
+            state[PersistedOptions] = options;
+            state[PersistedState] = new Dictionary<string, object>
+            {
+                { Prompt<int>.AttemptCountKey, 0 },
+            };
+
+            // Send initial prompt
+            await OnPromptAsync(dc.Context, (IDictionary<string, object>)state[PersistedState], (PromptOptions)state[PersistedOptions], false, cancellationToken).ConfigureAwait(false);
+
+            return Dialog.EndOfTurn;
+        }
+
+        // Override ContinueDialogAsync so that we can catch Activity.Value (which is ignored, by default)
+        public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken)
+        {
+            // Perform base recognition
+            var instance = dc.ActiveDialog;
+            var state = (IDictionary<string, object>)instance.State[PersistedState];
+            var options = (PromptOptions)instance.State[PersistedOptions];
+            var recognized = await OnRecognizeAsync(dc.Context, cancellationToken).ConfigureAwait(false);
+
+            // Increment attempt count
+            // Convert.ToInt32 For issue https://github.com/Microsoft/botbuilder-dotnet/issues/1859
+            state[Prompt<int>.AttemptCountKey] = Convert.ToInt32(state[Prompt<int>.AttemptCountKey]) + 1;
+
+            var isValid = false;
+            if (_validator != null && recognized.Succeeded)
+            {
+                var promptContext = new PromptValidatorContext<object>(dc.Context, recognized, state, options);
+                isValid = await _validator(promptContext, cancellationToken).ConfigureAwait(false);
+            }
+            else if (recognized.Succeeded)
+            {
+                isValid = true;
+            }
+
+            // Return recognized value or re-prompt
+            if (isValid)
+            {
+                return await dc.EndDialogAsync(recognized.Value).ConfigureAwait(false);
+            }
+            else
+            {
+                // Re-prompt, conditionally display card again
+                if (Convert.ToInt32(state[Prompt<int>.AttemptCountKey]) % AttemptsBeforeCardRedisplayed == 0)
+                {
+                    await OnPromptAsync(dc.Context, state, options, true, cancellationToken).ConfigureAwait(false);
+                }
+
+                return Dialog.EndOfTurn;
+            }
+        }
+
+        protected virtual async Task OnPromptAsync(ITurnContext context, IDictionary<string, object> state, PromptOptions options, bool isRetry, CancellationToken cancellationToken)
+        {
+            // Only the most recently-promted card submission is acccepted
+            _promptId = usesCustomPromptId ? _promptId : Guid.NewGuid().ToString();
+
+            var prompt = isRetry && options.RetryPrompt != null ? options.RetryPrompt : options.Prompt;
+
+            // Create a prompt if user didn't pass it in through PromptOptions
+            if (prompt == null || prompt.Attachments.Count == 0)
+            {
+                prompt = MessageFactory.Text(!string.IsNullOrEmpty(prompt.Text) ? prompt.Text : string.Empty);
+                prompt.Attachments = new List<Attachment>();
+            }
+
+            // Use card passed into PromptOptions or if it doesn't exist, use the one passed in from the constructor
+            var card = prompt.Attachments.Count > 0 ? prompt.Attachments[0] : Card;
+
+            ValidateIsCard(card, isRetry);
+
+            prompt.Attachments.Insert(0, AddPromptIdToCard(card));
+
+            await context.SendActivityAsync(prompt, cancellationToken).ConfigureAwait(false);
+        }
+
+        protected virtual async Task<PromptRecognizerResult<object>> OnRecognizeAsync(ITurnContext context, CancellationToken cancellationToken)
+        {
+            // Ignore user input that doesn't come from adaptive card
+            if (string.IsNullOrWhiteSpace(context.Activity.Text) && context.Activity.Value != null)
+            {
+                var value = JObject.FromObject(context.Activity.Value);
+
+                // Validate it comes from the correct card - This is only a worry while the prompt/dialog has not ended
+                if (value["promptId"].ToString() != _promptId)
+                {
+                    return new PromptRecognizerResult<object>() { Succeeded = false };
+                }
+
+                // Check for required input data, if specified in AdpativeCardPromptOptions
+                var missingIds = new List<string>();
+                foreach (var id in RequiredInputIds)
+                {
+                    if (value[id] == null || string.IsNullOrWhiteSpace(value[id].ToString()))
+                    {
+                        missingIds.Add(id);
+                    }
+                }
+
+                // Alert user to missing data
+                if (missingIds.Count > 0)
+                {
+                    if (!string.IsNullOrWhiteSpace(MissingRequiredInputsMessage))
+                    {
+                        await context.SendActivityAsync($"{MissingRequiredInputsMessage}: {string.Join(", ", missingIds)}", cancellationToken: cancellationToken).ConfigureAwait(false);
+                    }
+
+                    return new PromptRecognizerResult<object>() { Succeeded = false };
+                }
+
+                return new PromptRecognizerResult<object>() { Succeeded = true, Value = context.Activity.Value };
+            }
+            else
+            {
+                if (!string.IsNullOrWhiteSpace(InputFailMessage))
+                {
+                    await context.SendActivityAsync(InputFailMessage, cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+
+                return new PromptRecognizerResult<object>() { Succeeded = false };
+            }
+        }
+
+        private void ValidateIsCard(Attachment card, bool isRetry)
+        {
+            var adaptiveCardType = "application/vnd.microsoft.card.adaptive";
+
+            if (card == null || card.Content == null)
+            {
+                var cardLocation = isRetry ? "retryPrompt" : "prompt";
+                throw new NullReferenceException($"No Adaptive Card provided. Include in the constructor or PromptOptions.{cardLocation}.Attachments[0]");
+            }
+            else if (string.IsNullOrEmpty(card.ContentType) || card.ContentType != adaptiveCardType)
+            {
+                throw new ArgumentException($"Attachment is not a valid Adaptive Card.\n" +
+                                    "Ensure card.contentType is '${ adaptiveCardType }'\n" +
+                                    "and card.content contains the card json");
+            }
+        }
+
+        private Attachment AddPromptIdToCard(Attachment card)
+        {
+            card.Content = DeepSearchJsonForActionsAndAddPromptId((JObject)card.Content);
+            return card;
+        }
+
+        private JObject DeepSearchJsonForActionsAndAddPromptId(JObject json)
+        {
+            var submitAction = "Action.Submit";
+            var showCardAction = "Action.ShowCard";
+
+            foreach (var obj in json)
+            {
+                // Search for all submits in actions
+                if (obj.Key == "actions")
+                {
+                    // Must convert json to list so that we can make changes to it
+                    var i = 0;
+                    foreach (var action in (obj.Value as JArray).ToObject<List<JObject>>())
+                    {
+                        if (!string.IsNullOrWhiteSpace(action["type"].ToString()) && action["type"].ToString() == submitAction)
+                        {
+                            // Make changes to original json, not the created list
+                            json[obj.Key][i]["data"] = json[obj.Key][i]["data"] ?? new JObject();
+                            json[obj.Key][i]["data"]["promptId"] = _promptId;
+
+                            // Recursively search Action.ShowCard for Submits within the nested card
+                        }
+                        else if (!string.IsNullOrWhiteSpace(action["type"].ToString()) && action["type"].ToString() == showCardAction)
+                        {
+                            json[obj.Key][i] = DeepSearchJsonForActionsAndAddPromptId(action);
+                        }
+
+                        i++;
+                    }
+                }
+
+                // Search for all submits in selectActions
+                else if (obj.Key == "selectAction")
+                {
+                    if (!string.IsNullOrWhiteSpace(obj.Value["type"].ToString()) && obj.Value["type"].ToString() == submitAction)
+                    {
+                        json[obj.Key]["data"] = obj.Value["data"] ?? new JObject();
+                        json[obj.Key]["data"]["promptId"] = _promptId;
+                    }
+
+                    // Recursively search Action.ShowCard for Submits within the nested card
+                    if (!string.IsNullOrWhiteSpace(obj.Value["type"].ToString()) && obj.Value["type"].ToString() == showCardAction)
+                    {
+                        json[obj.Key] = DeepSearchJsonForActionsAndAddPromptId(obj.Value as JObject);
+                    }
+                }
+
+                // Recursively search all other objects
+                else if (!string.IsNullOrWhiteSpace(obj.Value.ToString()) && obj.Value is JObject)
+                {
+                    json[obj.Key] = DeepSearchJsonForActionsAndAddPromptId(obj.Value as JObject);
+                }
+            }
+
+            return json;
+        }
+    }
+}

--- a/experimental/adaptive-card-prompt-sample/dotnet/AdaptiveCardPromptBot.csproj
+++ b/experimental/adaptive-card-prompt-sample/dotnet/AdaptiveCardPromptBot.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.4.5" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.4.5" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.1.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+</Project>

--- a/experimental/adaptive-card-prompt-sample/dotnet/AdaptiveCardPromptSettings.cs
+++ b/experimental/adaptive-card-prompt-sample/dotnet/AdaptiveCardPromptSettings.cs
@@ -1,0 +1,90 @@
+﻿using System.Collections.Generic;
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.Bot.Builder.Dialogs
+{
+    /// <summary>
+    /// Settings to control the behavior of AdaptiveCardPrompt.
+    /// </summary>
+    public class AdaptiveCardPromptSettings
+    {
+        /// <summary>
+        /// Gets or sets the card to send the user.
+        /// </summary>
+        /// <value>
+        /// An Adaptive Card. Can be input here or in constructor.
+        /// </value>
+        public Attachment Card { get; set; }
+
+        /// <summary>
+        /// Gets or sets the message sent (if not null) when user uses text input instead of Adaptive Card Input.
+        /// </summary>
+        /// <value>
+        /// The message sent (if not null) when user uses text input instead of Adaptive Card Input.
+        /// </value>
+        /// <remarks>
+        /// Defaults to: 'Please fill out the Adaptive Card'.
+        /// </remarks>
+        public string InputFailMessage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the array of strings matching IDs of required input fields.
+        /// </summary>
+        /// <value>
+        /// The message sent (if not null) when user uses text input instead of Adaptive Card Input.
+        /// </value>
+        /// <remarks>
+        /// The ID strings must exactly match those used in the Adaptive Card JSON Input IDs
+        /// For JSON:
+        /// ```json
+        /// {
+        ///   "type": "Input.Text",
+        ///   "id": "myCustomId",
+        /// },
+        /// ```
+        ///   You would use `"myCustomId"` if you want that to be a required input.
+        /// </remarks>
+        public List<string> RequiredInputIds { get; set; }
+
+        /// <summary>
+        /// Gets or sets the message sent (if not null) when user doesn't submit a required input.
+        /// </summary>
+        /// <value>
+        /// The message sent (if not null) when user doesn't submit a required input.
+        /// <Each, Missing, Input> gets appended to the end of the string
+        /// </value>
+        /// <remarks>
+        /// Defaults to: The following inputs are required'
+        /// </remarks>
+        public string MissingRequiredInputsMessage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of attempts before the card is redisplayed/re-prompted.
+        /// </summary>
+        /// <value>
+        /// The number of attempts before the card is redisplayed/re-prompted.
+        /// </value>
+        /// <remarks>
+        /// Card will not be redisplayed/re-prompted unless:
+        ///   * PromptOptions includes a retryPrompt with a card, or
+        ///   * Number of attempts per displayed card equals this value
+        /// This is meant to prevent the user from providing input to the original,
+        ///   and not the re-prompted card.
+        /// Defaults to 3.
+        /// </remarks>
+        public int? AttemptsBeforeCardRedisplayed { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ID specific to this prompt.
+        /// </summary>
+        /// <value>
+        /// The ID specific to this prompt.
+        /// </value>
+        /// <remarks>
+        /// Card input is only accepted if SubmitAction.data.promptId matches the promptId.
+        /// This is set to a random GUID and randomizes again on reprompts by default.
+        ///   If set manually, will not change between reprompts.
+        /// </remarks>
+        public string PromptId { get; set; }
+    }
+}

--- a/experimental/adaptive-card-prompt-sample/dotnet/Bots/DialogAndWelcome.cs
+++ b/experimental/adaptive-card-prompt-sample/dotnet/Bots/DialogAndWelcome.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.BotBuilderSamples
+{
+    public class DialogAndWelcomeBot<T> : DialogBot<T> where T : Dialog
+    {
+        public DialogAndWelcomeBot(ConversationState conversationState, UserState userState, T dialog, ILogger<DialogBot<T>> logger)
+            : base(conversationState, userState, dialog, logger)
+        {
+        }
+
+        protected override async Task OnMembersAddedAsync(
+            IList<ChannelAccount> membersAdded,
+            ITurnContext<IConversationUpdateActivity> turnContext,
+            CancellationToken cancellationToken)
+        {
+            foreach (var member in membersAdded)
+            {
+                // Greet anyone that was not the target (recipient) of this message.
+                // To learn more about Adaptive Cards, see https://aka.ms/msbot-adaptivecards for more details.
+                if (member.Id != turnContext.Activity.Recipient.Id)
+                {
+                    var reply = MessageFactory.Text($"Welcome to Complex Dialog Bot {member.Name}. " +
+                        "This bot provides a complex conversation, with multiple dialogs. " +
+                        "Type anything to get started.");
+                    await turnContext.SendActivityAsync(reply, cancellationToken);
+                }
+            }
+        }
+    }
+}

--- a/experimental/adaptive-card-prompt-sample/dotnet/Bots/DialogBot.cs
+++ b/experimental/adaptive-card-prompt-sample/dotnet/Bots/DialogBot.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.BotBuilderSamples
+{
+    // This IBot implementation can run any type of Dialog. The use of type parameterization is to allows multiple different bots
+    // to be run at different endpoints within the same project. This can be achieved by defining distinct Controller types
+    // each with dependency on distinct IBot types, this way ASP Dependency Injection can glue everything together without ambiguity.
+    // The ConversationState is used by the Dialog system. The UserState isn't, however, it might have been used in a Dialog implementation,
+    // and the requirement is that all BotState objects are saved at the end of a turn.
+    public class DialogBot<T> : ActivityHandler where T : Dialog
+    {
+        protected readonly BotState ConversationState;
+        protected readonly Dialog Dialog;
+        protected readonly ILogger Logger;
+        protected readonly BotState UserState;
+
+        public DialogBot(ConversationState conversationState, UserState userState, T dialog, ILogger<DialogBot<T>> logger)
+        {
+            ConversationState = conversationState;
+            UserState = userState;
+            Dialog = dialog;
+            Logger = logger;
+        }
+
+        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await base.OnTurnAsync(turnContext, cancellationToken);
+
+            // Save any state changes that might have occured during the turn.
+            await ConversationState.SaveChangesAsync(turnContext, false, cancellationToken);
+            await UserState.SaveChangesAsync(turnContext, false, cancellationToken);
+        }
+
+        protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
+        {
+            Logger.LogInformation("Running dialog with Message Activity.");
+
+            // Run the Dialog with the new message Activity.
+            await Dialog.Run(turnContext, ConversationState.CreateProperty<DialogState>(nameof(DialogState)), cancellationToken);
+        }
+    }
+}

--- a/experimental/adaptive-card-prompt-sample/dotnet/Controllers/BotController.cs
+++ b/experimental/adaptive-card-prompt-sample/dotnet/Controllers/BotController.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+
+namespace Microsoft.BotBuilderSamples
+{
+    // This ASP Controller is created to handle a request. Dependency Injection will provide the Adapter and IBot
+    // implementation at runtime. Multiple different IBot implementations running at different endpoints can be
+    // achieved by specifying a more specific type for the bot constructor argument.
+    [Route("api/messages")]
+    [ApiController]
+    public class BotController : ControllerBase
+    {
+        private readonly IBotFrameworkHttpAdapter _adapter;
+        private readonly IBot _bot;
+
+        public BotController(IBotFrameworkHttpAdapter adapter, IBot bot)
+        {
+            _adapter = adapter;
+            _bot = bot;
+        }
+
+        [HttpPost]
+        public async Task PostAsync()
+        {
+            // Delegate the processing of the HTTP POST to the adapter.
+            // The adapter will invoke the bot.
+            await _adapter.ProcessAsync(Request, Response, _bot);
+        }
+    }
+}

--- a/experimental/adaptive-card-prompt-sample/dotnet/DialogExtensions.cs
+++ b/experimental/adaptive-card-prompt-sample/dotnet/DialogExtensions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+
+namespace Microsoft.BotBuilderSamples
+{
+    public static class DialogExtensions
+    {
+        public static async Task Run(this Dialog dialog, ITurnContext turnContext, IStatePropertyAccessor<DialogState> accessor, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var dialogSet = new DialogSet(accessor);
+            dialogSet.Add(dialog);
+
+            var dialogContext = await dialogSet.CreateContextAsync(turnContext, cancellationToken);
+            var results = await dialogContext.ContinueDialogAsync(cancellationToken);
+            if (results.Status == DialogTurnStatus.Empty)
+            {
+                await dialogContext.BeginDialogAsync(dialog.Id, null, cancellationToken);
+            }
+        }
+    }
+}

--- a/experimental/adaptive-card-prompt-sample/dotnet/Dialogs/AdaptiveCardDialog.cs
+++ b/experimental/adaptive-card-prompt-sample/dotnet/Dialogs/AdaptiveCardDialog.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Linq;
+using System;
+
+namespace Microsoft.BotBuilderSamples
+{
+    public class AdaptiveCardDialog : ComponentDialog
+    {
+
+        public AdaptiveCardDialog()
+            : base(nameof(AdaptiveCardDialog))
+        {
+            var adaptiveCardPrompt = new AdaptiveCardPrompt(nameof(AdaptiveCardPrompt));
+
+            AddDialog(adaptiveCardPrompt);
+
+            AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[]
+            {
+                ShowCardAsync,
+                DisplayResultsAsync
+            }));
+
+            InitialDialogId = nameof(WaterfallDialog);
+        }
+
+        private static async Task<DialogTurnResult> ShowCardAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            var cardPath = Path.Combine("../Resources/", "adaptiveCard.json");
+            var cardJson = File.ReadAllText(cardPath);
+            var cardAttachment = new Attachment()
+            {
+                ContentType = "application/vnd.microsoft.card.adaptive",
+                Content = JsonConvert.DeserializeObject(cardJson),
+            };
+
+            var promptSettings = new AdaptiveCardPromptSettings()
+            {
+                Card = cardAttachment
+            };
+
+            // Call the prompt
+            return await stepContext.PromptAsync(nameof(AdaptiveCardPrompt), new PromptOptions()
+            {
+                Prompt = new Activity { Attachments = new List<Attachment>() { cardAttachment } }
+            });
+            
+        }
+
+        private async Task<DialogTurnResult> DisplayResultsAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            // Use the result
+            var result = stepContext.Result as JObject;
+            var resultArray = result.Properties().Select(p => $"Key: {p.Name}  |  Value: {p.Value}").ToList();
+            var resultString = string.Join("\n", resultArray);
+
+            return await stepContext.EndDialogAsync();
+        }
+    }
+}

--- a/experimental/adaptive-card-prompt-sample/dotnet/Dialogs/MainDialog.cs
+++ b/experimental/adaptive-card-prompt-sample/dotnet/Dialogs/MainDialog.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+
+namespace Microsoft.BotBuilderSamples
+{
+    public class MainDialog : ComponentDialog
+    {
+        public MainDialog()
+            : base(nameof(MainDialog))
+        {
+            AddDialog(new AdaptiveCardDialog());
+
+            AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[]
+            {
+                InitialStepAsync,
+                FinalStepAsync,
+            }));
+
+            InitialDialogId = nameof(WaterfallDialog);
+        }
+
+        private async Task<DialogTurnResult> InitialStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            return await stepContext.BeginDialogAsync(nameof(AdaptiveCardDialog), null, cancellationToken);
+        }
+
+        private async Task<DialogTurnResult> FinalStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            return await stepContext.EndDialogAsync(null, cancellationToken);
+        }
+    }
+}

--- a/experimental/adaptive-card-prompt-sample/dotnet/Program.cs
+++ b/experimental/adaptive-card-prompt-sample/dotnet/Program.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.BotBuilderSamples
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .ConfigureLogging((logging) =>
+                {
+                    logging.AddDebug();
+                    logging.AddConsole();
+                })
+                .UseStartup<Startup>();
+    }
+}

--- a/experimental/adaptive-card-prompt-sample/dotnet/Properties/launchSettings.json
+++ b/experimental/adaptive-card-prompt-sample/dotnet/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:3978/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "ComplexDialog": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:3978/"
+    }
+  }
+}

--- a/experimental/adaptive-card-prompt-sample/dotnet/README.md
+++ b/experimental/adaptive-card-prompt-sample/dotnet/README.md
@@ -3,7 +3,7 @@
 Bot Framework v4 Adaptive Card Prompt Sample
 
 // TODO: Update AdaptiveCardPrompt link once in SDK
-This bot has been created using [Bot Framework](https://dev.botframework.com), it shows how to use the new [AdaptiveCardPrompt](https://github.com/mdrichardson/botbuilder-js/blob/adaptiveCardPrompt/libraries/botbuilder-dialogs/src/prompts/adaptiveCardPrompt.ts) to gather data in a dialog.
+This bot has been created using [Bot Framework](https://dev.botframework.com), it shows how to use the new [AdaptiveCardPrompt](https://github.com/mdrichardson/botbuilder-dotnet/blob/adaptiveCardPrompt/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/AdaptiveCardPrompt.cs) to gather data in a dialog.
 
 ## AdaptiveCardPrompt Features
 
@@ -13,26 +13,27 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Usage
 
-```js
+```csharp
 // Load an adaptive card
 const cardJson = require('./adaptiveCard.json');
 const card = CardFactory.adaptiveCard(cardJson);
 
+// TODO: Verify
 // Configure settings - All optional
-const promptSettings = {
-    card: card,
-    inputFailMessage: 'Please fill out the adaptive card',
-    requiredInputIds: [
+var promptSettings = new AdaptiveCardPromptSettings() {
+    Card: card,
+    InputFailMessage: 'Please fill out the adaptive card',
+    RequiredInputIds: [
         'inputA',
         'inputB',
     ],
-    missingRequiredInputsMessage: 'The following inputs are required',
-    attemptsBeforeCardRedsiplayed: 5,
-    promptId: 'myCustomId'
+    MissingRequiredInputsMessage: 'The following inputs are required',
+    AttemptsBeforeCardRedsiplayed: 5,
+    PromptId: 'myCustomId'
 }
 
 // Initialize the prompt
-const adaptiveCardPrompt = new AdaptiveCardPrompt('adaptiveCardPrompt', null, promptSettings);
+var adaptiveCardPrompt = new AdaptiveCardPrompt('adaptiveCardPrompt', null, promptSettings);
 
 // Add the prompt to your dialogs
 dialogSet.add(adaptiveCardPrompt);
@@ -46,12 +47,12 @@ const result = stepContext.result;
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [.NET Core SDK](https://dotnet.microsoft.com/download) version 2.1
 
-    ```bash
-    # determine node version
-    node --version
-    ```
+  ```bash
+  # determine dotnet version
+  dotnet --version
+  ```
 
 ## To try this sample
 
@@ -61,24 +62,24 @@ const result = stepContext.result;
     git clone https://github.com/Microsoft/botbuilder-samples.git
     ```
 
-// TODO: Update this line
-- In a terminal, navigate to `samples/javascript_nodejs/07.using-adaptive-cards`
+- In a terminal, navigate to `samples/csharp_dotnetcore/07.using-adaptive-cards`
+- Run the bot from a terminal or from Visual Studio, choose option A or B.
 
-    ```bash
-    cd samples/javascript_nodejs/07.using-adaptive-cards
-    ```
+  A) From a terminal
 
-- Install modules
+  ```bash
+  # run the bot
+  dotnet run
+  ```
 
-    ```bash
-    npm install
-    ```
+  // TODO: Change if published
+  B) Or from Visual Studio
 
-- Start the bot
-
-    ```bash
-    npm start
-    ```
+  - Launch Visual Studio
+  - File -> Open -> Project/Solution
+  - Navigate to `samples/csharp_dotnetcore/XX.adaptive-card-prompt` folder
+  - Select `AdaptiveCardPromptBot.csproj` file
+  - Press `F5` to run the project
 
 ## Testing the bot using Bot Framework Emulator
 
@@ -135,5 +136,8 @@ To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](htt
 - [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
 - [Azure Bot Service Introduction](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 - [Azure Bot Service Documentation](https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0)
+- [.NET Core CLI tools](https://docs.microsoft.com/en-us/dotnet/core/tools/?tabs=netcore2x)
 - [Azure CLI](https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
 - [Azure Portal](https://portal.azure.com)
+- [Language Understanding using LUIS](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/)
+- [Channels and Bot Connector Service](https://docs.microsoft.com/en-us/azure/bot-service/bot-concepts?view=azure-bot-service-4.0)

--- a/experimental/adaptive-card-prompt-sample/dotnet/Resources/adaptiveCard.json
+++ b/experimental/adaptive-card-prompt-sample/dotnet/Resources/adaptiveCard.json
@@ -1,0 +1,172 @@
+{
+    "type": "AdaptiveCard",
+    "body": [
+        {
+            "type": "TextBlock",
+            "size": "Medium",
+            "weight": "Bolder",
+            "text": "Your registration is almost complete"
+        },
+        {
+            "type": "TextBlock",
+            "text": "What type of food do you prefer?",
+            "wrap": true
+        },
+        {
+            "type": "ImageSet",
+            "images": [
+                {
+                    "type": "Image",
+                    "url": "http://contososcubademo.azurewebsites.net/assets/steak.jpg",
+                    "size": "Medium"
+                },
+                {
+                    "type": "Image",
+                    "url": "http://contososcubademo.azurewebsites.net/assets/chicken.jpg",
+                    "size": "Medium"
+                },
+                {
+                    "type": "Image",
+                    "url": "http://contososcubademo.azurewebsites.net/assets/tofu.jpg",
+                    "size": "Medium"
+                }
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.ShowCard",
+            "title": "Steak",
+            "card": {
+                "type": "AdaptiveCard",
+                "body": [
+                    {
+                        "type": "TextBlock",
+                        "size": "Medium",
+                        "text": "How would you like your steak prepared?",
+                        "wrap": true
+                    },
+                    {
+                        "type": "Input.ChoiceSet",
+                        "id": "SteakTemp",
+                        "choices": [
+                            {
+                                "title": "Rare",
+                                "value": "rare"
+                            },
+                            {
+                                "title": "Medium-Rare",
+                                "value": "medium-rare"
+                            },
+                            {
+                                "title": "Well-done",
+                                "value": "well-done"
+                            }
+                        ],
+                        "style": "expanded"
+                    },
+                    {
+                        "type": "Input.Text",
+                        "id": "SteakOther",
+                        "placeholder": "Any other preparation requests?",
+                        "isMultiline": true
+                    }
+                ],
+                "actions": [
+                    {
+                        "type": "Action.Submit",
+                        "title": "OK",
+                        "data": {
+                            "FoodChoice": "Steak"
+                        }
+                    }
+                ],
+                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
+            }
+        },
+        {
+            "type": "Action.ShowCard",
+            "title": "Chicken",
+            "card": {
+                "type": "AdaptiveCard",
+                "body": [
+                    {
+                        "type": "TextBlock",
+                        "size": "Medium",
+                        "text": "Do you have any allergies?",
+                        "wrap": true
+                    },
+                    {
+                        "type": "Input.ChoiceSet",
+                        "id": "ChickenAllergy",
+                        "choices": [
+                            {
+                                "title": "I'm allergic to peanuts",
+                                "value": "peanut"
+                            }
+                        ],
+                        "style": "expanded",
+                        "isMultiSelect": true
+                    },
+                    {
+                        "type": "Input.Text",
+                        "id": "ChickenOther",
+                        "placeholder": "Any other preparation requests?",
+                        "isMultiline": true
+                    }
+                ],
+                "actions": [
+                    {
+                        "type": "Action.Submit",
+                        "title": "OK",
+                        "data": {
+                            "FoodChoice": "Chicken"
+                        }
+                    }
+                ],
+                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
+            }
+        },
+        {
+            "type": "Action.ShowCard",
+            "title": "Tofu",
+            "card": {
+                "type": "AdaptiveCard",
+                "body": [
+                    {
+                        "type": "TextBlock",
+                        "size": "Medium",
+                        "text": "Would you like it prepared vegan?",
+                        "wrap": true
+                    },
+                    {
+                        "type": "Input.Toggle",
+                        "id": "Vegetarian",
+                        "title": "Please prepare it vegan",
+                        "valueOn": "vegan",
+                        "valueOff": "notVegan",
+                        "wrap": false
+                    },
+                    {
+                        "type": "Input.Text",
+                        "id": "VegOther",
+                        "placeholder": "Any other preparation requests?",
+                        "isMultiline": true
+                    }
+                ],
+                "actions": [
+                    {
+                        "type": "Action.Submit",
+                        "title": "OK",
+                        "data": {
+                            "FoodChoice": "Vegetarian"
+                        }
+                    }
+                ],
+                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
+            }
+        }
+    ],
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.0"
+}

--- a/experimental/adaptive-card-prompt-sample/dotnet/Startup.cs
+++ b/experimental/adaptive-card-prompt-sample/dotnet/Startup.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.BotFramework;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.BotBuilderSamples
+{
+    public class Startup
+    {
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+
+            // Create the Bot Framework Adapter with error handling enabled.
+            services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
+
+            // Create the storage we'll be using for User and Conversation state. (Memory is great for testing purposes.)
+            services.AddSingleton<IStorage, MemoryStorage>();
+
+            // Create the User state. (Used in this bot's Dialog implementation.)
+            services.AddSingleton<UserState>();
+
+            // Create the Conversation state. (Used by the Dialog system itself.)
+            services.AddSingleton<ConversationState>();
+
+            services.AddSingleton<MainDialog>();
+            // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
+            services.AddTransient<IBot, DialogAndWelcomeBot<MainDialog>>();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseHsts();
+            }
+
+            app.UseDefaultFiles();
+            app.UseStaticFiles();
+
+            //app.UseHttpsRedirection();
+            app.UseMvc();
+        }
+    }
+}

--- a/experimental/adaptive-card-prompt-sample/dotnet/UserProfile.cs
+++ b/experimental/adaptive-card-prompt-sample/dotnet/UserProfile.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.BotBuilderSamples
+{
+    using System.Collections.Generic;
+
+    /// <summary>Contains information about a user.</summary>
+    public class UserProfile
+    {
+        public string Name { get; set; }
+        public int Age { get; set; }
+
+        // The list of companies the user wants to review.
+        public List<string> CompaniesToReview { get; set; } = new List<string>();
+    }
+}

--- a/experimental/adaptive-card-prompt-sample/dotnet/appsettings.Development.json
+++ b/experimental/adaptive-card-prompt-sample/dotnet/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/experimental/adaptive-card-prompt-sample/dotnet/appsettings.json
+++ b/experimental/adaptive-card-prompt-sample/dotnet/appsettings.json
@@ -1,0 +1,4 @@
+﻿{
+  "MicrosoftAppId": "",
+  "MicrosoftAppPassword": ""
+}

--- a/experimental/adaptive-card-prompt-sample/dotnet/wwwroot/default.htm
+++ b/experimental/adaptive-card-prompt-sample/dotnet/wwwroot/default.htm
@@ -1,0 +1,417 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Adaptive Card Prompt Sample</title>
+    <style>
+        body {
+            margin: 0px;
+            padding: 0px;
+            font-family: Segoe UI;
+        }
+
+        html,
+        body {
+            height: 100%;
+        }
+
+        header {
+            background-image: url("data:image/svg+xml,%3Csvg version='1.1' id='Layer_1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' viewBox='0 0 4638.9 651.6' style='enable-background:new 0 0 4638.9 651.6;' xml:space='preserve'%3E%3Cstyle type='text/css'%3E .st0%7Bfill:%2355A0E0;%7D .st1%7Bfill:none;%7D .st2%7Bfill:%230058A8;%7D .st3%7Bfill:%23328BD8;%7D .st4%7Bfill:%23B6DCF1;%7D .st5%7Bopacity:0.2;fill:url(%23SVGID_1_);enable-background:new ;%7D%0A%3C/style%3E%3Crect y='1.1' class='st0' width='4640' height='646.3'/%3E%3Cpath class='st1' d='M3987.8,323.6L4310.3,1.1h-65.6l-460.1,460.1c-17.5,17.5-46.1,17.5-63.6,0L3260.9,1.1H0v646.3h3660.3 L3889,418.7c17.5-17.5,46.1-17.5,63.6,0l228.7,228.7h66.6l-260.2-260.2C3970.3,369.8,3970.3,341.1,3987.8,323.6z'/%3E%3Cpath class='st2' d='M3784.6,461.2L4244.7,1.1h-983.9l460.1,460.1C3738.4,478.7,3767.1,478.7,3784.6,461.2z'/%3E%3Cpath class='st3' d='M4640,1.1h-329.8l-322.5,322.5c-17.5,17.5-17.5,46.1,0,63.6l260.2,260.2H4640L4640,1.1L4640,1.1z'/%3E%3Cpath class='st4' d='M3889,418.8l-228.7,228.7h521.1l-228.7-228.7C3935.2,401.3,3906.5,401.3,3889,418.8z'/%3E%3ClinearGradient id='SVGID_1_' gradientUnits='userSpaceOnUse' x1='3713.7576' y1='438.1175' x2='3911.4084' y2='14.2535' gradientTransform='matrix(1 0 0 -1 0 641.3969)'%3E%3Cstop offset='0' style='stop-color:%23FFFFFF;stop-opacity:0.5'/%3E%3Cstop offset='1' style='stop-color:%23FFFFFF'/%3E%3C/linearGradient%3E%3Cpath class='st5' d='M3952.7,124.5c-17.5-17.5-46.1-17.5-63.6,0l-523,523h1109.6L3952.7,124.5z'/%3E%3C/svg%3E%0A");
+            background-repeat: no-repeat;
+            background-size: 100%;
+            background-position: right;
+            background-color: #55A0E0;
+            width: 100%;
+            font-size: 44px;
+            height: 120px;
+            color: white;
+            padding: 30px 0 40px 0px;
+            display: inline-block;
+        }
+
+        .header-icon {
+            background-image: url("data:image/svg+xml;utf8,%3Csvg%20version%3D%221.1%22%20id%3D%22Layer_1%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20viewBox%3D%220%200%20150.2%20125%22%20style%3D%22enable-background%3Anew%200%200%20150.2%20125%3B%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cstyle%20type%3D%22text/css%22%3E%0A%09.st0%7Bfill%3Anone%3B%7D%0A%09.st1%7Bfill%3A%23FFFFFF%3B%7D%0A%3C/style%3E%0A%3Crect%20x%3D%220.5%22%20class%3D%22st0%22%20width%3D%22149.7%22%20height%3D%22125%22/%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M59%2C102.9L21.8%2C66c-3.5-3.5-3.5-9.1%2C0-12.5l37-36.5l2.9%2C3l-37%2C36.4c-1.8%2C1.8-1.8%2C4.7%2C0%2C6.6l37.2%2C37L59%2C102.9z%22%0A%09%09/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M92.5%2C102.9l-3-3l37.2-37c0.9-0.9%2C1.4-2%2C1.4-3.3c0-1.2-0.5-2.4-1.4-3.3L89.5%2C20l2.9-3l37.2%2C36.4%0A%09%09c1.7%2C1.7%2C2.6%2C3.9%2C2.6%2C6.3s-0.9%2C4.6-2.6%2C6.3L92.5%2C102.9z%22/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M90.1%2C68.4c-4.5%2C0-8-3.5-8-8.1c0-4.5%2C3.5-8.1%2C8-8.1c4.4%2C0%2C8%2C3.7%2C8%2C8.1C98.1%2C64.7%2C94.4%2C68.4%2C90.1%2C68.4z%0A%09%09%20M90.1%2C56.5c-2.2%2C0-3.8%2C1.7-3.8%2C3.9c0%2C2.2%2C1.7%2C3.9%2C3.8%2C3.9c1.9%2C0%2C3.8-1.6%2C3.8-3.9S91.9%2C56.5%2C90.1%2C56.5z%22/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M61.4%2C68.4c-4.5%2C0-8-3.5-8-8.1c0-4.5%2C3.5-8.1%2C8-8.1c4.4%2C0%2C8%2C3.7%2C8%2C8.1C69.5%2C64.7%2C65.8%2C68.4%2C61.4%2C68.4z%0A%09%09%20M61.4%2C56.5c-2.2%2C0-3.8%2C1.7-3.8%2C3.9c0%2C2.2%2C1.7%2C3.9%2C3.8%2C3.9c1.9%2C0%2C3.8-1.6%2C3.8-3.9S63.3%2C56.5%2C61.4%2C56.5z%22/%3E%0A%3C/g%3E%0A%3C/svg%3E%0A");
+            background-repeat: no-repeat;
+            float: left;
+            height: 140px;
+            width: 140px;
+            display: inline-block;
+            vertical-align: middle;
+        }
+
+        .header-text {
+            padding-left: 1%;
+            color: #FFFFFF;
+            font-family: "Segoe UI";
+            font-size: 72px;
+            font-weight: 300;
+            letter-spacing: 0.35px;
+            line-height: 96px;
+            display: inline-block;
+            vertical-align: middle;
+        }
+
+        .header-inner-container {
+            min-width: 480px;
+            max-width: 1366px;
+            margin-left: auto;
+            margin-right: auto;
+            vertical-align: middle;
+        }
+
+        .header-inner-container::after {
+            content: "";
+            clear: both;
+            display: table;
+        }
+
+        .main-content-area {
+            padding-left: 30px;
+        }
+
+        .content-title {
+            color: #000000;
+            font-family: "Segoe UI";
+            font-size: 46px;
+            font-weight: 300;
+            line-height: 62px;
+        }
+
+        .main-text {
+            color: #808080;
+            font-size: 24px;
+            font-family: "Segoe UI";
+            font-size: 24px;
+            font-weight: 200;
+            line-height: 32px;
+        }
+
+        .main-text-p1{
+            padding-top: 48px;
+            padding-bottom: 28px;
+        }
+
+        .endpoint {
+           height: 32px;
+           width: 571px;
+           color: #808080;
+           font-family: "Segoe UI";
+           font-size: 24px;
+           font-weight: 200;
+           line-height: 32px;
+           padding-top: 28px;
+        }
+
+        .how-to-build-section {
+            padding-top: 20px;
+            padding-left: 30px;
+        }
+
+        .how-to-build-section>h3 {
+            font-size: 16px;
+            font-weight: 600;
+            letter-spacing: 0.35px;
+            line-height: 22px;
+            margin: 0 0 24px 0;
+            text-transform: uppercase;
+        }
+
+        .step-container {
+            display: flex;
+            align-items: stretch;
+            position: relative;
+        }
+
+        .step-container dl {
+            border-left: 1px solid #A0A0A0;
+            display: block;
+            padding: 0 24px;
+            margin: 0;
+        }
+
+        .step-container dl>dt::before {
+            background-color: white;
+            border: 1px solid #A0A0A0;
+            border-radius: 100%;
+            content: '';
+            left: 47px;
+            height: 11px;
+            position: absolute;
+            width: 11px;
+        }
+
+        .step-container dl>.test-bullet::before {
+            background-color: blue;
+        }
+
+        .step-container dl>dt {
+            display: block;
+            font-size: inherit;
+            font-weight: bold;
+            line-height: 20px;
+        }
+
+        .step-container dl>dd {
+            font-size: inherit;
+            line-height: 20px;
+            margin-left: 0;
+            padding-bottom: 32px;
+        }
+
+        .step-container:last-child dl {
+            border-left: 1px solid transparent;
+        }
+
+        .ctaLink {
+            background-color: transparent;
+            border: 1px solid transparent;
+            color: #006AB1;
+            cursor: pointer;
+            font-weight: 600;
+            padding: 0;
+            white-space: normal;
+        }
+
+        .ctaLink:focus {
+            outline: 1px solid #00bcf2;
+        }
+
+        .ctaLink:hover {
+            text-decoration: underline;
+        }
+
+        .step-icon {
+            display: flex;
+            height: 38px;
+            margin-right: 15px;
+            width: 38px;
+        }
+
+        .step-icon>div {
+            height: 30px;
+            width: 30px;
+            background-repeat: no-repeat;
+        }
+
+        .ms-logo-container {
+            min-width: 580px;
+            max-width: 980px;
+            margin-left: auto;
+            margin-right: auto;
+            left: 0;
+            right: 0;
+            transition: bottom 400ms;
+        }
+
+        .ms-logo {
+            float: right;
+            background-image: url("data:image/svg+xml;utf8,%0A%3Csvg%20version%3D%221.1%22%20id%3D%22MS-symbol%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20viewBox%3D%220%200%20400%20120%22%20style%3D%22enable-background%3Anew%200%200%20400%20120%3B%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cstyle%20type%3D%22text/css%22%3E%0A%09.st0%7Bfill%3Anone%3B%7D%0A%09.st1%7Bfill%3A%23737474%3B%7D%0A%09.st2%7Bfill%3A%23D63F26%3B%7D%0A%09.st3%7Bfill%3A%23167D3E%3B%7D%0A%09.st4%7Bfill%3A%232E76BC%3B%7D%0A%09.st5%7Bfill%3A%23FDB813%3B%7D%0A%3C/style%3E%0A%3Crect%20x%3D%220.6%22%20class%3D%22st0%22%20width%3D%22398.7%22%20height%3D%22119%22/%3E%0A%3Cpath%20class%3D%22st1%22%20d%3D%22M171.3%2C38.4v43.2h-7.5V47.7h-0.1l-13.4%2C33.9h-5l-13.7-33.9h-0.1v33.9h-6.9V38.4h10.8l12.4%2C32h0.2l13.1-32H171.3%0A%09z%20M177.6%2C41.7c0-1.2%2C0.4-2.2%2C1.3-3c0.9-0.8%2C1.9-1.2%2C3.1-1.2c1.3%2C0%2C2.4%2C0.4%2C3.2%2C1.3c0.8%2C0.8%2C1.3%2C1.8%2C1.3%2C3c0%2C1.2-0.4%2C2.2-1.3%2C3%0A%09c-0.9%2C0.8-1.9%2C1.2-3.2%2C1.2s-2.3-0.4-3.1-1.2C178%2C43.8%2C177.6%2C42.8%2C177.6%2C41.7z%20M185.7%2C50.6v31h-7.3v-31H185.7z%20M207.8%2C76.3%0A%09c1.1%2C0%2C2.3-0.3%2C3.6-0.8c1.3-0.5%2C2.5-1.2%2C3.6-2v6.8c-1.2%2C0.7-2.5%2C1.2-4%2C1.5c-1.5%2C0.3-3.1%2C0.5-4.9%2C0.5c-4.6%2C0-8.3-1.4-11.1-4.3%0A%09c-2.9-2.9-4.3-6.6-4.3-11c0-5%2C1.5-9.1%2C4.4-12.3c2.9-3.2%2C7-4.8%2C12.4-4.8c1.4%2C0%2C2.7%2C0.2%2C4.1%2C0.5c1.4%2C0.4%2C2.5%2C0.8%2C3.3%2C1.2v7%0A%09c-1.1-0.8-2.3-1.5-3.4-1.9c-1.2-0.5-2.4-0.7-3.6-0.7c-2.9%2C0-5.2%2C0.9-7%2C2.8c-1.8%2C1.9-2.7%2C4.4-2.7%2C7.6c0%2C3.1%2C0.8%2C5.6%2C2.5%2C7.3%0A%09C202.6%2C75.4%2C204.9%2C76.3%2C207.8%2C76.3z%20M235.7%2C50.1c0.6%2C0%2C1.1%2C0%2C1.6%2C0.1s0.9%2C0.2%2C1.2%2C0.3v7.4c-0.4-0.3-0.9-0.5-1.7-0.8%0A%09c-0.7-0.3-1.6-0.4-2.7-0.4c-1.8%2C0-3.3%2C0.8-4.5%2C2.3c-1.2%2C1.5-1.9%2C3.8-1.9%2C7v15.6h-7.3v-31h7.3v4.9h0.1c0.7-1.7%2C1.7-3%2C3-4%0A%09C232.2%2C50.6%2C233.8%2C50.1%2C235.7%2C50.1z%20M238.9%2C66.6c0-5.1%2C1.4-9.2%2C4.3-12.2c2.9-3%2C6.9-4.5%2C12.1-4.5c4.8%2C0%2C8.6%2C1.4%2C11.3%2C4.3%0A%09c2.7%2C2.9%2C4.1%2C6.8%2C4.1%2C11.7c0%2C5-1.4%2C9-4.3%2C12c-2.9%2C3-6.8%2C4.5-11.8%2C4.5c-4.8%2C0-8.6-1.4-11.4-4.2C240.3%2C75.3%2C238.9%2C71.4%2C238.9%2C66.6z%0A%09%20M246.5%2C66.3c0%2C3.2%2C0.7%2C5.7%2C2.2%2C7.4c1.5%2C1.7%2C3.6%2C2.6%2C6.3%2C2.6c2.7%2C0%2C4.7-0.9%2C6.1-2.6c1.4-1.7%2C2.1-4.2%2C2.1-7.6c0-3.3-0.7-5.8-2.2-7.5%0A%09c-1.4-1.7-3.4-2.5-6-2.5c-2.7%2C0-4.7%2C0.9-6.2%2C2.7C247.2%2C60.5%2C246.5%2C63%2C246.5%2C66.3z%20M281.5%2C58.8c0%2C1%2C0.3%2C1.9%2C1%2C2.5%0A%09c0.7%2C0.6%2C2.1%2C1.3%2C4.4%2C2.2c2.9%2C1.2%2C5%2C2.5%2C6.1%2C3.9c1.2%2C1.5%2C1.8%2C3.2%2C1.8%2C5.3c0%2C2.9-1.1%2C5.3-3.4%2C7c-2.2%2C1.8-5.3%2C2.7-9.1%2C2.7%0A%09c-1.3%2C0-2.7-0.2-4.3-0.5c-1.6-0.3-2.9-0.7-4-1.2v-7.2c1.3%2C0.9%2C2.8%2C1.7%2C4.3%2C2.2c1.5%2C0.5%2C2.9%2C0.8%2C4.2%2C0.8c1.6%2C0%2C2.9-0.2%2C3.6-0.7%0A%09c0.8-0.5%2C1.2-1.2%2C1.2-2.3c0-1-0.4-1.9-1.2-2.5c-0.8-0.7-2.4-1.5-4.6-2.4c-2.7-1.1-4.6-2.4-5.7-3.8c-1.1-1.4-1.7-3.2-1.7-5.4%0A%09c0-2.8%2C1.1-5.1%2C3.3-6.9c2.2-1.8%2C5.1-2.7%2C8.6-2.7c1.1%2C0%2C2.3%2C0.1%2C3.6%2C0.4c1.3%2C0.2%2C2.5%2C0.6%2C3.4%2C0.9v6.9c-1-0.6-2.1-1.2-3.4-1.7%0A%09c-1.3-0.5-2.6-0.7-3.8-0.7c-1.4%2C0-2.5%2C0.3-3.2%2C0.8C281.9%2C57.1%2C281.5%2C57.8%2C281.5%2C58.8z%20M297.9%2C66.6c0-5.1%2C1.4-9.2%2C4.3-12.2%0A%09c2.9-3%2C6.9-4.5%2C12.1-4.5c4.8%2C0%2C8.6%2C1.4%2C11.3%2C4.3c2.7%2C2.9%2C4.1%2C6.8%2C4.1%2C11.7c0%2C5-1.4%2C9-4.3%2C12c-2.9%2C3-6.8%2C4.5-11.8%2C4.5%0A%09c-4.8%2C0-8.6-1.4-11.4-4.2C299.4%2C75.3%2C297.9%2C71.4%2C297.9%2C66.6z%20M305.5%2C66.3c0%2C3.2%2C0.7%2C5.7%2C2.2%2C7.4c1.5%2C1.7%2C3.6%2C2.6%2C6.3%2C2.6%0A%09c2.7%2C0%2C4.7-0.9%2C6.1-2.6c1.4-1.7%2C2.1-4.2%2C2.1-7.6c0-3.3-0.7-5.8-2.2-7.5c-1.4-1.7-3.4-2.5-6-2.5c-2.7%2C0-4.7%2C0.9-6.2%2C2.7%0A%09C306.3%2C60.5%2C305.5%2C63%2C305.5%2C66.3z%20M353.9%2C56.6h-10.9v25h-7.4v-25h-5.2v-6h5.2v-4.3c0-3.3%2C1.1-5.9%2C3.2-8c2.1-2.1%2C4.8-3.1%2C8.1-3.1%0A%09c0.9%2C0%2C1.7%2C0%2C2.4%2C0.1c0.7%2C0.1%2C1.3%2C0.2%2C1.8%2C0.4V42c-0.2-0.1-0.7-0.3-1.3-0.5c-0.6-0.2-1.3-0.3-2.1-0.3c-1.5%2C0-2.7%2C0.5-3.5%2C1.4%0A%09s-1.2%2C2.4-1.2%2C4.2v3.7h10.9v-7l7.3-2.2v9.2h7.4v6h-7.4v14.5c0%2C1.9%2C0.3%2C3.3%2C1%2C4c0.7%2C0.8%2C1.8%2C1.2%2C3.3%2C1.2c0.4%2C0%2C0.9-0.1%2C1.5-0.3%0A%09c0.6-0.2%2C1.1-0.4%2C1.6-0.7v6c-0.5%2C0.3-1.2%2C0.5-2.3%2C0.7c-1.1%2C0.2-2.1%2C0.3-3.2%2C0.3c-3.1%2C0-5.4-0.8-6.9-2.5c-1.5-1.6-2.3-4.1-2.3-7.4%0A%09V56.6z%22/%3E%0A%3Cg%3E%0A%09%3Crect%20x%3D%2231%22%20y%3D%2224%22%20class%3D%22st2%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2268.8%22%20y%3D%2224%22%20class%3D%22st3%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2231%22%20y%3D%2261.8%22%20class%3D%22st4%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2268.8%22%20y%3D%2261.8%22%20class%3D%22st5%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%3C/g%3E%0A%3C/svg%3E%0A");
+        }
+
+        .ms-logo-container>div {
+            min-height: 60px;
+            width: 150px;
+            background-repeat: no-repeat;
+        }
+
+        .row {
+            padding: 90px 0px 0 20px;
+            min-width: 480px;
+            max-width: 1366px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        .column {
+            float: left;
+            width: 45%;
+            padding-right: 20px;
+        }
+
+        .row:after {
+            content: "";
+            display: table;
+            clear: both;
+        }
+
+        a {
+            text-decoration: none;
+        }
+
+        .download-the-emulator {
+            height: 20px;
+            color: #0063B1;
+            font-size: 15px;
+            line-height: 20px;
+            padding-bottom: 70px;
+        }
+
+        .how-to-iframe {
+            max-width: 700px !important;
+            min-width: 650px !important;
+            height: 700px !important;
+        }
+
+        .remove-frame-height {
+            height: 10px;
+        }
+
+        @media only screen and (max-width: 1300px) {
+            .ms-logo {
+                padding-top: 30px;
+            }
+
+            .header-text {
+                font-size: 40x;
+            }
+
+            .column {
+                float: none;
+                padding-top: 30px;
+                width: 100%;
+            }
+
+            .ms-logo-container {
+                padding-top: 30px;
+                min-width: 480px;
+                max-width: 650px;
+                margin-left: auto;
+                margin-right: auto;
+            }
+
+            .row {
+                padding: 20px 0px 0 20px;
+                min-width: 480px;
+                max-width: 650px;
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
+
+        @media only screen and (max-width: 1370px) {
+            header {
+                background-color: #55A0E0;
+                background-size: auto 200px;
+            }
+        }
+
+        @media only screen and (max-width: 1230px) {
+            header {
+                background-color: #55A0E0;
+                background-size: auto 200px;
+            }
+
+            .header-text {
+                font-size: 44px;
+            }
+
+            .header-icon {
+                height: 120px;
+                width: 120px;
+            }
+        }
+
+        @media only screen and (max-width: 1000px) {
+            header {
+                background-color: #55A0E0;
+                background-image: none;
+            }
+        }
+
+        @media only screen and (max-width: 632px) {
+            .header-text {
+                font-size: 32px;
+            }
+
+            .row {
+                padding: 10px 0px 0 10px;
+                max-width: 490px !important;
+                min-width: 410px !important;
+            }
+
+            .endpoint {
+                font-size: 25px;
+            }
+
+            .main-text {
+                font-size: 20px;
+            }
+
+            .step-container dl>dd {
+                font-size: 14px;
+            }
+
+            .column {
+                padding-right: 5px;
+            }
+
+            .header-icon {
+                height: 110px;
+                width: 110px;
+            }
+
+            .how-to-iframe {
+                max-width: 480px !important;
+                min-width: 400px !important;
+                height: 650px !important;
+                overflow: hidden;
+            }
+        }
+
+        .remove-frame-height {
+            max-height: 10px;
+        }
+    </style>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            loadFrame();
+        });
+        var loadFrame = function () {
+            var iframe = document.createElement('iframe');
+            iframe.setAttribute("id", "iframe");
+            var offLineHTMLContent = "";
+            var frameElement = document.getElementById("how-to-iframe");
+            if (window.navigator.onLine) {
+                iframe.src = 'https://docs.botframework.com/static/abs/pages/f5.htm';
+                iframe.setAttribute("scrolling", "no");
+                iframe.setAttribute("frameborder", "0");
+                iframe.setAttribute("width", "100%");
+                iframe.setAttribute("height", "100%");
+                var frameDiv = document.getElementById("how-to-iframe");
+                frameDiv.appendChild(iframe);
+            } else {
+                frameElement.classList.add("remove-frame-height");
+            }
+        };
+    </script>
+</head>
+
+<body>
+    <header class="header">
+        <div class="header-inner-container">
+            <div class="header-icon" style="display: inline-block"></div>
+            <div class="header-text" style="display: inline-block">Complex Dialog Sample</div>
+        </div>
+    </header>
+    <div class="row">
+        <div class="column" class="main-content-area">
+            <div class="content-title">Your bot is ready!</div>
+            <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
+                by connecting to http://localhost:3978/api/messages.</div>
+            <div class="main-text download-the-emulator"><a class="ctaLink" href="https://aka.ms/bot-framework-F5-download-emulator"
+                    target="_blank">Download the Emulator</a></div>
+            <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home" target="_blank">Azure
+                    Bot Service</a> to register your bot and add it to<br />
+                various channels. The bot's endpoint URL typically looks
+                like this:</div>
+            <div class="endpoint">https://<i>your_bots_hostname</i>/api/messages</div>
+        </div>
+        <div class="column how-to-iframe" id="how-to-iframe"></div>
+    </div>
+    <div class="ms-logo-container">
+        <div class="ms-logo"></div>
+    </div>
+</body>
+</html>

--- a/experimental/adaptive-card-prompt-sample/javascript_nodejs/.env
+++ b/experimental/adaptive-card-prompt-sample/javascript_nodejs/.env
@@ -1,0 +1,2 @@
+MicrosoftAppId=
+MicrosoftAppPassword=

--- a/experimental/adaptive-card-prompt-sample/javascript_nodejs/.eslintrc.js
+++ b/experimental/adaptive-card-prompt-sample/javascript_nodejs/.eslintrc.js
@@ -1,0 +1,14 @@
+module.exports = {
+  "extends": "standard",
+  "rules": {
+    "semi": [2, "always"],
+    "indent": [2, 4],
+    "no-return-await": 0,
+    "space-before-function-paren": [2, {
+      "named": "never",
+      "anonymous": "never",
+      "asyncArrow": "always"
+    }],
+    "template-curly-spacing": [2, "always"]
+  }
+};

--- a/experimental/adaptive-card-prompt-sample/javascript_nodejs/README.md
+++ b/experimental/adaptive-card-prompt-sample/javascript_nodejs/README.md
@@ -1,0 +1,139 @@
+# Adaptive Card Prompt Sample
+
+Bot Framework v4 Adaptive Card Prompt Sample
+
+// TODO: Update AdaptiveCardPrompt link once in SDK
+This bot has been created using [Bot Framework](https://dev.botframework.com), it shows how to use the new [AdaptiveCardPrompt](https://github.com/mdrichardson/botbuilder-js/blob/adaptiveCardPrompt/libraries/botbuilder-dialogs/src/prompts/adaptiveCardPrompt.ts) to gather data in a dialog.
+
+## AdaptiveCardPrompt Features
+
+* Includes validation for specified required input fields
+* Displays custom message if user replies via text and not card input
+* Ensures input is only valid if it comes from the appropriate card (not one shown previous to prompt)
+
+## Usage
+
+```js
+// Load an adaptive card
+const cardJson = require('./adaptiveCard.json');
+const card = CardFactory.adaptiveCard(cardJson);
+
+// Configure settings - All optional
+const promptSettings = {
+    card: card,
+    inputFailMessage: 'Please fill out the adaptive card',
+    requiredInputIds: [
+        'inputA',
+        'inputB',
+    ],
+    missingRequiredInputsMessage: 'The following inputs are required',
+    attemptsBeforeCardRedsiplayed: 5,
+    promptId: 'myCustomId'
+}
+
+// Initialize the prompt
+const adaptiveCardPrompt = new AdaptiveCardPrompt('adaptiveCardPrompt', null, promptSettings);
+
+// Add the prompt to your dialogs
+dialogSet.add(adaptiveCardPrompt);
+
+// Call the prompt
+return await stepContext.prompt('adaptiveCardPrompt');
+
+// Use the result
+const result = stepContext.result;
+```
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org) version 10.14 or higher
+
+    ```bash
+    # determine node version
+    node --version
+    ```
+
+## To try this sample
+
+- Clone the repository
+
+    ```bash
+    git clone https://github.com/Microsoft/botbuilder-samples.git
+    ```
+
+// TODO: Update this line
+- In a terminal, navigate to `samples/javascript_nodejs/07.using-adaptive-cards`
+
+    ```bash
+    cd samples/javascript_nodejs/07.using-adaptive-cards
+    ```
+
+- Install modules
+
+    ```bash
+    npm install
+    ```
+
+- Start the bot
+
+    ```bash
+    npm start
+    ```
+
+## Testing the bot using Bot Framework Emulator
+
+[Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
+
+- Install the Bot Framework Emulator version 4.3.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
+
+### Connect to the bot using Bot Framework Emulator
+
+- Launch Bot Framework Emulator
+- File -> Open Bot
+- Enter a Bot URL of `http://localhost:3978/api/messages`
+
+## Adaptive Cards
+
+Card authors describe their content as a simple JSON object. That content can then be rendered natively inside a host application, automatically adapting to the look and feel of the host. For example, Contoso Bot can author an Adaptive Card through the Bot Framework, and when delivered to Skype, it will look and feel like a Skype card. When that same payload is sent to Microsoft Teams, it will look and feel like Microsoft Teams. As more host apps start to support Adaptive Cards, that same payload will automatically light up inside these applications, yet still feel entirely native to the app. Users win because everything feels familiar. Host apps win because they control the user experience. Card authors win because their content gets broader reach without any additional work.
+
+The Bot Framework provides support for Adaptive Cards.  See the following to learn more about Adaptive Cards.
+
+- [Adaptive card](http://adaptivecards.io)
+- [Send an Adaptive card](https://docs.microsoft.com/en-us/azure/bot-service/nodejs/bot-builder-nodejs-send-rich-cards?view=azure-bot-service-3.0&viewFallbackFrom=azure-bot-service-4.0#send-an-adaptive-card)
+
+### Getting Input Data From Adaptive Cards
+
+In a `TextPrompt`, the user response is returned in the `Activity.Text` property, which only accepts strings. Because Adaptive Cards can contain multiple inputs, the user response is sent as a JSON object in `Activity.Value`, like so:
+
+```json
+const activity = {
+    [...]
+    "value": {
+        "inputA": "response A",
+        "inputB": "response B",
+        [...etc]
+    }
+}
+```
+
+Because of this, it can be a little difficult to gather user input using an Adaptive Card within a dialog. The `AdaptiveCardPrompt` allows you to do so easily and returns the JSON object user response in `stepContext.result`.
+
+### Adding media to messages
+
+A message exchange between user and bot can contain media attachments, such as cards, images, video, audio, and files.
+
+## Deploy the bot to Azure
+
+To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.
+
+## Further reading
+
+- [Bot Framework Documentation](https://docs.botframework.com)
+- [Bot Basics](https://docs.microsoft.com/azure/bot-service/bot-builder-basics?view=azure-bot-service-4.0)
+- [Adaptive Cards](https://adaptivecards.io/)
+- [Send an Adaptive card](https://docs.microsoft.com/en-us/azure/bot-service/nodejs/bot-builder-nodejs-send-rich-cards?view=azure-bot-service-3.0&viewFallbackFrom=azure-bot-service-4.0#send-an-adaptive-card)
+- [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
+- [Azure Bot Service Introduction](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
+- [Azure Bot Service Documentation](https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0)
+- [Azure CLI](https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
+- [Azure Portal](https://portal.azure.com)

--- a/experimental/adaptive-card-prompt-sample/javascript_nodejs/adaptiveCardPrompt.js
+++ b/experimental/adaptive-card-prompt-sample/javascript_nodejs/adaptiveCardPrompt.js
@@ -1,0 +1,222 @@
+// Note: This is an edit of the compiled version of: 
+// https://github.com/mdrichardson/botbuilder-js/blob/adaptiveCardPrompt/libraries/botbuilder-dialogs/src/prompts/adaptiveCardPrompt.ts
+
+const { Dialog } = require("botbuilder-dialogs");
+const { InputHints } = require("botbuilder");
+/**
+ * Waits for Adaptive Card Input to be received.
+ *
+ * @remarks
+ * This prompt is similar to ActivityPrompt but provides features specific to Adaptive Cards:
+ *   * Card can be passed in constructor or as prompt/reprompt activity attachment
+ *   * Includes validation for specified required input fields
+ *   * Displays custom message if user replies via text and not card input
+ *   * Ensures input is only valid if it comes from the appropriate card (not one shown previous to prompt)
+ * DO NOT USE WITH CHANNELS THAT DON'T SUPPORT ADAPTIVE CARDS
+ */
+class AdaptiveCardPrompt extends Dialog {
+    /**
+     * Creates a new AdaptiveCardPrompt instance
+     * @param dialogId Unique ID of the dialog within its parent `DialogSet` or `ComponentDialog`.
+     * @param validator (optional) Validator that will be called each time a new activity is received. Validator should handle error messages on failures.
+     * @param settings (optional) Additional options for AdaptiveCardPrompt behavior
+     */
+    constructor(dialogId, validator, settings) {
+        super(dialogId);
+        this.usesCustomPromptId = false;
+        // Necessary for when this compiles to js since strictPropertyInitialization is false/unset in tsconfig
+        settings = typeof (settings) === 'object' ? settings : {};
+        this.validator = validator;
+        this._inputFailMessage = settings.inputFailMessage || 'Please fill out the Adaptive Card';
+        this._requiredInputIds = settings.requiredInputIds || [];
+        this._missingRequiredInputsMessage = settings.missingRequiredInputsMessage || 'The following inputs are required';
+        this._attemptsBeforeCardRedisplayed = settings.attemptsBeforeCardRedisplayed || 3;
+        this._card = settings.card;
+        if (settings.promptId) {
+            this._promptId = settings.promptId;
+            this.usesCustomPromptId = true;
+        }
+    }
+    get inputFailMessage() {
+        return this._inputFailMessage;
+    }
+    set inputFailMessage(message) {
+        this._inputFailMessage = message;
+    }
+    get requiredInputIds() {
+        return this._requiredInputIds;
+    }
+    set requiredInputIds(ids) {
+        this._requiredInputIds = ids;
+    }
+    get missingRequiredInputsMessage() {
+        return this._missingRequiredInputsMessage;
+    }
+    set missingRequiredInputsMessage(message) {
+        this._missingRequiredInputsMessage = message;
+    }
+    get attemptsBeforeCardRedisplayed() {
+        return this._attemptsBeforeCardRedisplayed;
+    }
+    set attemptsBeforeCardRedisplayed(attempts) {
+        this._attemptsBeforeCardRedisplayed = attempts;
+    }
+    get promptId() {
+        return this._promptId;
+    }
+    set promptId(id) {
+        this.usesCustomPromptId = true;
+        this._promptId = id;
+    }
+    get card() {
+        return this._card;
+    }
+    set card(card) {
+        this._card = card;
+    }
+    async beginDialog(dc, options) {
+        // Initialize prompt state
+        const state = dc.activeDialog.state;
+        state.options = options;
+        state.state = {};
+        // Send initial prompt
+        await this.onPrompt(dc.context, state.state, state.options, false);
+        return Dialog.EndOfTurn;
+    }
+    async onPrompt(context, state, options, isRetry) {
+        // Should use GUID for C# -- it isn't native to Node, so this keeps dependencies down
+        // Only the most recently-prompted card submission is accepted
+        this._promptId = this.usesCustomPromptId ? this._promptId : `${Math.random()}`;
+        let prompt = isRetry && options.retryPrompt ? options.retryPrompt : options.prompt;
+        // Create a prompt if user didn't pass it in through PromptOptions
+        if (!prompt || Object.keys(prompt).length === 0 || typeof (prompt) != 'object' || !prompt.attachments || prompt.attachments.length === 0) {
+            prompt = {
+                attachments: [],
+                text: typeof (prompt) === 'string' ? prompt : undefined,
+            };
+        }
+        // Use card passed in PromptOptions or if it doesn't exist, use the one passed in from the constructor
+        const card = prompt.attachments && prompt.attachments[0] ? prompt.attachments[0] : this._card;
+        this.validateIsCard(card, isRetry);
+        prompt.attachments = [this.addPromptIdToCard(card)];
+        await context.sendActivity(prompt, undefined, InputHints.ExpectingInput);
+    }
+    // Override continueDialog so that we can catch activity.value (which is ignored, by default)
+    async continueDialog(dc) {
+        // Perform base recognition
+        const state = dc.activeDialog.state;
+        const recognized = await this.onRecognize(dc.context);
+        if (state.state['attemptCount'] === undefined) {
+            state.state['attemptCount'] = 1;
+        }
+        else {
+            state.state['attemptCount']++;
+        }
+        let isValid = false;
+        if (this.validator && recognized.succeeded) {
+            isValid = await this.validator({
+                context: dc.context,
+                recognized: recognized,
+                state: state.state,
+                options: state.options,
+                attemptCount: state.state['attemptCount']
+            });
+        }
+        else if (recognized.succeeded) {
+            isValid = true;
+        }
+        // Return recognized value or re-prompt
+        if (isValid) {
+            return await dc.endDialog(recognized.value);
+        }
+        else {
+            // Re-prompt, conditionally display card again
+            if (state.state['attemptCount'] % this._attemptsBeforeCardRedisplayed === 0) {
+                await this.onPrompt(dc.context, state.state, state.options, true);
+            }
+            return await Dialog.EndOfTurn;
+        }
+    }
+    async onRecognize(context) {
+        // Ignore user input that doesn't come from adaptive card
+        if (!context.activity.text && context.activity.value) {
+            // Validate it comes from the correct card - This is only a worry while the prompt/dialog has not ended
+            if (context.activity.value && context.activity.value['promptId'] != this._promptId) {
+                return { succeeded: false };
+            }
+            // Check for required input data, if specified in AdaptiveCardPromptSettings
+            let missingIds = [];
+            this._requiredInputIds.forEach((id) => {
+                if (!context.activity.value[id] || !context.activity.value[id].trim()) {
+                    missingIds.push(id);
+                }
+            });
+            // Alert user to missing data
+            if (missingIds.length > 0) {
+                if (this._missingRequiredInputsMessage) {
+                    await context.sendActivity(`${this._missingRequiredInputsMessage}: ${missingIds.join(', ')}`);
+                }
+                return { succeeded: false };
+            }
+            return { succeeded: true, value: context.activity.value };
+        }
+        else {
+            // User used text input instead of card input or is missing required Inputs
+            if (this._inputFailMessage) {
+                await context.sendActivity(this._inputFailMessage);
+            }
+            return { succeeded: false };
+        }
+    }
+    validateIsCard(card, isRetry) {
+        const adaptiveCardType = 'application/vnd.microsoft.card.adaptive';
+        const cardLocation = isRetry ? 'retryPrompt' : 'prompt';
+        if (!card || !card.content) {
+            throw new Error(`No Adaptive Card provided. Include in the constructor or PromptOptions.${cardLocation}.attachments[0]`);
+        }
+        else if (!card.contentType || card.contentType !== adaptiveCardType) {
+            throw new Error(`Attachment is not a valid Adaptive Card.\n` +
+                `Ensure card.contentType is '${adaptiveCardType}'\n` +
+                `and card.content contains the card json`);
+        }
+    }
+    addPromptIdToCard(card) {
+        card.content = this.deepSearchJsonForActionsAndAddPromptId(card.content);
+        return card;
+    }
+    deepSearchJsonForActionsAndAddPromptId(json) {
+        const submitAction = 'Action.Submit';
+        const showCardAction = 'Action.ShowCard';
+        for (const key in json) {
+            // Search for all submits in actions
+            if (key === 'actions') {
+                for (const action in json[key]) {
+                    if (json[key][action].type && json[key][action].type === submitAction) {
+                        json[key][action].data = { ...json[key][action].data, ...{ promptId: this._promptId } };
+                        // Recursively search Action.ShowCard for Submits within the nested card
+                    }
+                    else if (json[key][action].type && json[key][action].type === showCardAction) {
+                        json[key][action] = this.deepSearchJsonForActionsAndAddPromptId(json[key][action]);
+                    }
+                }
+                // Search for all submits in selectActions
+            }
+            else if (key === 'selectAction') {
+                if (json[key].type && json[key].type === submitAction) {
+                    json[key].data = { ...json[key].data, ...{ promptId: this._promptId } };
+                    // Recursively search Action.ShowCard for Submits within the nested card
+                }
+                else if (json[key].type && json[key].type === showCardAction) {
+                    json[key] = this.deepSearchJsonForActionsAndAddPromptId(json[key]);
+                }
+                // Recursively search all other objects
+            }
+            else if (json[key] && typeof json[key] === 'object') {
+                json[key] = this.deepSearchJsonForActionsAndAddPromptId(json[key]);
+            }
+        }
+        return json;
+    }
+}
+exports.AdaptiveCardPrompt = AdaptiveCardPrompt;
+//# sourceMappingURL=adaptiveCardPrompt.js.map

--- a/experimental/adaptive-card-prompt-sample/javascript_nodejs/bots/dialogAndWelcomeBot.js
+++ b/experimental/adaptive-card-prompt-sample/javascript_nodejs/bots/dialogAndWelcomeBot.js
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { DialogBot } = require('./dialogBot');
+
+class DialogAndWelcomeBot extends DialogBot {
+    constructor(conversationState, userState, dialog) {
+        super(conversationState, userState, dialog);
+
+        this.onMembersAdded(async (context, next) => {
+            const membersAdded = context.activity.membersAdded;
+            for (let cnt = 0; cnt < membersAdded.length; cnt++) {
+                if (membersAdded[cnt].id !== context.activity.recipient.id) {
+                    const reply = `Welcome to Adaptive Card Dialog Bot ${ membersAdded[cnt].name }. This bot shows how Adaptive Card inputs are gathered in dialogs. Type anything to get started.`;
+                    await context.sendActivity(reply);
+                }
+            }
+
+            // By calling next() you ensure that the next BotHandler is run.
+            await next();
+        });
+    }
+}
+
+module.exports.DialogAndWelcomeBot = DialogAndWelcomeBot;

--- a/experimental/adaptive-card-prompt-sample/javascript_nodejs/bots/dialogBot.js
+++ b/experimental/adaptive-card-prompt-sample/javascript_nodejs/bots/dialogBot.js
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { ActivityHandler } = require('botbuilder');
+
+class DialogBot extends ActivityHandler {
+    /**
+     *
+     * @param {ConversationState} conversationState
+     * @param {UserState} userState
+     * @param {Dialog} dialog
+     */
+    constructor(conversationState, userState, dialog) {
+        super();
+        if (!conversationState) throw new Error('[DialogBot]: Missing parameter. conversationState is required');
+        if (!userState) throw new Error('[DialogBot]: Missing parameter. userState is required');
+        if (!dialog) throw new Error('[DialogBot]: Missing parameter. dialog is required');
+
+        this.conversationState = conversationState;
+        this.userState = userState;
+        this.dialog = dialog;
+        this.dialogState = this.conversationState.createProperty('DialogState');
+
+        this.onMessage(async (context, next) => {
+            console.log('Running dialog with Message Activity.');
+
+            // Run the Dialog with the new message Activity.
+            await this.dialog.run(context, this.dialogState);
+
+            // By calling next() you ensure that the next BotHandler is run.
+            await next();
+        });
+
+        this.onDialog(async (context, next) => {
+            // Save any state changes. The load happened during the execution of the Dialog.
+            await this.conversationState.saveChanges(context, false);
+            await this.userState.saveChanges(context, false);
+
+            // By calling next() you ensure that the next BotHandler is run.
+            await next();
+        });
+    }
+}
+
+module.exports.DialogBot = DialogBot;

--- a/experimental/adaptive-card-prompt-sample/javascript_nodejs/dialogs/adaptiveCardDialog.js
+++ b/experimental/adaptive-card-prompt-sample/javascript_nodejs/dialogs/adaptiveCardDialog.js
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { AdaptiveCardPrompt } = require('../adaptiveCardPrompt');
+const { ComponentDialog, DialogSet, DialogTurnStatus, WaterfallDialog } = require('botbuilder-dialogs');
+const { CardFactory } = require('botbuilder');
+
+const ADAPTIVE_CARD_DIALOG = 'ADAPTIVE_CARD_DIALOG';
+const USER_PROFILE_PROPERTY = 'USER_PROFILE_PROPERTY';
+
+class AdaptiveCardDialog extends ComponentDialog {
+    constructor() {
+        super(ADAPTIVE_CARD_DIALOG);
+
+        // Load an adaptive card
+        const cardJson = require('../resources/adaptiveCard.json');
+        const card = CardFactory.adaptiveCard(cardJson);
+
+        // Configure settings - All optional
+        const promptSettings = { card: card };
+
+        // Initialize the prompt
+        const adaptiveCardPrompt = new AdaptiveCardPrompt('adaptiveCardPrompt', null, promptSettings);
+
+        this.addDialog(adaptiveCardPrompt);
+
+        this.addDialog(new WaterfallDialog(ADAPTIVE_CARD_DIALOG, [
+            this.initialStep.bind(this),
+            this.finalStep.bind(this)
+        ]));
+
+        this.initialDialogId = ADAPTIVE_CARD_DIALOG;
+    }
+
+    async initialStep(stepContext) {
+        // Call the prompt
+        return await stepContext.prompt('adaptiveCardPrompt');
+    }
+
+    async finalStep(stepContext) {
+        // Use the result
+        const result = stepContext.result;
+        const resultString = Object.keys(result).map((key) => `Key: ${ key }   |   Value: ${ result[key] }`).join('\n');
+        await stepContext.context.sendActivity(`Your input:\n\n${ resultString }`);
+        return await stepContext.endDialog('You have finished the Adaptive Card Dialog. Happy coding!');
+    }
+}
+
+module.exports.AdaptiveCardDialog = AdaptiveCardDialog;
+module.exports.ADAPTIVE_CARD_DIALOG = ADAPTIVE_CARD_DIALOG;

--- a/experimental/adaptive-card-prompt-sample/javascript_nodejs/dialogs/adaptiveCardDialog.js
+++ b/experimental/adaptive-card-prompt-sample/javascript_nodejs/dialogs/adaptiveCardDialog.js
@@ -2,11 +2,10 @@
 // Licensed under the MIT License.
 
 const { AdaptiveCardPrompt } = require('../adaptiveCardPrompt');
-const { ComponentDialog, DialogSet, DialogTurnStatus, WaterfallDialog } = require('botbuilder-dialogs');
+const { ComponentDialog, WaterfallDialog } = require('botbuilder-dialogs');
 const { CardFactory } = require('botbuilder');
 
 const ADAPTIVE_CARD_DIALOG = 'ADAPTIVE_CARD_DIALOG';
-const USER_PROFILE_PROPERTY = 'USER_PROFILE_PROPERTY';
 
 class AdaptiveCardDialog extends ComponentDialog {
     constructor() {
@@ -25,24 +24,24 @@ class AdaptiveCardDialog extends ComponentDialog {
         this.addDialog(adaptiveCardPrompt);
 
         this.addDialog(new WaterfallDialog(ADAPTIVE_CARD_DIALOG, [
-            this.initialStep.bind(this),
-            this.finalStep.bind(this)
+            this.showCard.bind(this),
+            this.displayResults.bind(this)
         ]));
 
         this.initialDialogId = ADAPTIVE_CARD_DIALOG;
     }
 
-    async initialStep(stepContext) {
+    async showCard(stepContext) {
         // Call the prompt
         return await stepContext.prompt('adaptiveCardPrompt');
     }
 
-    async finalStep(stepContext) {
+    async displayResults(stepContext) {
         // Use the result
         const result = stepContext.result;
         const resultString = Object.keys(result).map((key) => `Key: ${ key }   |   Value: ${ result[key] }`).join('\n');
         await stepContext.context.sendActivity(`Your input:\n\n${ resultString }`);
-        return await stepContext.endDialog('You have finished the Adaptive Card Dialog. Happy coding!');
+        return await stepContext.endDialog();
     }
 }
 

--- a/experimental/adaptive-card-prompt-sample/javascript_nodejs/dialogs/mainDialog.js
+++ b/experimental/adaptive-card-prompt-sample/javascript_nodejs/dialogs/mainDialog.js
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { ComponentDialog, DialogSet, DialogTurnStatus, WaterfallDialog } = require('botbuilder-dialogs');
+const { AdaptiveCardDialog, ADAPTIVE_CARD_DIALOG } = require('./adaptiveCardDialog');
+
+const MAIN_DIALOG = 'MAIN_DIALOG';
+const WATERFALL_DIALOG = 'WATERFALL_DIALOG';
+
+class MainDialog extends ComponentDialog {
+    constructor(userState) {
+        super(MAIN_DIALOG);
+        this.userState = userState;
+
+        this.addDialog(new AdaptiveCardDialog());
+        this.addDialog(new WaterfallDialog(WATERFALL_DIALOG, [
+            this.initialStep.bind(this),
+            this.finalStep.bind(this)
+        ]));
+
+        this.initialDialogId = WATERFALL_DIALOG;
+    }
+
+    /**
+     * The run method handles the incoming activity (in the form of a TurnContext) and passes it through the dialog system.
+     * If no dialog is active, it will start the default dialog.
+     * @param {*} turnContext
+     * @param {*} accessor
+     */
+    async run(turnContext, accessor) {
+        const dialogSet = new DialogSet(accessor);
+        dialogSet.add(this);
+
+        const dialogContext = await dialogSet.createContext(turnContext);
+        const results = await dialogContext.continueDialog();
+        if (results.status === DialogTurnStatus.empty) {
+            await dialogContext.beginDialog(this.id);
+        }
+    }
+
+    async initialStep(stepContext) {
+        return await stepContext.beginDialog(ADAPTIVE_CARD_DIALOG);
+    }
+
+    async finalStep(stepContext) {
+        return await stepContext.endDialog();
+    }
+}
+
+module.exports.MainDialog = MainDialog;
+module.exports.MAIN_DIALOG = MAIN_DIALOG;

--- a/experimental/adaptive-card-prompt-sample/javascript_nodejs/dialogs/mainDialog.js
+++ b/experimental/adaptive-card-prompt-sample/javascript_nodejs/dialogs/mainDialog.js
@@ -8,9 +8,8 @@ const MAIN_DIALOG = 'MAIN_DIALOG';
 const WATERFALL_DIALOG = 'WATERFALL_DIALOG';
 
 class MainDialog extends ComponentDialog {
-    constructor(userState) {
+    constructor() {
         super(MAIN_DIALOG);
-        this.userState = userState;
 
         this.addDialog(new AdaptiveCardDialog());
         this.addDialog(new WaterfallDialog(WATERFALL_DIALOG, [

--- a/experimental/adaptive-card-prompt-sample/javascript_nodejs/index.js
+++ b/experimental/adaptive-card-prompt-sample/javascript_nodejs/index.js
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const path = require('path');
+const restify = require('restify');
+
+// Import required bot services.
+// See https://aka.ms/bot-services to learn more about the different parts of a bot.
+const { BotFrameworkAdapter, MemoryStorage, UserState, ConversationState } = require('botbuilder');
+
+const { DialogAndWelcomeBot } = require('./bots/dialogAndWelcomeBot');
+const { MainDialog } = require('./dialogs/mainDialog');
+
+// Read environment variables from .env file
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
+// Create HTTP server
+let server = restify.createServer();
+server.listen(process.env.port || process.env.PORT || 3978, function() {
+    console.log(`\n${ server.name } listening to ${ server.url }`);
+    console.log(`\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator`);
+});
+
+// Create adapter.
+// See https://aka.ms/about-bot-adapter to learn more about adapters.
+const adapter = new BotFrameworkAdapter({
+    appId: process.env.MicrosoftAppId,
+    appPassword: process.env.MicrosoftAppPassword
+});
+
+// Define state store for your bot.
+// See https://aka.ms/about-bot-state to learn more about bot state.
+const memoryStorage = new MemoryStorage();
+
+// Create user and conversation state with in-memory storage provider.
+const userState = new UserState(memoryStorage);
+const conversationState = new ConversationState(memoryStorage);
+
+// Create the main dialog.
+const dialog = new MainDialog(userState);
+const bot = new DialogAndWelcomeBot(conversationState, userState, dialog);
+
+// Catch-all for errors.
+adapter.onTurnError = async (context, error) => {
+    // This check writes out errors to console log .vs. app insights.
+    console.error(`\n [onTurnError]: ${ error }`);
+    // Send a message to the user
+    await context.sendActivity(`Oops. Something went wrong!`);
+    // Clear out state
+    await conversationState.load(context);
+    await conversationState.clear(context);
+    // Save state changes.
+    await conversationState.saveChanges(context);
+};
+
+// Listen for incoming requests.
+server.post('/api/messages', (req, res) => {
+    adapter.processActivity(req, res, async (context) => {
+        // Route to main dialog.
+        await bot.run(context);
+    });
+});

--- a/experimental/adaptive-card-prompt-sample/javascript_nodejs/index.js
+++ b/experimental/adaptive-card-prompt-sample/javascript_nodejs/index.js
@@ -38,7 +38,7 @@ const userState = new UserState(memoryStorage);
 const conversationState = new ConversationState(memoryStorage);
 
 // Create the main dialog.
-const dialog = new MainDialog(userState);
+const dialog = new MainDialog();
 const bot = new DialogAndWelcomeBot(conversationState, userState, dialog);
 
 // Catch-all for errors.

--- a/experimental/adaptive-card-prompt-sample/javascript_nodejs/package.json
+++ b/experimental/adaptive-card-prompt-sample/javascript_nodejs/package.json
@@ -1,0 +1,29 @@
+{
+    "name": "complex-dialog-bot",
+    "version": "1.0.0",
+    "description": "Sample code for the how to topic for creating advanced conversation flow",
+    "author": "Microsoft",
+    "license": "MIT",
+    "main": "index.js",
+    "scripts": {
+        "start": "node ./index.js",
+        "watch": "nodemon ./index.js",
+        "lint": "eslint .",
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "dependencies": {
+        "botbuilder": "~4.4.0",
+        "botbuilder-dialogs": "~4.4.0",
+        "dotenv": "^6.2.0",
+        "restify": "~8.3.3"
+    },
+    "devDependencies": {
+        "eslint": "^5.16.0",
+        "eslint-config-standard": "^12.0.0",
+        "eslint-plugin-import": "^2.14.0",
+        "eslint-plugin-node": "^7.0.1",
+        "eslint-plugin-promise": "^4.0.1",
+        "eslint-plugin-standard": "^4.0.0",
+        "nodemon": "^1.18.11"
+    }
+}

--- a/experimental/adaptive-card-prompt-sample/javascript_nodejs/resources/adaptiveCard.json
+++ b/experimental/adaptive-card-prompt-sample/javascript_nodejs/resources/adaptiveCard.json
@@ -1,0 +1,172 @@
+{
+    "type": "AdaptiveCard",
+    "body": [
+        {
+            "type": "TextBlock",
+            "size": "Medium",
+            "weight": "Bolder",
+            "text": "Your registration is almost complete"
+        },
+        {
+            "type": "TextBlock",
+            "text": "What type of food do you prefer?",
+            "wrap": true
+        },
+        {
+            "type": "ImageSet",
+            "images": [
+                {
+                    "type": "Image",
+                    "url": "http://contososcubademo.azurewebsites.net/assets/steak.jpg",
+                    "size": "Medium"
+                },
+                {
+                    "type": "Image",
+                    "url": "http://contososcubademo.azurewebsites.net/assets/chicken.jpg",
+                    "size": "Medium"
+                },
+                {
+                    "type": "Image",
+                    "url": "http://contososcubademo.azurewebsites.net/assets/tofu.jpg",
+                    "size": "Medium"
+                }
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.ShowCard",
+            "title": "Steak",
+            "card": {
+                "type": "AdaptiveCard",
+                "body": [
+                    {
+                        "type": "TextBlock",
+                        "size": "Medium",
+                        "text": "How would you like your steak prepared?",
+                        "wrap": true
+                    },
+                    {
+                        "type": "Input.ChoiceSet",
+                        "id": "SteakTemp",
+                        "choices": [
+                            {
+                                "title": "Rare",
+                                "value": "rare"
+                            },
+                            {
+                                "title": "Medium-Rare",
+                                "value": "medium-rare"
+                            },
+                            {
+                                "title": "Well-done",
+                                "value": "well-done"
+                            }
+                        ],
+                        "style": "expanded"
+                    },
+                    {
+                        "type": "Input.Text",
+                        "id": "SteakOther",
+                        "placeholder": "Any other preparation requests?",
+                        "isMultiline": true
+                    }
+                ],
+                "actions": [
+                    {
+                        "type": "Action.Submit",
+                        "title": "OK",
+                        "data": {
+                            "FoodChoice": "Steak"
+                        }
+                    }
+                ],
+                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
+            }
+        },
+        {
+            "type": "Action.ShowCard",
+            "title": "Chicken",
+            "card": {
+                "type": "AdaptiveCard",
+                "body": [
+                    {
+                        "type": "TextBlock",
+                        "size": "Medium",
+                        "text": "Do you have any allergies?",
+                        "wrap": true
+                    },
+                    {
+                        "type": "Input.ChoiceSet",
+                        "id": "ChickenAllergy",
+                        "choices": [
+                            {
+                                "title": "I'm allergic to peanuts",
+                                "value": "peanut"
+                            }
+                        ],
+                        "style": "expanded",
+                        "isMultiSelect": true
+                    },
+                    {
+                        "type": "Input.Text",
+                        "id": "ChickenOther",
+                        "placeholder": "Any other preparation requests?",
+                        "isMultiline": true
+                    }
+                ],
+                "actions": [
+                    {
+                        "type": "Action.Submit",
+                        "title": "OK",
+                        "data": {
+                            "FoodChoice": "Chicken"
+                        }
+                    }
+                ],
+                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
+            }
+        },
+        {
+            "type": "Action.ShowCard",
+            "title": "Tofu",
+            "card": {
+                "type": "AdaptiveCard",
+                "body": [
+                    {
+                        "type": "TextBlock",
+                        "size": "Medium",
+                        "text": "Would you like it prepared vegan?",
+                        "wrap": true
+                    },
+                    {
+                        "type": "Input.Toggle",
+                        "id": "Vegetarian",
+                        "title": "Please prepare it vegan",
+                        "valueOn": "vegan",
+                        "valueOff": "notVegan",
+                        "wrap": false
+                    },
+                    {
+                        "type": "Input.Text",
+                        "id": "VegOther",
+                        "placeholder": "Any other preparation requests?",
+                        "isMultiline": true
+                    }
+                ],
+                "actions": [
+                    {
+                        "type": "Action.Submit",
+                        "title": "OK",
+                        "data": {
+                            "FoodChoice": "Vegetarian"
+                        }
+                    }
+                ],
+                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
+            }
+        }
+    ],
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.0"
+}


### PR DESCRIPTION
Reference: https://github.com/microsoft/botframework-sdk/issues/5396

Per @johnataylor in SDK standup on 6/28, adding this as a sample.

## Proposed Changes

Adds a sample for using the un-merged [AdaptiveCardPrompt](https://github.com/mdrichardson/botbuilder-js/blob/adaptiveCardPrompt/libraries/botbuilder-dialogs/src/prompts/adaptiveCardPrompt.ts)

## Testing

![image](https://user-images.githubusercontent.com/40401643/60469279-fbd59880-9c10-11e9-837f-edbf19e92c6c.png)

## Note

The C# Sample doesn't work because it uses:

* [`Prompt<int>.AttemptCountKey`](https://github.com/microsoft/BotBuilder-Samples/blob/7535fd4333813fe7e62a55cef0c45b1fa3f3a57d/experimental/adaptive-card-prompt-sample/dotnet/AdaptiveCardPrompt.cs#L93), and
* [`PromptValidatorContext`](https://github.com/microsoft/BotBuilder-Samples/blob/7535fd4333813fe7e62a55cef0c45b1fa3f3a57d/experimental/adaptive-card-prompt-sample/dotnet/AdaptiveCardPrompt.cs#L118)

...which are both internal to the Dotnet SDK and can't be directly used in a sample without AdaptiveCardPrompt getting merged. However, the C# sample is included (without having tested), so it's easy to add, if needed.