### PR TITLE
Updated Cancel tests to check for the right status (Cancelled) in 4.6

### DIFF
--- a/samples/csharp_dotnetcore/13.core-bot.tests/Dialogs/BookingDialogTests.cs
+++ b/samples/csharp_dotnetcore/13.core-bot.tests/Dialogs/BookingDialogTests.cs
@@ -67,7 +67,7 @@ namespace CoreBot.Tests.Dialogs
                 Assert.Equal(bookingTestData.UtterancesAndReplies[i, 1], reply.Text);
             }
 
-            Assert.Equal(DialogTurnStatus.Complete, testClient.DialogTurnResult.Status);
+            Assert.Equal(DialogTurnStatus.Cancelled, testClient.DialogTurnResult.Status);
             Assert.Null(testClient.DialogTurnResult.Result);
         }
     }

--- a/samples/csharp_dotnetcore/13.core-bot.tests/Dialogs/CancelAndHelpDialogTests.cs
+++ b/samples/csharp_dotnetcore/13.core-bot.tests/Dialogs/CancelAndHelpDialogTests.cs
@@ -42,7 +42,7 @@ namespace CoreBot.Tests.Dialogs
 
             reply = await testClient.SendActivityAsync<IMessageActivity>(cancelUtterance);
             Assert.Equal("Cancelling...", reply.Text);
-            Assert.Equal(DialogTurnStatus.Complete, testClient.DialogTurnResult.Status);
+            Assert.Equal(DialogTurnStatus.Cancelled, testClient.DialogTurnResult.Status);
         }
 
         [Theory]


### PR DESCRIPTION
Updated cancellation tests to check against the right status (Cancelled) that was fixed in 4.6