### PR TITLE
[C#, Speech] remove ssml from C# EchoBot samples, generators

### DIFF
--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/Bots/EchoBot.cs
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/Bots/EchoBot.cs
@@ -15,28 +15,20 @@ namespace __PROJECT_NAME__.Bots
     {
         protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
-            await turnContext.SendActivityAsync(CreateActivityWithTextAndSpeak($"Echo: {turnContext.Activity.Text}"), cancellationToken);
+            var replyText = $"Echo: {turnContext.Activity.Text}";
+            await turnContext.SendActivityAsync(MessageFactory.Text(replyText, replyText), cancellationToken);
         }
 
         protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
         {
+            var welcomeText = "Hello and welcome!";
             foreach (var member in membersAdded)
             {
                 if (member.Id != turnContext.Activity.Recipient.Id)
                 {
-                    await turnContext.SendActivityAsync(CreateActivityWithTextAndSpeak($"Hello and welcome!"), cancellationToken);
+                    await turnContext.SendActivityAsync(MessageFactory.Text(welcomeText, welcomeText), cancellationToken);
                 }
             }
-        }
-
-        private IActivity CreateActivityWithTextAndSpeak(string message)
-        {
-            var activity = MessageFactory.Text(message);
-            string speak = @"<speak version='1.0' xmlns='https://www.w3.org/2001/10/synthesis' xml:lang='en-US'>
-              <voice name='Microsoft Server Speech Text to Speech Voice (en-US, JessaRUS)'>" +
-              $"{message}" + "</voice></speak>";
-            activity.Speak = speak;
-            return activity;
         }
     }
 }

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/Bots/EchoBot.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/Bots/EchoBot.cs
@@ -15,28 +15,20 @@ namespace $safeprojectname$.Bots
     {
         protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
-            await turnContext.SendActivityAsync(CreateActivityWithTextAndSpeak($"Echo: {turnContext.Activity.Text}"), cancellationToken);
+            var replyText = $"Echo: {turnContext.Activity.Text}";
+            await turnContext.SendActivityAsync(MessageFactory.Text(replyText, replyText), cancellationToken);
         }
 
         protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
         {
+            var welcomeText = "Hello and welcome!";
             foreach (var member in membersAdded)
             {
                 if (member.Id != turnContext.Activity.Recipient.Id)
                 {
-                    await turnContext.SendActivityAsync(CreateActivityWithTextAndSpeak($"Hello and welcome!"), cancellationToken);
+                    await turnContext.SendActivityAsync(MessageFactory.Text(welcomeText, welcomeText), cancellationToken);
                 }
             }
-        }
-
-        private IActivity CreateActivityWithTextAndSpeak(string message)
-        {
-            var activity = MessageFactory.Text(message);
-            string speak = @"<speak version='1.0' xmlns='https://www.w3.org/2001/10/synthesis' xml:lang='en-US'>
-              <voice name='Microsoft Server Speech Text to Speech Voice (en-US, JessaRUS)'>" +
-              $"{message}" + "</voice></speak>";
-            activity.Speak = speak;
-            return activity;
         }
     }
 }

--- a/samples/csharp_dotnetcore/02.echo-bot/Bots/EchoBot.cs
+++ b/samples/csharp_dotnetcore/02.echo-bot/Bots/EchoBot.cs
@@ -13,28 +13,20 @@ namespace Microsoft.BotBuilderSamples.Bots
     {
         protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
-            await turnContext.SendActivityAsync(CreateActivityWithTextAndSpeak($"Echo: {turnContext.Activity.Text}"), cancellationToken);
+            var replyText = $"Echo: {turnContext.Activity.Text}";
+            await turnContext.SendActivityAsync(MessageFactory.Text(replyText, replyText), cancellationToken);
         }
 
         protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
         {
+            var welcomeText = "Hello and welcome!";
             foreach (var member in membersAdded)
             {
                 if (member.Id != turnContext.Activity.Recipient.Id)
                 {
-                    await turnContext.SendActivityAsync(CreateActivityWithTextAndSpeak($"Hello and welcome!"), cancellationToken);
+                    await turnContext.SendActivityAsync(MessageFactory.Text(welcomeText, welcomeText), cancellationToken);
                 }
             }
-        }
-
-        private IActivity CreateActivityWithTextAndSpeak(string message)
-        {
-            var activity = MessageFactory.Text(message);
-            string speak = @"<speak version='1.0' xmlns='https://www.w3.org/2001/10/synthesis' xml:lang='en-US'>	
-              <voice name='Microsoft Server Speech Text to Speech Voice (en-US, JessaRUS)'>" +
-              $"{message}" + "</voice></speak>";
-            activity.Speak = speak;
-            return activity;
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes
  - Remove SSML from C# EchoBot samples and Generators, use plain text for the `Activity.Speak` properties.
 
## Testing
Tested by deploying bot to Azure and used the Direct Line Speech Client.