### PR TITLE
Use standard tts voice

### DIFF
--- a/experimental/directline-speech/csharp_dotnetcore/02.echo-bot/Bots/EchoBot.cs
+++ b/experimental/directline-speech/csharp_dotnetcore/02.echo-bot/Bots/EchoBot.cs
@@ -31,7 +31,7 @@ namespace Microsoft.BotBuilderSamples.Bots
         {
             var activity = MessageFactory.Text(message);
             string body = @"<speak version='1.0' xmlns='https://www.w3.org/2001/10/synthesis' xml:lang='en-US'>
-              <voice name='Microsoft Server Speech Text to Speech Voice (en-US, JessaRUS)'>" +
+              <voice name='Microsoft Server Speech Text to Speech Voice (en-US, JessaNeural)'>" +
               $"{message}" + "</voice></speak>";
             activity.Speak = body;
             return activity;

--- a/experimental/directline-speech/csharp_dotnetcore/02.echo-bot/Bots/EchoBot.cs
+++ b/experimental/directline-speech/csharp_dotnetcore/02.echo-bot/Bots/EchoBot.cs
@@ -31,7 +31,7 @@ namespace Microsoft.BotBuilderSamples.Bots
         {
             var activity = MessageFactory.Text(message);
             string body = @"<speak version='1.0' xmlns='https://www.w3.org/2001/10/synthesis' xml:lang='en-US'>
-              <voice name='Microsoft Server Speech Text to Speech Voice (en-US, JessaNeural)'>" +
+              <voice name='Microsoft Server Speech Text to Speech Voice (en-US, JessaRUS)'>" +
               $"{message}" + "</voice></speak>";
             activity.Speak = body;
             return activity;

--- a/experimental/directline-speech/csharp_dotnetcore/13.core-bot/SpeakExtensions.cs
+++ b/experimental/directline-speech/csharp_dotnetcore/13.core-bot/SpeakExtensions.cs
@@ -13,7 +13,7 @@ namespace CoreBot
         {
             var activity = MessageFactory.Text(message);
             string body = @"<speak version='1.0' xmlns='https://www.w3.org/2001/10/synthesis' xml:lang='en-US'>
-              <voice name='Microsoft Server Speech Text to Speech Voice (en-US, JessaRUS)'>" +
+              <voice name='Microsoft Server Speech Text to Speech Voice (en-US, JessaNeural)'>" +
               $"{message}" + "</voice></speak>";
             activity.Speak = body;
             return activity;

--- a/experimental/directline-speech/csharp_dotnetcore/13.core-bot/SpeakExtensions.cs
+++ b/experimental/directline-speech/csharp_dotnetcore/13.core-bot/SpeakExtensions.cs
@@ -13,7 +13,7 @@ namespace CoreBot
         {
             var activity = MessageFactory.Text(message);
             string body = @"<speak version='1.0' xmlns='https://www.w3.org/2001/10/synthesis' xml:lang='en-US'>
-              <voice name='Microsoft Server Speech Text to Speech Voice (en-US, JessaNeural)'>" +
+              <voice name='Microsoft Server Speech Text to Speech Voice (en-US, JessaRUS)'>" +
               $"{message}" + "</voice></speak>";
             activity.Speak = body;
             return activity;


### PR DESCRIPTION
## Proposed Changes
Use standard voice instead of Neural voice, since Neural voices are only available in limited Azure regions. For example, developers who are using free-trial speech subscriptions will not be able to use this voice. In my tutorial I will address this and show how to use Neural. But the checked-in sample code should use Standard voice until we have more wide-spread deployment of Neural voices.

## Testing
Compiled, deployed bot. Tested with DL Speech Client tool with west-us speech keys to make sure the Bot can speak.