### PR TITLE
QnABot now messages user warning if QnA not configured properly

### DIFF
--- a/samples/javascript_nodejs/11.qnamaker/bots/QnABot.js
+++ b/samples/javascript_nodejs/11.qnamaker/bots/QnABot.js
@@ -33,6 +33,13 @@ class QnABot extends ActivityHandler {
 
         // When a user sends a message, perform a call to the QnA Maker service to retrieve matching Question and Answer pairs.
         this.onMessage(async (context, next) => {
+            if (!process.env.QnAKnowledgebaseId || !process.env.QnAEndpointKey || !process.env.QnAEndpointHostName) {
+                let configQnaMessage = 'NOTE: QnA Maker is not configured. To enable all capabilities, add `QnAKnowledgebaseId`, `QnAEndpointKey` and `QnAEndpointHostName` to the .env file. \n' +
+                    'You may visit www.qnamaker.ai to create a QnA Maker knowledge base.'
+                
+                await context.sendActivity(configQnaMessage)
+            }
+
             console.log('Calling QnA Maker');
 
             const qnaResults = await this.qnaMaker.getAnswers(context);


### PR DESCRIPTION
Fixes #1578 

## Proposed Changes
  - Previously when user started QnABot in sample 11.qnamaker without setting up QnA KB, bot would simply respond "Oops. Something went wrong" without any clear explanation, when the user started the bot and sent a message to bot
  - Now bot will check if a QnA KB is configured properly with the bot, and will message the user to provide missing credentials, if needed. Provides link to qnamaker.ai if KB needs to be created.
    - This is done in the onMessage handler
