### PR TITLE
Highlight includeApiResults flag in NLP samples

### DIFF
--- a/samples/csharp_dotnetcore/14.nlp-with-dispatch/BotServices.cs
+++ b/samples/csharp_dotnetcore/14.nlp-with-dispatch/BotServices.cs
@@ -14,12 +14,14 @@ namespace Microsoft.BotBuilderSamples
         public BotServices(IConfiguration configuration)
         {
             // Read the setting for cognitive services (LUIS, QnA) from the appsettings.json
+            // If includeApiResults is set to true, the full response from the LUIS api (LuisResult)
+            // will be made available in the properties collection of the RecognizerResult
             Dispatch = new LuisRecognizer(new LuisApplication(
                 configuration["LuisAppId"],
                 configuration["LuisAPIKey"],
                 $"https://{configuration["LuisAPIHostName"]}.api.cognitive.microsoft.com"),
                 new LuisPredictionOptions { IncludeAllIntents = true, IncludeInstanceData = true },
-                true);
+                includeApiResults: true);
 
             SampleQnA = new QnAMaker(new QnAMakerEndpoint
             {

--- a/samples/javascript_nodejs/14.nlp-with-dispatch/bots/dispatchBot.js
+++ b/samples/javascript_nodejs/14.nlp-with-dispatch/bots/dispatchBot.js
@@ -8,6 +8,8 @@ class DispatchBot extends ActivityHandler {
     constructor() {
         super();
 
+        // If the includeApiResults parameter is set to true, as shown below, the full response 
+        // from the LUIS api will be made available in the properties  of the RecognizerResult
         const dispatchRecognizer = new LuisRecognizer({
             applicationId: process.env.LuisAppId,
             endpointKey: process.env.LuisAPIKey,


### PR DESCRIPTION
Based on this issue https://github.com/microsoft/botbuilder-dotnet/issues/2686 the includeApiResults flag is not explicitly called out as being able to provide the full Luis results on the recognizer results.  This update simply adds a comment highlighting the use of the parameter.