### PR TITLE
DO NOT MERGE: Enable WebSockets and HttpGet on DotNet Samples

### DIFF
--- a/samples/csharp_dotnetcore/02.echo-bot/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/02.echo-bot/Controllers/BotController.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples.Controllers
             Bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/02.echo-bot/Startup.cs
+++ b/samples/csharp_dotnetcore/02.echo-bot/Startup.cs
@@ -48,7 +48,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/03.welcome-user/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/03.welcome-user/Controllers/BotController.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples
             _bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/03.welcome-user/Startup.cs
+++ b/samples/csharp_dotnetcore/03.welcome-user/Startup.cs
@@ -48,7 +48,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/Controllers/BotController.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples
             _bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/Startup.cs
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/Startup.cs
@@ -52,7 +52,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/06.using-cards/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/06.using-cards/Controllers/BotController.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples
             _bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/06.using-cards/Startup.cs
+++ b/samples/csharp_dotnetcore/06.using-cards/Startup.cs
@@ -52,7 +52,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/Controllers/BotController.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples
             _bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/Startup.cs
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/Startup.cs
@@ -40,7 +40,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/08.suggested-actions/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/08.suggested-actions/Controllers/BotController.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples
             _bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/08.suggested-actions/Startup.cs
+++ b/samples/csharp_dotnetcore/08.suggested-actions/Startup.cs
@@ -40,7 +40,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/11.qnamaker/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/11.qnamaker/Controllers/BotController.cs
@@ -26,7 +26,7 @@ namespace Microsoft.BotBuilderSamples.Controllers
             Bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/11.qnamaker/Startup.cs
+++ b/samples/csharp_dotnetcore/11.qnamaker/Startup.cs
@@ -65,7 +65,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/13.core-bot/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/13.core-bot/Controllers/BotController.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples.Controllers
             Bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/13.core-bot/Startup.cs
+++ b/samples/csharp_dotnetcore/13.core-bot/Startup.cs
@@ -58,7 +58,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             app.UseMvc();
         }
     }

--- a/samples/csharp_dotnetcore/14.nlp-with-dispatch/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/14.nlp-with-dispatch/Controllers/BotController.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
             _bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processingg of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/14.nlp-with-dispatch/Startup.cs
+++ b/samples/csharp_dotnetcore/14.nlp-with-dispatch/Startup.cs
@@ -43,7 +43,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/15.handling-attachments/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/15.handling-attachments/Controllers/BotController.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples
             _bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/15.handling-attachments/Startup.cs
+++ b/samples/csharp_dotnetcore/15.handling-attachments/Startup.cs
@@ -42,7 +42,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/16.proactive-messages/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/16.proactive-messages/Controllers/BotController.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples
             _bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/16.proactive-messages/Startup.cs
+++ b/samples/csharp_dotnetcore/16.proactive-messages/Startup.cs
@@ -43,7 +43,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/17.multilingual-bot/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/Controllers/BotController.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples.Controllers
             Bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/17.multilingual-bot/Startup.cs
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/Startup.cs
@@ -61,7 +61,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/18.bot-authentication/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/18.bot-authentication/Controllers/BotController.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples
             _bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/18.bot-authentication/Startup.cs
+++ b/samples/csharp_dotnetcore/18.bot-authentication/Startup.cs
@@ -52,7 +52,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/19.custom-dialogs/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/Controllers/BotController.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples
             _bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/19.custom-dialogs/Startup.cs
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/Startup.cs
@@ -52,7 +52,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/21.corebot-app-insights/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/21.corebot-app-insights/Controllers/BotController.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples.Controllers
             Bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/21.corebot-app-insights/Startup.cs
+++ b/samples/csharp_dotnetcore/21.corebot-app-insights/Startup.cs
@@ -74,7 +74,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseBotApplicationInsights();
             app.UseMvc();

--- a/samples/csharp_dotnetcore/23.facebook-events/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/23.facebook-events/Controllers/BotController.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples.Controllers
             Bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/23.facebook-events/Startup.cs
+++ b/samples/csharp_dotnetcore/23.facebook-events/Startup.cs
@@ -46,7 +46,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/Controllers/BotController.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples
             _bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/Startup.cs
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/Startup.cs
@@ -52,7 +52,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/42.scaleout/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/42.scaleout/Controllers/BotController.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples
             _bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/42.scaleout/Startup.cs
+++ b/samples/csharp_dotnetcore/42.scaleout/Startup.cs
@@ -56,7 +56,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/43.complex-dialog/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/43.complex-dialog/Controllers/BotController.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples
             _bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/43.complex-dialog/Startup.cs
+++ b/samples/csharp_dotnetcore/43.complex-dialog/Startup.cs
@@ -50,7 +50,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/44.prompt-users-for-input/Startup.cs
+++ b/samples/csharp_dotnetcore/44.prompt-users-for-input/Startup.cs
@@ -49,7 +49,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/45.state-management/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/45.state-management/Controllers/BotController.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples
             _bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/45.state-management/Startup.cs
+++ b/samples/csharp_dotnetcore/45.state-management/Startup.cs
@@ -49,7 +49,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/46.teams-auth/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/46.teams-auth/Controllers/BotController.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples
             _bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/46.teams-auth/Startup.cs
+++ b/samples/csharp_dotnetcore/46.teams-auth/Startup.cs
@@ -50,7 +50,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/47.inspection/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/47.inspection/Controllers/BotController.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples.Controllers
             Bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/47.inspection/Startup.cs
+++ b/samples/csharp_dotnetcore/47.inspection/Startup.cs
@@ -50,7 +50,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_dotnetcore/48.qnamaker-active-learning-bot/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/48.qnamaker-active-learning-bot/Controllers/BotController.cs
@@ -26,7 +26,7 @@ namespace Microsoft.BotBuilderSamples
             Bot = bot;
         }
 
-        [HttpPost]
+        [HttpPost, HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/samples/csharp_dotnetcore/48.qnamaker-active-learning-bot/Startup.cs
+++ b/samples/csharp_dotnetcore/48.qnamaker-active-learning-bot/Startup.cs
@@ -60,7 +60,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
+            app.UseWebSockets();
             //app.UseHttpsRedirection();
             app.UseMvc();
         }

--- a/samples/csharp_webapi/13.core-bot/Controllers/BotController.cs
+++ b/samples/csharp_webapi/13.core-bot/Controllers/BotController.cs
@@ -60,7 +60,7 @@ namespace Microsoft.BotBuilderSamples
 
         [HttpPost]
         [HttpGet]
-        public async Task<HttpResponseMessage> Post()
+        public async Task<HttpResponseMessage> PostAsync()
         {
             var response = new HttpResponseMessage();
 

--- a/samples/csharp_webapi/13.core-bot/Controllers/BotController.cs
+++ b/samples/csharp_webapi/13.core-bot/Controllers/BotController.cs
@@ -58,6 +58,8 @@ namespace Microsoft.BotBuilderSamples
             _dialog = new MainDialog(bookingRecognizer, bookingDialog, _loggerFactory.CreateLogger<MainDialog>());
         }
 
+        [HttpPost]
+        [HttpGet]
         public async Task<HttpResponseMessage> Post()
         {
             var response = new HttpResponseMessage();


### PR DESCRIPTION
These changes add the lines app.useWebSockets() to startup.cs and HttpGet to BotController.cs for all of the DotNetCore samples, in order to have them support the Streaming extensions added in BotBuilder 4.6, which allows them to work with the DirectLine Speech channel without further code changes.

For the lone WebAPI sample WebSocket support is included by default, so the controller method only needed route decorators. (It previous had none but was named Post, allowing the auto-route to be created for Post, but not Get.)