### PR TITLE
Update state sample to show usage of Blob / CosmosDB storage.

### DIFF
--- a/samples/csharp_dotnetcore/45.state-management/README.md
+++ b/samples/csharp_dotnetcore/45.state-management/README.md
@@ -4,6 +4,41 @@ This sample demonstrates how to save user and conversation data in an ASP.Net Co
 The bot maintains conversation state to track and direct the conversation and ask the user questions.
 The bot maintains user state to track the user's answers.
 
+By default this bot uses MemoryStorage for Conversation and User state.
+Memory Storage is great for testing purposes, but in a production scenario you will need to use persistent storage.
+Startup.cs contains commented examples of using Azure Blob Storage or Cosmos DB instead.
+
+# Azure Blob Storage
+
+To use Azure Blob Storage, create a Blob Storage account in your Azure subscription. You can then use the following code to
+create your storage layer, passing in your Blob Storage connection string and a blob container name.  
+
+***Note: You do not need to create the container manually, the bot will create the container for you if it does not exist.***
+
+```cs
+    var storage = new AzureBlobStorage("<blob-storage-connection-string>", "bot-state");
+```
+
+# CosmosDB Storage
+
+To use CosmosDB Storage, you need to create a CosmosDB instance in your Azure subscription. You can then use the following code to
+create your storage layer.  
+
+***Note: It is your responsibility to create an appropriate database within your CosmosDB instance. However, you should **not**
+create the container within the database, as the bot will do this for you and ensure the container is configured correctly.***
+
+```cs
+    var cosmosDbStorageOptions = new CosmosDbPartitionedStorageOptions()
+    {
+        CosmosDbEndpoint = "<endpoint-for-your-cosmosdb-instance>",
+        AuthKey = "<your-cosmosdb-auth-key>",
+        DatabaseId = "<your-database-id>",
+        ContainerId = "<cosmosdb-container-id>"
+    };
+
+    var storage = new CosmosDbPartitionedStorage(cosmosDbStorageOptions);    
+```
+
 ## Further reading
 
 - [Azure Bot Service](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)

--- a/samples/csharp_dotnetcore/45.state-management/Startup.cs
+++ b/samples/csharp_dotnetcore/45.state-management/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Azure;
 using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Connector.Authentication;
@@ -22,14 +23,38 @@ namespace Microsoft.BotBuilderSamples
             // Create the Bot Framework Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 
-            // Create the storage we'll be using for User and Conversation state. (Memory is great for testing purposes.)
-            services.AddSingleton<IStorage, MemoryStorage>();
+            // Create the storage we'll be using for User and Conversation state.
+            // (Memory is great for testing purposes - examples of implementing storage with
+            // Azure Blob Storage or Cosmos DB are below).
+            var storage = new MemoryStorage();
 
-            // Create the User state.
-            services.AddSingleton<UserState>();
+            /* AZURE BLOB STORAGE - Uncomment the code in this section to use Azure blob storage */
+                           
+            // var storage = new AzureBlobStorage("<blob-storage-connection-string>", "bot-state");
 
-            // Create the Conversation state.
-            services.AddSingleton<ConversationState>();
+            /* END AZURE BLOB STORAGE */
+
+
+            /* COSMOSDB STORAGE - Uncomment the code in this section to use CosmosDB storage */
+
+            // var cosmosDbStorageOptions = new CosmosDbPartitionedStorageOptions()
+            // {
+            //     CosmosDbEndpoint = "<endpoint-for-your-cosmosdb-instance>",
+            //     AuthKey = "<your-cosmosdb-auth-key>",
+            //     DatabaseId = "<your-database-id>",
+            //     ContainerId = "<cosmosdb-container-id>"
+            // };
+            // var storage = new CosmosDbPartitionedStorage(cosmosDbStorageOptions);
+
+            /* END COSMOSDB STORAGE */
+
+            // Create the User state passing in the storage layer.
+            var userState = new UserState(storage);
+            services.AddSingleton(userState);
+
+            // Create the Conversation state passing in the storage layer.
+            var conversationState = new ConversationState(storage);
+            services.AddSingleton(conversationState);
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
             services.AddTransient<IBot, StateManagementBot>();

--- a/samples/csharp_dotnetcore/45.state-management/StateMangementBot.csproj
+++ b/samples/csharp_dotnetcore/45.state-management/StateMangementBot.csproj
@@ -7,7 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.5.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.6.0-preview-191001-1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.6.0-preview-191001-1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
@cleemullins @sgellock This change is in response to #1719. Can you comment as to if this meets your requirements for showing Cosmos / Blob usage.

I took the decision to have them all in the single state sample, with MemoryStorage still the default - so that the bot still runs OOTB with no changes, but then have commented implementations for Cosmos / blob.
I also updated the readme with more details for the user to understand that other storage layers are available (and recommended for production) and some notes on implementation.