### PR TITLE
Update App Insights sample to use new TelemetryInitializerMiddleware

### DIFF
--- a/samples/csharp_dotnetcore/21.corebot-app-insights/CoreBot-App-Insights.csproj
+++ b/samples/csharp_dotnetcore/21.corebot-app-insights/CoreBot-App-Insights.csproj
@@ -6,11 +6,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.5.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.5.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.5.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.5.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.5.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.6.0-preview-191002-1" />
+    <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Version="4.6.0-preview-191002-1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.6.0-preview-191002-1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.6.0-preview-191002-1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.6.0-preview-191002-1" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.1.5" />
   </ItemGroup>
 

--- a/samples/csharp_dotnetcore/21.corebot-app-insights/Startup.cs
+++ b/samples/csharp_dotnetcore/21.corebot-app-insights/Startup.cs
@@ -29,17 +29,17 @@ namespace Microsoft.BotBuilderSamples
             // Create the telemetry client.
             services.AddSingleton<IBotTelemetryClient, BotTelemetryClient>();
 
-            // Add ASP middleware to store the http body mapped with bot activity key in the httpcontext.items. This will be picked by the TelemetryBotIdInitializer
-            services.AddTransient<TelemetrySaveBodyASPMiddleware>();
-
             // Add telemetry initializer that will set the correlation context for all telemetry items.
             services.AddSingleton<ITelemetryInitializer, OperationCorrelationTelemetryInitializer>();
 
             // Add telemetry initializer that sets the user ID and session ID (in addition to other bot-specific properties such as activity ID)
             services.AddSingleton<ITelemetryInitializer, TelemetryBotIdInitializer>();
 
-            // Create the telemetry middleware to track conversation events
-            services.AddSingleton<IMiddleware, TelemetryLoggerMiddleware>();
+            // Create the telemetry middleware to initialize telemetry gathering
+            services.AddSingleton<IMiddleware, TelemetryInitializerMiddleware>();
+
+            // Create the telemetry middleware (used by the telemetry initializer) to track conversation events
+            services.AddSingleton<TelemetryLoggerMiddleware>();
 
             // Create the Bot Framework Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
@@ -76,7 +76,6 @@ namespace Microsoft.BotBuilderSamples
             app.UseStaticFiles();
 
             //app.UseHttpsRedirection();
-            app.UseBotApplicationInsights();
             app.UseMvc();
         }
     }


### PR DESCRIPTION
Updated sample to use new TelemetryInitializer middleware and remove deprecated middleware / method calls.

Note: This PR will merge into a 4.6 samples branch, which will track the daily myget packages until the public packages are available. Once they are the 4.6 samples branch will be merged into master.