### PR TITLE
Sends user warning if QnA is unconfigured; if unconfigured, doesn't c…

### DIFF
--- a/samples/javascript_nodejs/11.qnamaker/bots/QnABot.js
+++ b/samples/javascript_nodejs/11.qnamaker/bots/QnABot.js
@@ -54,9 +54,10 @@ class QnABot extends ActivityHandler {
                     await context.sendActivity('No QnA Maker answers were found.');
                 }
     
-                // By calling next() you ensure that the next BotHandler is run.
-                await next();
             }
+            
+            // By calling next() you ensure that the next BotHandler is run.
+            await next();
         });
     }
 }

--- a/samples/javascript_nodejs/11.qnamaker/bots/QnABot.js
+++ b/samples/javascript_nodejs/11.qnamaker/bots/QnABot.js
@@ -33,21 +33,30 @@ class QnABot extends ActivityHandler {
 
         // When a user sends a message, perform a call to the QnA Maker service to retrieve matching Question and Answer pairs.
         this.onMessage(async (context, next) => {
-            console.log('Calling QnA Maker');
+            if (!process.env.QnAKnowledgebaseId || !process.env.QnAEndpointKey || !process.env.QnAEndpointHostName) {
+                let unconfiguredQnaMessage = 'NOTE: \r\n' + 
+                    'QnA Maker is not configured. To enable all capabilities, add `QnAKnowledgebaseId`, `QnAEndpointKey` and `QnAEndpointHostName` to the .env file. \r\n' +
+                    'You may visit www.qnamaker.ai to create a QnA Maker knowledge base.'
 
-            const qnaResults = await this.qnaMaker.getAnswers(context);
-
-            // If an answer was received from QnA Maker, send the answer back to the user.
-            if (qnaResults[0]) {
-                await context.sendActivity(qnaResults[0].answer);
-
-            // If no answers were returned from QnA Maker, reply with help.
-            } else {
-                await context.sendActivity('No QnA Maker answers were found.');
+                 await context.sendActivity(unconfiguredQnaMessage)
             }
-
-            // By calling next() you ensure that the next BotHandler is run.
-            await next();
+            else {
+                console.log('Calling QnA Maker');
+    
+                const qnaResults = await this.qnaMaker.getAnswers(context);
+    
+                // If an answer was received from QnA Maker, send the answer back to the user.
+                if (qnaResults[0]) {
+                    await context.sendActivity(qnaResults[0].answer);
+    
+                // If no answers were returned from QnA Maker, reply with help.
+                } else {
+                    await context.sendActivity('No QnA Maker answers were found.');
+                }
+    
+                // By calling next() you ensure that the next BotHandler is run.
+                await next();
+            }
         });
     }
 }


### PR DESCRIPTION
Fixes #1578 

## Proposed Changes
  - **Previously** when user started QnABot in sample 11.qnamaker without setting up QnA KB, bot would simply respond "Oops. Something went wrong" without any clear explanation, when the user started the bot and sent a message to bot
  - **Now** bot will check if a QnA KB is configured properly with the bot, and will message the user to provide missing credentials, if needed. Provides link to qnamaker.ai if KB needs to be created.
    - This is done in the onMessage handler
    - If QnA is not configured, then bot will _not_ call `QnAMaker.getAnswers()`

## Screen shot

![image](https://user-images.githubusercontent.com/35248895/63977898-e2629880-ca69-11e9-9735-4618b9f2fb3c.png)
