### PR TITLE
[Node.js Samples] Refactor bots to override ActivityHandler.run() to save state instead 

### DIFF
--- a/samples/javascript_nodejs/03.welcome-users/bots/welcomeBot.js
+++ b/samples/javascript_nodejs/03.welcome-users/bots/welcomeBot.js
@@ -55,8 +55,6 @@ class WelcomeBot extends ActivityHandler {
                                                     Framework Emulator, press the 'Start Over' button to simulate user joining a bot or a channel`);
                 }
             }
-            // Save state changes
-            await this.userState.saveChanges(context);
 
             // By calling next() you ensure that the next BotHandler is run.
             await next();
@@ -86,6 +84,16 @@ class WelcomeBot extends ActivityHandler {
             // By calling next() you ensure that the next BotHandler is run.
             await next();
         });
+    }
+
+    /**
+     * Override the ActivityHandler.run() method to save state changes after the bot logic completes.
+     */
+    async run(context) {
+        await super.run(context);
+
+        // Save state changes
+        await this.userState.saveChanges(context);
     }
 
     async sendIntroCard(context) {

--- a/samples/javascript_nodejs/05.multi-turn-prompt/bots/dialogBot.js
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/bots/dialogBot.js
@@ -29,13 +29,17 @@ class DialogBot extends ActivityHandler {
 
             await next();
         });
+    }
 
-        this.onDialog(async (context, next) => {
-            // Save any state changes. The load happened during the execution of the Dialog.
-            await this.conversationState.saveChanges(context, false);
-            await this.userState.saveChanges(context, false);
-            await next();
-        });
+    /**
+     * Override the ActivityHandler.run() method to save state changes after the bot logic completes.
+     */
+    async run(context) {
+        await super.run(context);
+
+        // Save any state changes. The load happened during the execution of the Dialog.
+        await this.conversationState.saveChanges(context, false);
+        await this.userState.saveChanges(context, false);
     }
 }
 

--- a/samples/javascript_nodejs/06.using-cards/bots/dialogBot.js
+++ b/samples/javascript_nodejs/06.using-cards/bots/dialogBot.js
@@ -37,15 +37,17 @@ class DialogBot extends ActivityHandler {
             // By calling next() you ensure that the next BotHandler is run.
             await next();
         });
+    }
 
-        this.onDialog(async (context, next) => {
-            // Save any state changes. The load happened during the execution of the Dialog.
-            await this.conversationState.saveChanges(context, false);
-            await this.userState.saveChanges(context, false);
+    /**
+     * Override the ActivityHandler.run() method to save state changes after the bot logic completes.
+     */
+    async run(context) {
+        await super.run(context);
 
-            // By calling next() you ensure that the next BotHandler is run.
-            await next();
-        });
+        // Save any state changes. The load happened during the execution of the Dialog.
+        await this.conversationState.saveChanges(context, false);
+        await this.userState.saveChanges(context, false);
     }
 }
 

--- a/samples/javascript_nodejs/13.core-bot/bots/dialogBot.js
+++ b/samples/javascript_nodejs/13.core-bot/bots/dialogBot.js
@@ -30,15 +30,17 @@ class DialogBot extends ActivityHandler {
             // By calling next() you ensure that the next BotHandler is run.
             await next();
         });
+    }
 
-        this.onDialog(async (context, next) => {
-            // Save any state changes. The load happened during the execution of the Dialog.
-            await this.conversationState.saveChanges(context, false);
-            await this.userState.saveChanges(context, false);
+    /**
+     * Override the ActivityHandler.run() method to save state changes after the bot logic completes.
+     */
+    async run(context) {
+        await super.run(context);
 
-            // By calling next() you ensure that the next BotHandler is run.
-            await next();
-        });
+        // Save any state changes. The load happened during the execution of the Dialog.
+        await this.conversationState.saveChanges(context, false);
+        await this.userState.saveChanges(context, false);
     }
 }
 

--- a/samples/javascript_nodejs/17.multilingual-bot/bots/multilingualBot.js
+++ b/samples/javascript_nodejs/17.multilingual-bot/bots/multilingualBot.js
@@ -62,7 +62,6 @@ class MultilingualBot extends ActivityHandler {
                 // selected language.
                 // If Spanish was selected by the user, the reply below will actually be shown in spanish to the user.
                 await context.sendActivity(`Your current language code is: ${ lang }`);
-                await this.userState.saveChanges(context);
             } else {
                 // Show the user the possible options for language. The translation middleware
                 // will pick up the language selected by the user and
@@ -87,6 +86,16 @@ class MultilingualBot extends ActivityHandler {
             // By calling next() you ensure that the next BotHandler is run.
             await next();
         });
+    }
+
+    /**
+     * Override the ActivityHandler.run() method to save state changes after the bot logic completes.
+     */
+    async run(context) {
+        await super.run(context);
+
+        // Save state changes
+        await this.userState.saveChanges(context);
     }
 }
 

--- a/samples/javascript_nodejs/18.bot-authentication/bots/dialogBot.js
+++ b/samples/javascript_nodejs/18.bot-authentication/bots/dialogBot.js
@@ -29,14 +29,17 @@ class DialogBot extends ActivityHandler {
 
             await next();
         });
+    }
 
-        this.onDialog(async (context, next) => {
-            // Save any state changes. The load happened during the execution of the Dialog.
-            await this.conversationState.saveChanges(context, false);
-            await this.userState.saveChanges(context, false);
+    /**
+     * Override the ActivityHandler.run() method to save state changes after the bot logic completes.
+     */
+    async run(context) {
+        await super.run(context);
 
-            await next();
-        });
+        // Save any state changes. The load happened during the execution of the Dialog.
+        await this.conversationState.saveChanges(context, false);
+        await this.userState.saveChanges(context, false);
     }
 }
 

--- a/samples/javascript_nodejs/19.custom-dialogs/bots/dialogBot.js
+++ b/samples/javascript_nodejs/19.custom-dialogs/bots/dialogBot.js
@@ -30,15 +30,17 @@ class DialogBot extends ActivityHandler {
             // By calling next() you ensure that the next BotHandler is run.
             await next();
         });
+    }
 
-        this.onDialog(async (context, next) => {
-            // Save any state changes. The load happened during the execution of the Dialog.
-            await this.conversationState.saveChanges(context, false);
-            await this.userState.saveChanges(context, false);
+    /**
+     * Override the ActivityHandler.run() method to save state changes after the bot logic completes.
+     */
+    async run(context) {
+        await super.run(context);
 
-            // By calling next() you ensure that the next BotHandler is run.
-            await next();
-        });
+        // Save any state changes. The load happened during the execution of the Dialog.
+        await this.conversationState.saveChanges(context, false);
+        await this.userState.saveChanges(context, false);
     }
 }
 

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/bots/dialogBot.js
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/bots/dialogBot.js
@@ -30,15 +30,17 @@ class DialogBot extends ActivityHandler {
             // By calling next() you ensure that the next BotHandler is run.
             await next();
         });
+    }
 
-        this.onDialog(async (context, next) => {
-            // Save any state changes. The load happened during the execution of the Dialog.
-            await this.conversationState.saveChanges(context, false);
-            await this.userState.saveChanges(context, false);
+    /**
+     * Override the ActivityHandler.run() method to save state changes after the bot logic completes.
+     */
+    async run(context) {
+        await super.run(context);
 
-            // By calling next() you ensure that the next BotHandler is run.
-            await next();
-        });
+        // Save any state changes. The load happened during the execution of the Dialog.
+        await this.conversationState.saveChanges(context, false);
+        await this.userState.saveChanges(context, false);
     }
 }
 

--- a/samples/javascript_nodejs/43.complex-dialog/bots/dialogBot.js
+++ b/samples/javascript_nodejs/43.complex-dialog/bots/dialogBot.js
@@ -30,15 +30,17 @@ class DialogBot extends ActivityHandler {
             // By calling next() you ensure that the next BotHandler is run.
             await next();
         });
+    }
 
-        this.onDialog(async (context, next) => {
-            // Save any state changes. The load happened during the execution of the Dialog.
-            await this.conversationState.saveChanges(context, false);
-            await this.userState.saveChanges(context, false);
+    /**
+     * Override the ActivityHandler.run() method to save state changes after the bot logic completes.
+     */
+    async run(context) {
+        await super.run(context);
 
-            // By calling next() you ensure that the next BotHandler is run.
-            await next();
-        });
+        // Save any state changes. The load happened during the execution of the Dialog.
+        await this.conversationState.saveChanges(context, false);
+        await this.userState.saveChanges(context, false);
     }
 }
 

--- a/samples/javascript_nodejs/44.prompt-for-user-input/bots/customPromptBot.js
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/bots/customPromptBot.js
@@ -37,15 +37,17 @@ class CustomPromptBot extends ActivityHandler {
             // By calling next() you ensure that the next BotHandler is run.
             await next();
         });
+    }
 
-        this.onDialog(async (context, next) => {
-            // Save any state changes. The load happened during the execution of the Dialog.
-            await this.conversationState.saveChanges(context, false);
-            await this.userState.saveChanges(context, false);
+    /**
+     * Override the ActivityHandler.run() method to save state changes after the bot logic completes.
+     */
+    async run(context) {
+        await super.run(context);
 
-            // By calling next() you ensure that the next BotHandler is run.
-            await next();
-        });
+        // Save any state changes. The load happened during the execution of the Dialog.
+        await this.conversationState.saveChanges(context, false);
+        await this.userState.saveChanges(context, false);
     }
 
     // Manages the conversation flow for filling out the user's profile.

--- a/samples/javascript_nodejs/45.state-management/bots/stateManagementBot.js
+++ b/samples/javascript_nodejs/45.state-management/bots/stateManagementBot.js
@@ -57,15 +57,6 @@ class StateManagementBot extends ActivityHandler {
             await next();
         });
 
-        this.onDialog(async (turnContext, next) => {
-            // Save any state changes. The load happened during the execution of the Dialog.
-            await this.conversationState.saveChanges(turnContext, false);
-            await this.userState.saveChanges(turnContext, false);
-
-            // By calling next() you ensure that the next BotHandler is run.
-            await next();
-        });
-
         this.onMembersAdded(async (context, next) => {
             const membersAdded = context.activity.membersAdded;
             for (let cnt = 0; cnt < membersAdded.length; ++cnt) {
@@ -76,6 +67,17 @@ class StateManagementBot extends ActivityHandler {
             // By calling next() you ensure that the next BotHandler is run.
             await next();
         });
+    }
+
+    /**
+     * Override the ActivityHandler.run() method to save state changes after the bot logic completes.
+     */
+    async run(context) {
+        await super.run(context);
+
+        // Save any state changes. The load happened during the execution of the Dialog.
+        await this.conversationState.saveChanges(context, false);
+        await this.userState.saveChanges(context, false);
     }
 }
 

--- a/samples/javascript_nodejs/46.teams-auth/bots/dialogBot.js
+++ b/samples/javascript_nodejs/46.teams-auth/bots/dialogBot.js
@@ -29,14 +29,17 @@ class DialogBot extends TeamsActivityHandler {
 
             await next();
         });
+    }
 
-        this.onDialog(async (context, next) => {
-            // Save any state changes. The load happened during the execution of the Dialog.
-            await this.conversationState.saveChanges(context, false);
-            await this.userState.saveChanges(context, false);
+    /**
+     * Override the ActivityHandler.run() method to save state changes after the bot logic completes.
+     */
+    async run(context) {
+        await super.run(context);
 
-            await next();
-        });
+        // Save any state changes. The load happened during the execution of the Dialog.
+        await this.conversationState.saveChanges(context, false);
+        await this.userState.saveChanges(context, false);
     }
 }
 

--- a/samples/javascript_nodejs/47.inspection/bot.js
+++ b/samples/javascript_nodejs/47.inspection/bot.js
@@ -27,15 +27,6 @@ class IntersectionBot extends ActivityHandler {
             await next();
         });
 
-        this.onDialog(async (context, next) => {
-            // Save any state changes. The load happened during the execution of the Dialog.
-            await this.conversationState.saveChanges(context, false);
-            await this.userState.saveChanges(context, false);
-
-            // By calling next() you ensure that the next BotHandler is run.
-            await next();
-        });
-
         this.onMembersAdded(async (context, next) => {
             const membersAdded = context.activity.membersAdded;
             for (let cnt = 0; cnt < membersAdded.length; ++cnt) {
@@ -46,6 +37,17 @@ class IntersectionBot extends ActivityHandler {
             // By calling next() you ensure that the next BotHandler is run.
             await next();
         });
+    }
+
+    /**
+     * Override the ActivityHandler.run() method to save state changes after the bot logic completes.
+     */
+    async run(context) {
+        await super.run(context);
+
+        // Save any state changes. The load happened during the execution of the Dialog.
+        await this.conversationState.saveChanges(context, false);
+        await this.userState.saveChanges(context, false);
     }
 }
 

--- a/samples/javascript_nodejs/49.qnamaker-all-features/bots/QnABot.js
+++ b/samples/javascript_nodejs/49.qnamaker-all-features/bots/QnABot.js
@@ -47,15 +47,17 @@ class QnABot extends ActivityHandler {
             // By calling next() you ensure that the next BotHandler is run.
             await next();
         });
+    }
 
-        this.onDialog(async (context, next) => {
-            // Save any state changes. The load happened during the execution of the Dialog.
-            await this.conversationState.saveChanges(context, false);
-            await this.userState.saveChanges(context, false);
+    /**
+     * Override the ActivityHandler.run() method to save state changes after the bot logic completes.
+     */
+    async run(context) {
+        await super.run(context);
 
-            // By calling next() you ensure that the next BotHandler is run.
-            await next();
-        });
+        // Save any state changes. The load happened during the execution of the Dialog.
+        await this.conversationState.saveChanges(context, false);
+        await this.userState.saveChanges(context, false);
     }
 }
 

--- a/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/bots/teamsMessagingExtensionsSearchAuthConfigBot.js
+++ b/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/bots/teamsMessagingExtensionsSearchAuthConfigBot.js
@@ -23,6 +23,16 @@ class TeamsMessagingExtensionsSearchAuthConfigBot extends TeamsActivityHandler {
         this.userState = userState;
     }
 
+    /**
+     * Override the ActivityHandler.run() method to save state changes after the bot logic completes.
+     */
+    async run(context) {
+        await super.run(context);
+
+        // Save state changes
+        await this.userState.saveChanges(context);
+    }
+
     async handleTeamsMessagingExtensionConfigurationQuerySettingUrl(context, query) {
         // The user has requested the Messaging Extension Configuration page settings url.
         const userSettings = await this.userConfigurationProperty.get(context, '');
@@ -47,7 +57,6 @@ class TeamsMessagingExtensionsSearchAuthConfigBot extends TeamsActivityHandler {
         // When the user submits the settings page, this event is fired.
         if (settings.state != null) {
             await this.userConfigurationProperty.set(context, settings.state);
-            await this.userState.saveChanges(context, false);
         }
     }
 

--- a/samples/typescript_nodejs/13.core-bot/src/bots/dialogBot.ts
+++ b/samples/typescript_nodejs/13.core-bot/src/bots/dialogBot.ts
@@ -43,14 +43,16 @@ export class DialogBot extends ActivityHandler {
             // By calling next() you ensure that the next BotHandler is run.
             await next();
         });
+    }
 
-        this.onDialog(async (context, next) => {
-            // Save any state changes. The load happened during the execution of the Dialog.
-            await this.conversationState.saveChanges(context, false);
-            await this.userState.saveChanges(context, false);
+    /**
+     * Override the ActivityHandler.run() method to save state changes after the bot logic completes.
+     */
+    async run(context): Promise<void> {
+        await super.run(context);
 
-            // By calling next() you ensure that the next BotHandler is run.
-            await next();
-        });
+        // Save any state changes. The load happened during the execution of the Dialog.
+        await this.conversationState.saveChanges(context, false);
+        await this.userState.saveChanges(context, false);
     }
 }


### PR DESCRIPTION
## Proposed Changes
Override ActivityHandler.run() instead of using ActivityHandler.onDialog() to save state changes.

```js
class DialogBot extends ActivityHandler {
    constructor(conversationState, userState, dialog) {
        super();
        this.conversationState = conversationState;
        this.userState = userState;
        this.dialog = dialog;
        this.dialogState = this.conversationState.createProperty('DialogState');

        this.onMessage(async (context, next) => {
            console.log('Running dialog with Message Activity.');

            // Run the Dialog with the new message Activity.
            await this.dialog.run(context, this.dialogState);

            await next();
        });

        // NOTE: This handler registration goes away...
        this.onDialog(async (context, next) => {
            // Save any state changes. The load happened during the execution of the Dialog.
            await this.conversationState.saveChanges(context, false);
            await this.userState.saveChanges(context, false);
            await next();
        });
    }
}
```

### The above changes to:

```js
class DialogBot extends ActivityHandler {
    constructor(conversationState, userState, dialog) {
        super();
        this.conversationState = conversationState;
        this.userState = userState;
        this.dialog = dialog;
        this.dialogState = this.conversationState.createProperty('DialogState');

        this.onMessage(async (context, next) => {
            console.log('Running dialog with Message Activity.');

            // Run the Dialog with the new message Activity.
            await this.dialog.run(context, this.dialogState);

            await next();
        });
    }

    // NOTE: We instead override the ActivityHandler.run() method to save state.
    /**
     * Override the ActivityHandler.run() method to save state changes after the bot logic completes.
     */
    async run(context) {
        await super.run(context);

        // Save any state changes. The load happened during the execution of the Dialog.
        await this.conversationState.saveChanges(context, false);
        await this.userState.saveChanges(context, false);
    }
}
```



## Testing
Manually started and ran samples to make sure they built successfully. Tested the code in a few samples to ensure the state was properly saved.

FYI @Kaiqb, @JonathanFingold 