### PR TITLE
update default.html syntax for css and html class

### DIFF
--- a/samples/csharp_dotnetcore/02.echo-bot/wwwroot/default.html
+++ b/samples/csharp_dotnetcore/02.echo-bot/wwwroot/default.html
@@ -264,7 +264,7 @@
             }
 
             .header-text {
-                font-size: 40x;
+                font-size: 40px;
             }
 
             .column {
@@ -396,7 +396,7 @@
         </div>
     </header>
     <div class="row">
-        <div class="column" class="main-content-area">
+        <div class="column main-content-area">
             <div class="content-title">Your bot is ready!</div>
             <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
                 by connecting to http://localhost:3978/api/messages.</div>


### PR DESCRIPTION
# Need to change the syntax in default.html page for following line  i.e line 267 and line 399

Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Proposed Changes

1. Warning Validation (CSS 4.0): "x" is not a valid value for the "font-size" property. inline -267,
 "px" should be used.

![Screenshot (95)](https://user-images.githubusercontent.com/31169310/69015138-22754f80-09b7-11ea-8cef-b0c313e7b7a9.png)

2. Warning Attribute 'class' already exists. inline -399, 
a single class can handle the work

![Screenshot (96)](https://user-images.githubusercontent.com/31169310/69015139-2608d680-09b7-11ea-9b20-e91c64484373.png)



