### PR TITLE
[Sample 46] Added instructions for testing in Teams

### DIFF
--- a/samples/csharp_dotnetcore/46.teams-auth/README.md
+++ b/samples/csharp_dotnetcore/46.teams-auth/README.md
@@ -51,6 +51,11 @@ After Authentication has been configured via Azure Bot Service, you can test the
   - Select `TeamsAuth.csproj` file
   - Press `F5` to run the project
 
+## Testing the bot using Microsoft Teams
+
+1. Ensure that you've [enabled the Teams Channel](https://docs.microsoft.com/en-us/azure/bot-service/channel-connect-teams?view=azure-bot-service-4.0)
+2. [Install your Bot to Teams via App Studio](https://docs.microsoft.com/en-us/microsoftteams/platform/get-started/get-started-app-studio), ensuring that you've added `token.botframework.com` to the [Valid Domains](https://docs.microsoft.com/en-us/microsoftteams/platform/get-started/get-started-app-studio) (*Note: In App Studio, this is in `Manifest Editor > Your App > Domains and Permissions`*)
+
 ## Testing the bot using Bot Framework Emulator
 
 [Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.

--- a/samples/csharp_dotnetcore/46.teams-auth/README.md
+++ b/samples/csharp_dotnetcore/46.teams-auth/README.md
@@ -54,7 +54,7 @@ After Authentication has been configured via Azure Bot Service, you can test the
 ## Testing the bot using Microsoft Teams
 
 1. Ensure that you've [enabled the Teams Channel](https://docs.microsoft.com/en-us/azure/bot-service/channel-connect-teams?view=azure-bot-service-4.0)
-2. [Install your Bot to Teams via App Studio](https://docs.microsoft.com/en-us/microsoftteams/platform/get-started/get-started-app-studio), ensuring that you've added `token.botframework.com` to the [Valid Domains](https://docs.microsoft.com/en-us/microsoftteams/platform/get-started/get-started-app-studio) (*Note: In App Studio, this is in `Manifest Editor > Your App > Domains and Permissions`*)
+2. [Install your Bot to Teams via App Studio](https://docs.microsoft.com/en-us/microsoftteams/platform/get-started/get-started-app-studio), ensuring that you've added `token.botframework.com` to the [Valid Domains](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema#validdomains) (*Note: In App Studio, this is in `Manifest Editor > Your App > Domains and Permissions`*)
 
 ## Testing the bot using Bot Framework Emulator
 

--- a/samples/javascript_nodejs/46.teams-auth/README.md
+++ b/samples/javascript_nodejs/46.teams-auth/README.md
@@ -45,6 +45,11 @@ The sample uses the bot authentication capabilities in [Azure Bot Service](https
 
 After Authentication has been configured via Azure Bot Service, you can test the bot.
 
+## Testing the bot using Microsoft Teams
+
+1. Ensure that you've [enabled the Teams Channel](https://docs.microsoft.com/en-us/azure/bot-service/channel-connect-teams?view=azure-bot-service-4.0)
+2. [Install your Bot to Teams via App Studio](https://docs.microsoft.com/en-us/microsoftteams/platform/get-started/get-started-app-studio), ensuring that you've added `token.botframework.com` to the [Valid Domains](https://docs.microsoft.com/en-us/microsoftteams/platform/get-started/get-started-app-studio) (*Note: In App Studio, this is in `Manifest Editor > Your App > Domains and Permissions`*)
+
 ## Testing the bot using Bot Framework Emulator
 
 [Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.

--- a/samples/javascript_nodejs/46.teams-auth/README.md
+++ b/samples/javascript_nodejs/46.teams-auth/README.md
@@ -48,7 +48,7 @@ After Authentication has been configured via Azure Bot Service, you can test the
 ## Testing the bot using Microsoft Teams
 
 1. Ensure that you've [enabled the Teams Channel](https://docs.microsoft.com/en-us/azure/bot-service/channel-connect-teams?view=azure-bot-service-4.0)
-2. [Install your Bot to Teams via App Studio](https://docs.microsoft.com/en-us/microsoftteams/platform/get-started/get-started-app-studio), ensuring that you've added `token.botframework.com` to the [Valid Domains](https://docs.microsoft.com/en-us/microsoftteams/platform/get-started/get-started-app-studio) (*Note: In App Studio, this is in `Manifest Editor > Your App > Domains and Permissions`*)
+2. [Install your Bot to Teams via App Studio](https://docs.microsoft.com/en-us/microsoftteams/platform/get-started/get-started-app-studio), ensuring that you've added `token.botframework.com` to the [Valid Domains](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema#validdomains) (*Note: In App Studio, this is in `Manifest Editor > Your App > Domains and Permissions`*)
 
 ## Testing the bot using Bot Framework Emulator
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/BotBuilder-Samples/issues/1740
Fixes https://github.com/microsoft/BotBuilder-Samples/issues/1739

## Proposed Changes

Adds the following instructions to both languages of Sample 46 - Teams Auth:

1. Ensure that you've [enabled the Teams Channel](https://docs.microsoft.com/en-us/azure/bot-service/channel-connect-teams?view=azure-bot-service-4.0)
2. [Install your Bot to Teams via App Studio](https://docs.microsoft.com/en-us/microsoftteams/platform/get-started/get-started-app-studio), ensuring that you've added `token.botframework.com` to the [Valid Domains](https://docs.microsoft.com/en-us/microsoftteams/platform/get-started/get-started-app-studio) (*Note: In App Studio, this is in `Manifest Editor > Your App > Domains and Permissions`*)