### PR TITLE
Fix [48] QnA Maker Active Learning Sample (dotnet core sample - QnA Maker)

### DIFF
--- a/samples/csharp_dotnetcore/48.qnamaker-active-learning-bot/Dialog/DialogHelper.cs
+++ b/samples/csharp_dotnetcore/48.qnamaker-active-learning-bot/Dialog/DialogHelper.cs
@@ -75,7 +75,7 @@ namespace Microsoft.BotBuilderSamples
 
             stepContext.Values[QnAData] = new List<QueryResult>(filteredResponse);
             stepContext.Values[CurrentQuery] = stepContext.Context.Activity.Text;
-            return await stepContext.NextAsync(cancellationToken);
+            return await stepContext.NextAsync(stepContext.Context, cancellationToken);
         }
 
         private async Task<DialogTurnResult> FilterLowVariationScoreList(WaterfallStepContext stepContext, CancellationToken cancellationToken)


### PR DESCRIPTION
Fix System.ArgumentExcepion on QnA Maker Active Learning Sample (C#)
(https://github.com/microsoft/BotBuilder-Samples/blob/master/samples/csharp_dotnetcore/48.qnamaker-active-learning-bot)

## Change Proposal
The first argument of stepContext.NextAsync is expected to be object, but it is cancellationToken.
So, the sample bot got System.ArgumentExcepion : 'result cannot be a cancellation Token' in DialogHelper.cs.

- Before : return await stepContext.NextAsync(cancellationToken);
- **After** : return await stepContext.NextAsync(**stepContext.Result,** cancellationToken);

## Exception
System.ArgumentExcepion : 'result cannot be a cancellation Token' (DialogHelper.cs)

## Reference
https://github.com/microsoft/BotBuilder-Samples/blob/master/samples/csharp_dotnetcore/48.qnamaker-active-learning-bot/Dialog/DialogHelper.cs#L78
