### PR TITLE
Fixes 1710 - 1.console-echo bot does not exit after type 'quit'

### DIFF
--- a/samples/csharp_dotnetcore/01.console-echo/EchoBot.cs
+++ b/samples/csharp_dotnetcore/01.console-echo/EchoBot.cs
@@ -18,10 +18,17 @@ namespace Console_EchoBot
             // Handle Message activity type, which is the main activity type within a conversational interface
             // Message activities may contain text, speech, interactive cards, and binary or unknown attachments.
             // see https://aka.ms/about-bot-activity-message to learn more about the message and other activity types
-            if (turnContext.Activity.Type == ActivityTypes.Message)
+            if (turnContext.Activity.Type == ActivityTypes.Message && turnContext.Activity.Text != null)
             {
-                // Echo back to the user whatever they typed.
-                await turnContext.SendActivityAsync($"You sent '{turnContext.Activity.Text}'");
+                // Check to see if the user sent a simple "quit" message.
+                if (turnContext.Activity.Text.ToLower() == "quit") {
+                    // Send a reply.
+                    await turnContext.SendActivityAsync($"Bye!");
+                    System.Environment.Exit(0);
+                } else {
+                    // Echo back to the user whatever they typed.
+                    await turnContext.SendActivityAsync($"You sent '{turnContext.Activity.Text}'");
+                }
             }
             else
             {

--- a/samples/csharp_dotnetcore/01.console-echo/Program.cs
+++ b/samples/csharp_dotnetcore/01.console-echo/Program.cs
@@ -9,7 +9,8 @@ namespace Console_EchoBot
     {
         public static void Main(string[] args)
         {
-            Console.WriteLine("Welcome to the EchoBot. Type something to get started.");
+            Console.WriteLine("Console EchoBot is online. I will repeat any message you send me!");
+            Console.WriteLine("Say \"quit\" to end.");
 
             // Create the Console Adapter, and add Conversation State
             // to the Bot. The Conversation State will be stored in memory.


### PR DESCRIPTION
Fixes #1710 

## Proposed Changes
- added code to condition for `quit`


## Testing
Run the bot
type 'quit'
bot should terminate