### PR TITLE
Fix AdaptiveCards "isSubtle" by using true instead of "true"

### DIFF
--- a/experimental/adaptive-dialog/csharp_dotnetcore/04.core-bot/Dialogs/RootDialog.lg
+++ b/experimental/adaptive-dialog/csharp_dotnetcore/04.core-bot/Dialogs/RootDialog.lg
@@ -103,7 +103,7 @@
     {
       "type": "TextBlock",
       "size": "default",
-      "isSubtle": "true",
+      "isSubtle": true,
       "text": "Now that you have successfully run your bot, follow the links in this Adaptive Card to expand your knowledge of Bot Framework.",
       "wrap": true,
       "maxLines": 0

--- a/experimental/directline-app-service-extension/csharp_dotnetcore/13.core-bot/Cards/welcomeCard.json
+++ b/experimental/directline-app-service-extension/csharp_dotnetcore/13.core-bot/Cards/welcomeCard.json
@@ -20,7 +20,7 @@
     {
       "type": "TextBlock",
       "size": "default",
-      "isSubtle": "true",
+      "isSubtle": true,
       "text": "Now that you have successfully run your bot, follow the links in this Adaptive Card to expand your knowledge of Bot Framework.",
       "wrap": true,
       "maxLines": 0

--- a/experimental/language-generation/csharp_dotnetcore/13.core-bot/Resources/welcomeCard.LG
+++ b/experimental/language-generation/csharp_dotnetcore/13.core-bot/Resources/welcomeCard.LG
@@ -45,7 +45,7 @@
     {
       "type": "TextBlock",
       "size": "default",
-      "isSubtle": "true",
+      "isSubtle": true,
       "text": "Now that you have successfully run your bot, follow the links in this Adaptive Card to expand your knowledge of Bot Framework.",
       "wrap": true,
       "maxLines": 0

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/Cards/welcomeCard.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/Cards/welcomeCard.json
@@ -20,7 +20,7 @@
     {
       "type": "TextBlock",
       "size": "default",
-      "isSubtle": "true",
+      "isSubtle": true,
       "text": "Now that you have successfully run your bot, follow the links in this Adaptive Card to expand your knowledge of Bot Framework.",
       "wrap": true,
       "maxLines": 0

--- a/generators/generator-botbuilder/generators/app/templates/core/resources/welcomeCard.json
+++ b/generators/generator-botbuilder/generators/app/templates/core/resources/welcomeCard.json
@@ -20,7 +20,7 @@
     {
       "type": "TextBlock",
       "size": "default",
-      "isSubtle": "true",
+      "isSubtle": true,
       "text": "Now that you have successfully run your bot, follow the links in this Adaptive Card to expand your knowledge of Bot Framework.",
       "wrap": true,
       "maxLines": 0

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/Cards/welcomeCard.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/Cards/welcomeCard.json
@@ -20,7 +20,7 @@
     {
       "type": "TextBlock",
       "size": "default",
-      "isSubtle": "true",
+      "isSubtle": true,
       "text": "Now that you have successfully run your bot, follow the links in this Adaptive Card to expand your knowledge of Bot Framework.",
       "wrap": true,
       "maxLines": 0

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/Cards/welcomeCard.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/Cards/welcomeCard.json
@@ -20,7 +20,7 @@
     {
       "type": "TextBlock",
       "size": "default",
-      "isSubtle": "true",
+      "isSubtle": true,
       "text": "Now that you have successfully run your bot, follow the links in this Adaptive Card to expand your knowledge of Bot Framework.",
       "wrap": true,
       "maxLines": 0

--- a/samples/csharp_dotnetcore/13.core-bot/Cards/welcomeCard.json
+++ b/samples/csharp_dotnetcore/13.core-bot/Cards/welcomeCard.json
@@ -20,7 +20,7 @@
     {
       "type": "TextBlock",
       "size": "default",
-      "isSubtle": "true",
+      "isSubtle": true,
       "text": "Now that you have successfully run your bot, follow the links in this Adaptive Card to expand your knowledge of Bot Framework.",
       "wrap": true,
       "maxLines": 0

--- a/samples/csharp_dotnetcore/17.multilingual-bot/Cards/welcomeCard.json
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/Cards/welcomeCard.json
@@ -20,7 +20,7 @@
     {
       "type": "TextBlock",
       "size": "default",
-      "isSubtle": "true",
+      "isSubtle": true,
       "text": "Now that you have successfully run your bot, follow the links in this Adaptive Card to expand your knowledge of Bot Framework.",
       "wrap": true,
       "maxLines": 0

--- a/samples/csharp_dotnetcore/21.corebot-app-insights/Cards/welcomeCard.json
+++ b/samples/csharp_dotnetcore/21.corebot-app-insights/Cards/welcomeCard.json
@@ -20,7 +20,7 @@
     {
       "type": "TextBlock",
       "size": "default",
-      "isSubtle": "true",
+      "isSubtle": true,
       "text": "Now that you have successfully run your bot, follow the links in this Adaptive Card to expand your knowledge of Bot Framework.",
       "wrap": true,
       "maxLines": 0

--- a/samples/csharp_webapi/13.core-bot/Cards/welcomeCard.json
+++ b/samples/csharp_webapi/13.core-bot/Cards/welcomeCard.json
@@ -20,7 +20,7 @@
     {
       "type": "TextBlock",
       "size": "default",
-      "isSubtle": "true",
+      "isSubtle": true,
       "text": "Now that you have successfully run your bot, follow the links in this Adaptive Card to expand your knowledge of Bot Framework.",
       "wrap": true,
       "maxLines": 0

--- a/samples/javascript_nodejs/13.core-bot/bots/resources/welcomeCard.json
+++ b/samples/javascript_nodejs/13.core-bot/bots/resources/welcomeCard.json
@@ -20,7 +20,7 @@
     {
       "type": "TextBlock",
       "size": "default",
-      "isSubtle": "true",
+      "isSubtle": true,
       "text": "Now that you have successfully run your bot, follow the links in this Adaptive Card to expand your knowledge of Bot Framework.",
       "wrap": true,
       "maxLines": 0

--- a/samples/javascript_nodejs/17.multilingual-bot/cards/welcomeCard.json
+++ b/samples/javascript_nodejs/17.multilingual-bot/cards/welcomeCard.json
@@ -20,7 +20,7 @@
     {
       "type": "TextBlock",
       "size": "default",
-      "isSubtle": "true",
+      "isSubtle": true,
       "text": "Now that you have successfully run your bot, follow the links in this Adaptive Card to expand your knowledge of Bot Framework.",
       "wrap": true,
       "maxLines": 0

--- a/samples/typescript_nodejs/13.core-bot/resources/welcomeCard.json
+++ b/samples/typescript_nodejs/13.core-bot/resources/welcomeCard.json
@@ -20,7 +20,7 @@
     {
       "type": "TextBlock",
       "size": "default",
-      "isSubtle": "true",
+      "isSubtle": true,
       "text": "Now that you have successfully run your bot, follow the links in this Adaptive Card to expand your knowledge of Bot Framework.",
       "wrap": true,
       "maxLines": 0


### PR DESCRIPTION
Fixes: https://github.com/microsoft/BotBuilder-Samples/issues/1759

## Proposed Changes
  - Use `true` instead of `"true"` for `"isSubtle"`, per the [Adaptive Cards Schema Explorer](https://adaptivecards.io/explorer/TextBlock.html).

@vishwacsena can you chime in on if the changes I did in the `.lg`/`.LG` files are valid?