### PR TITLE
fix error handling and env for js translation

### DIFF
--- a/samples/javascript_nodejs/17.multilingual-bot/.env
+++ b/samples/javascript_nodejs/17.multilingual-bot/.env
@@ -1,3 +1,3 @@
 MicrosoftAppId=
 MicrosoftAppPassword=
-translationKey=
+translatorKey=

--- a/samples/javascript_nodejs/17.multilingual-bot/bots/multilingualBot.js
+++ b/samples/javascript_nodejs/17.multilingual-bot/bots/multilingualBot.js
@@ -48,7 +48,6 @@ class MultilingualBot extends ActivityHandler {
         });
 
         this.onMessage(async (context, next) => {
-            console.log('Running dialog with Message Activity.');
 
             if (isLanguageChangeRequested(context.activity.text)) {
                 const currentLang = context.activity.text.toLowerCase();

--- a/samples/javascript_nodejs/17.multilingual-bot/index.js
+++ b/samples/javascript_nodejs/17.multilingual-bot/index.js
@@ -11,7 +11,7 @@ const { TranslatorMiddleware } = require('./translation/translatorMiddleware');
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-const { BotFrameworkAdapter, MemoryStorage, UserState } = require('botbuilder');
+const { BotFrameworkAdapter, MemoryStorage, UserState, ActivityTypes, TurnContext } = require('botbuilder');
 
 // This bot's main dialog.
 const { MultilingualBot } = require('./bots/multilingualBot');
@@ -44,9 +44,11 @@ adapter.onTurnError = async (context, error) => {
         'TurnError'
     );
 
-    // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
-    await context.sendActivity('To continue to run this bot, please fix the bot source code.');
+    // Send a message to the user - send through the adapater to skip the translation middleware (because it might throw)
+    const conversationReference = TurnContext.getConversationReference(context.activity);
+    await context.adapter.sendActivities(context, [
+        TurnContext.applyConversationReference({ type: ActivityTypes.Message, text: 'The bot encounted an error or bug.' }, conversationReference),
+        TurnContext.applyConversationReference({ type: ActivityTypes.Message, text: 'To continue to run this bot, please fix the bot source code.' }, conversationReference)]);
 };
 
 // Define a state store for your bot. See https://aka.ms/about-bot-state to learn more about using MemoryStorage.

--- a/samples/javascript_nodejs/17.multilingual-bot/translation/microsoftTranslator.js
+++ b/samples/javascript_nodejs/17.multilingual-bot/translation/microsoftTranslator.js
@@ -22,22 +22,26 @@ class MicrosoftTranslator {
 
         const url = host + path + params + targetLocale;
 
-        return fetch(url, {
+        var res = await fetch(url, {
             method: 'POST',
             body: JSON.stringify([{ Text: text }]),
             headers: {
                 'Content-Type': 'application/json',
                 'Ocp-Apim-Subscription-Key': this.key
             }
-        })
-            .then(res => res.json())
-            .then(responseBody => {
-                if (responseBody && responseBody.length > 0) {
-                    return responseBody[0].translations[0].text;
-                } else {
-                    return text;
-                }
-            });
+        });
+
+        if (!res.ok) {
+            throw new Error('Call to translation services failed.');
+        }
+
+        var responseBody = await res.json();
+
+        if (responseBody && responseBody.length > 0) {
+            return responseBody[0].translations[0].text;
+        } else {
+            return text;
+        }
     }
 }
 


### PR DESCRIPTION
- fix typo in .env file on translator key
- changed code to use await (rather than a mix of async and raw Promise)
- fix error handler to send message directly through adapter so skipping middleware (because it might be the translate middleware that is failing)

