### PR TITLE
add credential provider back to dotnet proactive bot startup

### DIFF
--- a/samples/csharp_dotnetcore/02.echo-bot/Startup.cs
+++ b/samples/csharp_dotnetcore/02.echo-bot/Startup.cs
@@ -28,10 +28,7 @@ namespace Microsoft.BotBuilderSamples
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
-
-            // Create the credential provider to be used with the Bot Framework Adapter.
-            services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();
-
+            
             // Create the Bot Framework Adapter.
             services.AddSingleton<IBotFrameworkHttpAdapter, BotFrameworkHttpAdapter>();
 

--- a/samples/csharp_dotnetcore/16.proactive-messages/Controllers/NotifyController.cs
+++ b/samples/csharp_dotnetcore/16.proactive-messages/Controllers/NotifyController.cs
@@ -9,8 +9,8 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
 
 namespace ProactiveBot.Controllers
 {
@@ -22,11 +22,11 @@ namespace ProactiveBot.Controllers
         private readonly string _appId;
         private readonly ConcurrentDictionary<string, ConversationReference> _conversationReferences;
 
-        public NotifyController(IBotFrameworkHttpAdapter adapter, ICredentialProvider credentials, ConcurrentDictionary<string, ConversationReference> conversationReferences)
+        public NotifyController(IBotFrameworkHttpAdapter adapter, IConfiguration configuration, ConcurrentDictionary<string, ConversationReference> conversationReferences)
         {
             _adapter = adapter;
             _conversationReferences = conversationReferences;
-            _appId = ((SimpleCredentialProvider)credentials).AppId;
+            _appId = configuration["MicrosoftAppId"];
 
             // If the channel is the Emulator, and authentication is not in use,
             // the AppId will be null.  We generate a random AppId for this case only.

--- a/samples/csharp_dotnetcore/16.proactive-messages/Startup.cs
+++ b/samples/csharp_dotnetcore/16.proactive-messages/Startup.cs
@@ -21,6 +21,9 @@ namespace Microsoft.BotBuilderSamples
         {
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
 
+            // Create the credential provider to be used with the Bot Framework Adapter.
+            services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();
+
             // Create the Bot Framework Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 

--- a/samples/csharp_dotnetcore/16.proactive-messages/Startup.cs
+++ b/samples/csharp_dotnetcore/16.proactive-messages/Startup.cs
@@ -6,9 +6,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -20,10 +18,7 @@ namespace Microsoft.BotBuilderSamples
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
-
-            // Create the credential provider to be used in the NotifyController.
-            services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();
-
+            
             // Create the Bot Framework Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 

--- a/samples/csharp_dotnetcore/16.proactive-messages/Startup.cs
+++ b/samples/csharp_dotnetcore/16.proactive-messages/Startup.cs
@@ -18,7 +18,7 @@ namespace Microsoft.BotBuilderSamples
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
-            
+
             // Create the Bot Framework Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 


### PR DESCRIPTION
It was mistakenly removed with this commit: 
https://github.com/microsoft/BotBuilder-Samples/commit/31eb77e5923f48906844427a1b2a299bb1cadaf5#diff-633d7e7e1a7f5e883042736fbf9d039a