### PR TITLE
Log exceptions properly to get the stack trace

### DIFF
--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/AdapterWithErrorHandler.cs
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/AdapterWithErrorHandler.cs
@@ -20,7 +20,7 @@ namespace CoreBot
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
-                logger.LogError($"Exception caught : {exception.Message}");
+                logger.LogError(exception, $"Exception caught : {exception.Message}");
 
                 // Send a catch-all apology to the user.
                 var errorMessageText = "Sorry, it looks like something went wrong.";

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/AdapterWithErrorHandler.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/AdapterWithErrorHandler.cs
@@ -22,7 +22,7 @@ namespace $safeprojectname$
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
-                logger.LogError($"Exception caught : {exception.Message}");
+                logger.LogError(exception, $"Exception caught : {exception.Message}");
 
                 // Send a catch-all apology to the user.
                 var errorMessage = MessageFactory.Text(ErrorMsgText, ErrorMsgText, InputHints.ExpectingInput);

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/AdapterWithErrorHandler.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/AdapterWithErrorHandler.cs
@@ -22,7 +22,7 @@ namespace $ext_safeprojectname$
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
-                logger.LogError($"Exception caught : {exception.Message}");
+                logger.LogError(exception, $"Exception caught : {exception.Message}");
 
                 // Send a catch-all apology to the user.
                 var errorMessage = MessageFactory.Text(ErrorMsgText, ErrorMsgText, InputHints.ExpectingInput);

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/AdapterWithErrorHandler.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/AdapterWithErrorHandler.cs
@@ -17,7 +17,7 @@ namespace $safeprojectname$
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
-                logger.LogError($"Exception caught : {exception.Message}");
+                logger.LogError(exception, $"Exception caught : {exception.Message}");
 
                 // Send a catch-all apology to the user.
                 await turnContext.SendActivityAsync("Sorry, it looks like something went wrong.");

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/AdapterWithErrorHandler.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/AdapterWithErrorHandler.cs
@@ -17,7 +17,7 @@ namespace $safeprojectname$
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
-                logger.LogError($"Exception caught : {exception.Message}");
+                logger.LogError(exception, $"Exception caught : {exception.Message}");
 
                 // Send a catch-all apology to the user.
                 await turnContext.SendActivityAsync("Sorry, it looks like something went wrong.");


### PR DESCRIPTION
This is not really a bug fix or a new feature, just a minor enhancement.

## Proposed Changes

Currently, when exceptions are catched in the `AdapterWithErrorHandler` only the message is logged  but having the stack trace is usually useful to solve the problem.

So this change is to just use the logger overload that logs the stack trace.

## Testing

No testing really needed here, it's just enough to check that it compiles.