### PR TITLE
Simple url change to fix the link to LG readme.

### DIFF
--- a/experimental/adaptive-dialog/docs/language-generation.md
+++ b/experimental/adaptive-dialog/docs/language-generation.md
@@ -44,7 +44,7 @@ new SendActivity("[MyLGTemplateName]")
 - Roger
 ```
 
-[1]:../../language-generation/language-generation.md
+[1]:../../language-generation/README.md
 [2]:../csharp_dotnetcore
 
 


### PR DESCRIPTION
Simple url change to fix the link to LG readme.

Old link points to language-generation/language-generation.md and it should be language-generation/README.md

https://github.com/microsoft/BotBuilder-Samples/issues/1782
