### PR TITLE
#1712: Update sample 70 to warn users about using secrets

### DIFF
--- a/samples/javascript_es6/70.styling-webchat/README.md
+++ b/samples/javascript_es6/70.styling-webchat/README.md
@@ -8,6 +8,8 @@ This sample shows how to create a web page with customized [Web Chat](https://gi
 
 > You will need to obtain bot secret from a bot hosted on Azure Bot Services. You can follow this [article](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-channel-connect-webchat?view=azure-bot-service-3.0#step-1) to get the bot secret key.
 
+> To communicate with your bot securely, you will need to obtain a token from your implemented token server. To learn more about the differences between secrets and tokens, and to understand the risks associated with using secrets, read the [article on authentication](https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-direct-line-3-0-authentication?view=azure-bot-service-4.0). *For simplicity, this sample does not show an implementation of a token server*.
+
 - Clone this repository
 
    ```sh
@@ -20,7 +22,10 @@ This sample shows how to create a web page with customized [Web Chat](https://gi
    cd samples/javascript_es6/70.styling-webchat
    ```
 
-- In [`index.html`](https://github.com/Microsoft/BotBuilder-Samples/tree/v4/samples/javascript_es6/70.styling-webchat), put your bot secret key by replacing `YOUR_BOT_SECRET_FROM_AZURE` with the key
+- In [`index.html`](https://github.com/Microsoft/BotBuilder-Samples/tree/v4/samples/javascript_es6/70.styling-webchat), put your bot secret key by replacing `YOUR_BOT_SECRET_FROM_AZURE` with the key. 
+
+> Note: Reminder that using your secret to communicate with the bot is not secure, and we reccommend implementing a token server. Please see the notes above on authentication.
+
 - Host it using [`serve`](https://npmjs.com/package/serve)
 
    ```sh

--- a/samples/javascript_es6/70.styling-webchat/index.html
+++ b/samples/javascript_es6/70.styling-webchat/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
   <head>
     <title>Web Chat: Customizing thru style options</title>
-    <script type="text/javascript" src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
+    <script type="text/javascript" src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
     <style>
       html, body { height: 100% }
       body { margin: 0 }
@@ -29,8 +29,19 @@
         bubbleTextColor: 'White'
       };
 
+      // In this demo, we are showing how to initialize Web Chat with a secret. This is NOT RECOMMENDED for deployed bots.
+      // Your client code must provide either a secret or a token to talk to your bot.
+      // Tokens are more secure. To learn about the differences between secrets and tokens
+      // and to understand the risks associated with using secrets, visit https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-direct-line-3-0-authentication?view=azure-bot-service-4.0
+
+      // The code commented out below exemplifies how to implement the same page while fetching a token from your own token server.
+      
+      // const res = await fetch('https:YOUR_TOKEN_SERVER.NET/API', { method: 'POST' });
+      // const { token } = await res.json();
+
       window.WebChat.renderWebChat({
         directLine: window.WebChat.createDirectLine({ secret: 'YOUR_BOT_SECRET_FROM_AZURE' }),
+        // directLine: window.WebChat.createDirectLine({ token }),
         styleOptions
       }, document.getElementById('webchat'));
     </script>


### PR DESCRIPTION
Fixes #1712

## Proposed Changes
This PR is needed because we no longer recommend users sending a secret to DirectLine in order to speak to a bot. Although this sample still shows a user how to use a secret, this is done intentionally so that this sample works 'out of the box'. 

However, the `index.html` and README now both have notes that we do not recommend using the secret, and links to documentation on where they can learn more about secrets vs. tokens.

A token server sample does not yet exist, but once that is implemented, we can add that link to this sample. 

Working sample screenshot:
![image](https://user-images.githubusercontent.com/14900841/66527008-5ce1f780-eaaf-11e9-9512-5b8703d4f2e8.png)

~## Testing~
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->