### PR TITLE
[03.welcome-user] Changed verbatim string literals to string concatenation

### DIFF
--- a/samples/csharp_dotnetcore/03.welcome-user/Bots/WelcomeUserBot.cs
+++ b/samples/csharp_dotnetcore/03.welcome-user/Bots/WelcomeUserBot.cs
@@ -20,23 +20,23 @@ namespace Microsoft.BotBuilderSamples
     public class WelcomeUserBot : ActivityHandler
     {
         // Messages sent to the user.
-        private const string WelcomeMessage = @"This is a simple Welcome Bot sample. This bot will introduce you
-                                                to welcoming and greeting users. You can say 'intro' to see the
-                                                introduction card. If you are running this bot in the Bot Framework
-                                                Emulator, press the 'Start Over' button to simulate user joining
-                                                a bot or a channel";
+        private const string WelcomeMessage = "This is a simple Welcome Bot sample. This bot will introduce you " +
+                                                "to welcoming and greeting users. You can say 'intro' to see the " +
+                                                "introduction card. If you are running this bot in the Bot Framework " +
+                                                "Emulator, press the 'Start Over' button to simulate user joining " +
+                                                "a bot or a channel";
 
-        private const string InfoMessage = @"You are seeing this message because the bot received at least one
-                                            'ConversationUpdate' event, indicating you (and possibly others)
-                                            joined the conversation. If you are using the emulator, pressing
-                                            the 'Start Over' button to trigger this event again. The specifics
-                                            of the 'ConversationUpdate' event depends on the channel. You can
-                                            read more information at:
-                                             https://aka.ms/about-botframework-welcome-user";
+        private const string InfoMessage = "You are seeing this message because the bot received at least one " +
+                                            "'ConversationUpdate' event, indicating you (and possibly others) " +
+                                            "joined the conversation. If you are using the emulator, pressing " +
+                                            "the 'Start Over' button to trigger this event again. The specifics " +
+                                            "of the 'ConversationUpdate' event depends on the channel. You can " +
+                                            "read more information at: " +
+                                            "https://aka.ms/about-botframework-welcome-user";
 
-        private const string PatternMessage = @"It is a good pattern to use this event to send general greeting
-                                              to user, explaining what your bot can do. In this example, the bot
-                                              handles 'hello', 'hi', 'help' and 'intro'. Try it now, type 'hi'";
+        private const string PatternMessage = "It is a good pattern to use this event to send general greeting" +
+                                              "to user, explaining what your bot can do. In this example, the bot " +
+                                              "handles 'hello', 'hi', 'help' and 'intro'. Try it now, type 'hi'";
 
         private BotState _userState;
 


### PR DESCRIPTION
Fixes #1734 

___

### Changes

Given that WebChat uses Markdown, which interprets indentation as code blocks, currently the C# `03.welcome-user` sample appears broken when testing in emulator and web chat. 

Per front end team, **work around the Markdown interpretation by avoiding using verbatim string literals**, which sends `\r\n` when starting a new line. **Using string concatenation as a workaround**  to have block of text remain multi-lined, while not appearing as a malformed message in emulator. 

Before:
![image](https://user-images.githubusercontent.com/35248895/63815003-c9ca7500-c8e7-11e9-95b7-9c16e0961dfb.png)


After:
![image](https://user-images.githubusercontent.com/35248895/63814996-c1723a00-c8e7-11e9-9c09-93ffeca6c2a9.png)
