### PR TITLE
Updated Sample 24 Graph API version

### DIFF
--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/BotAuthenticationMSGraph.csproj
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/BotAuthenticationMSGraph.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Graph" Version="1.10.0" />
+    <PackageReference Include="Microsoft.Graph" Version="1.17.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.5.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.5.1" />
   </ItemGroup>

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/README.md
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/README.md
@@ -86,6 +86,13 @@ including Windows, Office 365, and Azure.
 
 To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.
 
+## GraphError 404: ResourceNotFound, Resource could not be discovered
+
+This error may confusingly present itself if either of the following are true:
+
+* You're using an email ending in `@microsoft.com`, and/or
+* Your OAuth AAD tenant is `microsoft.onmicrosoft.com`.
+
 ## Further reading
 
 - [Bot Framework Documentation](https://docs.botframework.com)

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/README.md
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/README.md
@@ -84,6 +84,13 @@ including Windows, Office 365, and Azure.
 
 To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.
 
+## GraphError 404: ResourceNotFound, Resource could not be discovered
+
+This error may confusingly present itself if either of the following are true:
+
+* You're using an email ending in `@microsoft.com`, and/or
+* Your OAuth AAD tenant is `microsoft.onmicrosoft.com`.
+
 ## Further Reading
 
 - [Bot Framework Documentation](https://docs.botframework.com)

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/package.json
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "@microsoft/microsoft-graph-client": "1.4.0",
+        "@microsoft/microsoft-graph-client": "~2.0.0",
         "botbuilder": "~4.5.1",
         "botbuilder-dialogs": "~4.5.1",
         "dotenv": "^8.0.0",


### PR DESCRIPTION
Fixes #1538 

## Proposed Changes

* Updates Node Sample 24 Graph API to v2.0.0
* Updates C# Sample 24 Graph API to v1.17.0 (latest stable)
* Adds the following note to both READMEs (because it took me far too long to troubleshoot this):

> ## GraphError 404: ResourceNotFound, Resource could not be discovered
> This error may confusingly present itself if either of the following are true:
> * You're using an email ending in `@microsoft.com`, and/or
> * Your OAuth AAD tenant is `microsoft.onmicrosoft.com`.

**I'm open to changing this message if somebody feels it could be more informative. In my own testing, this is what I discovered, but I'm not sure how our BotFramework tenant restrictions affect this.**

## Testing

I tested both samples with the updates and all three operations worked: `me`, `send <email>`, `recent`.