### PR TITLE
Fixes #1966 in 17.multilingual-bot

### DIFF
--- a/samples/csharp_dotnetcore/17.multilingual-bot/Translation/MicrosoftTranslator.cs
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/Translation/MicrosoftTranslator.cs
@@ -30,7 +30,7 @@ namespace Microsoft.BotBuilderSamples.Translation
             var key = configuration["TranslatorKey"];
             _key = key ?? throw new ArgumentNullException(nameof(key));
 
-            var region = configuration["TranslateRegion"];
+            var region = configuration["TranslatorRegion"];
             _region = region == null ? "westus" : region;
         }
 

--- a/samples/csharp_dotnetcore/17.multilingual-bot/Translation/MicrosoftTranslator.cs
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/Translation/MicrosoftTranslator.cs
@@ -22,12 +22,16 @@ namespace Microsoft.BotBuilderSamples.Translation
         private static HttpClient _client = new HttpClient();
 
         private readonly string _key;
+        private readonly string _region;
 
 
         public MicrosoftTranslator(IConfiguration configuration)
         {
             var key = configuration["TranslatorKey"];
             _key = key ?? throw new ArgumentNullException(nameof(key));
+
+            var region = configuration["TranslateRegion"];
+            _region = region == null ? "westus" : region;
         }
 
         public async Task<string> TranslateAsync(string text, string targetLocale, CancellationToken cancellationToken = default(CancellationToken))
@@ -43,6 +47,7 @@ namespace Microsoft.BotBuilderSamples.Translation
                 request.Method = HttpMethod.Post;
                 request.RequestUri = new Uri(uri);
                 request.Content = new StringContent(requestBody, Encoding.UTF8, "application/json");
+                request.Headers.Add("Ocp-Apim-Subscription-Region", _region);
                 request.Headers.Add("Ocp-Apim-Subscription-Key", _key);
 
                 var response = await _client.SendAsync(request, cancellationToken);

--- a/samples/csharp_dotnetcore/17.multilingual-bot/appsettings.json
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/appsettings.json
@@ -1,5 +1,6 @@
 ﻿{
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
-  "TranslatorKey": "<Your translation key here>"
+  "TranslatorKey": "",
+  "TranslatorRegion": "westus"
 }

--- a/samples/javascript_nodejs/17.multilingual-bot/.env
+++ b/samples/javascript_nodejs/17.multilingual-bot/.env
@@ -1,3 +1,4 @@
 MicrosoftAppId=
 MicrosoftAppPassword=
 translatorKey=
+translatorRegion=westus

--- a/samples/javascript_nodejs/17.multilingual-bot/README.md
+++ b/samples/javascript_nodejs/17.multilingual-bot/README.md
@@ -29,10 +29,10 @@ This sample **requires** prerequisites in order to run.
 - [Microsoft Translator Text API key](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/translator-text-how-to-signup)
 
     To consume the Microsoft Translator Text API, first obtain a key following the instructions in the [Microsoft Translator Text API documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/translator-text-how-to-signup).
-    Paste the key in the `TranslatorKey` setting in the `.env` file, or use your preferred configuration and update the following line in `index.js` with your translation key:
+    Paste the key in the `TranslatorKey` and `TranslatorRegion` settings in the `.env` file, or use your preferred configuration and update the following line in `index.js` with your translation key:
 
     ```js
-    adapter.use(new TranslatorMiddleware(languagePreferenceProperty, process.env.translatorKey));
+    adapter.use(new TranslatorMiddleware(languagePreferenceProperty, process.env.translatorKey, process.env.translatorRegion));
     ```
 
 

--- a/samples/javascript_nodejs/17.multilingual-bot/index.js
+++ b/samples/javascript_nodejs/17.multilingual-bot/index.js
@@ -62,7 +62,7 @@ const userState = new UserState(memoryStorage);
 
 const languagePreferenceProperty = userState.createProperty(LANGUAGE_PREFERENCE);
 
-const translator = new MicrosoftTranslator(process.env.translatorKey);
+const translator = new MicrosoftTranslator(process.env.translatorKey, process.env.translatorRegion);
 adapter.use(new TranslatorMiddleware(translator, languagePreferenceProperty));
 
 // Create the MultilingualBot.

--- a/samples/javascript_nodejs/17.multilingual-bot/translation/microsoftTranslator.js
+++ b/samples/javascript_nodejs/17.multilingual-bot/translation/microsoftTranslator.js
@@ -4,8 +4,9 @@
 const fetch = require('node-fetch');
 
 class MicrosoftTranslator {
-    constructor(translatorKey) {
+    constructor(translatorKey, translatorRegion) {
         this.key = translatorKey;
+        this.region = translatorRegion === null ? "westus" : translatorRegion;
     }
 
     /**
@@ -27,7 +28,8 @@ class MicrosoftTranslator {
             body: JSON.stringify([{ Text: text }]),
             headers: {
                 'Content-Type': 'application/json',
-                'Ocp-Apim-Subscription-Key': this.key
+                'Ocp-Apim-Subscription-Key': this.key,
+                'Ocp-Apim-Subscription-Region': this.region
             }
         });
 


### PR DESCRIPTION
Fixes #1966

Setting the region when translation calls happen.  The region can be set in the appsettings.json, and defaults to "westus".