### PR TITLE
Fix typos in templates and samples

### DIFF
--- a/experimental/directline-speech/javascript_nodejs/02.echo-bot/index.js
+++ b/experimental/directline-speech/javascript_nodejs/02.echo-bot/index.js
@@ -50,7 +50,7 @@ const onTurnErrorHandler = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/AdapterWithErrorHandler.cs
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/AdapterWithErrorHandler.cs
@@ -24,7 +24,7 @@ namespace CoreBot
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                var errorMessageText = "The bot encounted an error or bug.";
+                var errorMessageText = "The bot encountered an error or bug.";
                 var errorMessage = MessageFactory.Text(errorMessageText, errorMessageText, InputHints.ExpectingInput);
                 await turnContext.SendActivityAsync(errorMessage);
 

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/Bots/DialogBot.cs
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/Bots/DialogBot.cs
@@ -37,7 +37,7 @@ namespace CoreBot.Bots
         {
             await base.OnTurnAsync(turnContext, cancellationToken);
 
-            // Save any state changes that might have occured during the turn.
+            // Save any state changes that might have occurred during the turn.
             await ConversationState.SaveChangesAsync(turnContext, false, cancellationToken);
             await UserState.SaveChangesAsync(turnContext, false, cancellationToken);
         }

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/AdapterWithErrorHandler.cs
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace __PROJECT_NAME__
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 // Send a trace activity, which will be displayed in the Bot Framework Emulator

--- a/generators/generator-botbuilder/components/coreTemplateWriter.js
+++ b/generators/generator-botbuilder/components/coreTemplateWriter.js
@@ -24,7 +24,7 @@ const _getSourceFolders = language => {
     throw new Error(`coreTemplateWriter._getTargetFolders called for invalid language: ${ language }`);
   }
 
-  // get the folder strucure, based on language
+  // get the folder structure, based on language
   let folders = [
     'bots',
     'cognitiveModels',
@@ -77,7 +77,7 @@ const _getSourceTestFolders = language => {
     throw new Error(`coreTemplateWriter._getTargetFolders called for invalid language: ${ language }`);
   }
 
-  // get the folder strucure, based on language
+  // get the folder structure, based on language
   const folders = [
     'tests',
     path.join('tests', 'bots'),
@@ -137,7 +137,7 @@ const writeCoreTemplateTestFiles = (generator, templatePath) => {
   const DIALOGS_TESTDATA_FOLDER = 3;
   const DIALOGS_TESTDATA_JSON_FOLDER = 4;
 
-  // get the folder strucure, based on language
+  // get the folder structure, based on language
   const srcFolders = _getSourceTestFolders(_.toLower(generator.templateConfig.language));
   const destFolders = _getTargetTestFolders(_.toLower(generator.templateConfig.language));
 
@@ -250,7 +250,7 @@ const writeCoreTemplateFiles = (generator, templatePath) => {
   const DEPLOYMENT_SCRIPTS_FOLDER = 4;
   const TS_SRC_FOLDER = 'src';
 
-  // get the folder strucure, based on language
+  // get the folder structure, based on language
   const srcFolders = _getSourceFolders(_.toLower(generator.templateConfig.language), generator.options.addtests);
   const destFolders = _getTargetFolders(_.toLower(generator.templateConfig.language), generator.options.addtests);
 

--- a/generators/generator-botbuilder/generators/app/templates/core/index.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/index.js
@@ -48,7 +48,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    let onTurnErrorMessage = 'The bot encounted an error or bug.';
+    let onTurnErrorMessage = 'The bot encountered an error or bug.';
     await context.sendActivity(onTurnErrorMessage, onTurnErrorMessage, InputHints.ExpectingInput);
     onTurnErrorMessage = 'To continue to run this bot, please fix the bot source code.';
     await context.sendActivity(onTurnErrorMessage, onTurnErrorMessage, InputHints.ExpectingInput);

--- a/generators/generator-botbuilder/generators/app/templates/core/index.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/index.ts
@@ -48,7 +48,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
     // Clear out state
     await conversationState.delete(context);

--- a/generators/generator-botbuilder/generators/app/templates/echo/index.js
+++ b/generators/generator-botbuilder/generators/app/templates/echo/index.js
@@ -47,7 +47,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 

--- a/generators/generator-botbuilder/generators/app/templates/echo/index.ts
+++ b/generators/generator-botbuilder/generators/app/templates/echo/index.ts
@@ -46,7 +46,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 

--- a/generators/generator-botbuilder/generators/app/templates/empty/index.js
+++ b/generators/generator-botbuilder/generators/app/templates/empty/index.js
@@ -39,7 +39,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 

--- a/generators/generator-botbuilder/generators/app/templates/empty/index.ts
+++ b/generators/generator-botbuilder/generators/app/templates/empty/index.ts
@@ -39,7 +39,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/AdapterWithErrorHandler.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/AdapterWithErrorHandler.cs
@@ -24,7 +24,7 @@ namespace $safeprojectname$
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                var errorMessageText = "The bot encounted an error or bug.";
+                var errorMessageText = "The bot encountered an error or bug.";
                 var errorMessage = MessageFactory.Text(errorMessageText, errorMessageText, InputHints.ExpectingInput);
                 await turnContext.SendActivityAsync(errorMessage);
 

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/AdapterWithErrorHandler.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/AdapterWithErrorHandler.cs
@@ -24,7 +24,7 @@ namespace $ext_safeprojectname$
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                var errorMessageText = "The bot encounted an error or bug.";
+                var errorMessageText = "The bot encountered an error or bug.";
                 var errorMessage = MessageFactory.Text(errorMessageText, errorMessageText, InputHints.ExpectingInput);
                 await turnContext.SendActivityAsync(errorMessage);
 

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/AdapterWithErrorHandler.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace $safeprojectname$
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 // Send a trace activity, which will be displayed in the Bot Framework Emulator

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/AdapterWithErrorHandler.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace $safeprojectname$
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 // Send a trace activity, which will be displayed in the Bot Framework Emulator

--- a/samples/csharp_dotnetcore/02.echo-bot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/02.echo-bot/AdapterWithErrorHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 // Send a trace activity, which will be displayed in the Bot Framework Emulator

--- a/samples/csharp_dotnetcore/03.welcome-user/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/03.welcome-user/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/06.using-cards/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/06.using-cards/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/08.suggested-actions/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/08.suggested-actions/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/11.qnamaker/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/11.qnamaker/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/13.core-bot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/13.core-bot/AdapterWithErrorHandler.cs
@@ -22,7 +22,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                var errorMessageText = "The bot encounted an error or bug.";
+                var errorMessageText = "The bot encountered an error or bug.";
                 var errorMessage = MessageFactory.Text(errorMessageText, errorMessageText, InputHints.ExpectingInput);
                 await turnContext.SendActivityAsync(errorMessage);
 

--- a/samples/csharp_dotnetcore/14.nlp-with-dispatch/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/14.nlp-with-dispatch/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To run this sample make sure you have the LUIS and QnA models deployed.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 

--- a/samples/csharp_dotnetcore/15.handling-attachments/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/15.handling-attachments/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/16.proactive-messages/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/16.proactive-messages/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/17.multilingual-bot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/AdapterWithErrorHandler.cs
@@ -34,7 +34,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await SendWithoutMiddleware(turnContext, "The bot encounted an error or bug.");
+                await SendWithoutMiddleware(turnContext, "The bot encountered an error or bug.");
                 await SendWithoutMiddleware(turnContext, "To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/18.bot-authentication/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/18.bot-authentication/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/19.custom-dialogs/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/21.corebot-app-insights/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/21.corebot-app-insights/AdapterWithErrorHandler.cs
@@ -23,7 +23,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/23.facebook-events/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/23.facebook-events/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/42.scaleout/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/42.scaleout/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/43.complex-dialog/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/43.complex-dialog/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/44.prompt-users-for-input/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/44.prompt-users-for-input/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/45.state-management/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/45.state-management/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/46.teams-auth/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/46.teams-auth/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/47.inspection/AdapterWithInspection.cs
+++ b/samples/csharp_dotnetcore/47.inspection/AdapterWithInspection.cs
@@ -26,7 +26,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 // Send a trace activity, which will be displayed in the Bot Framework Emulator

--- a/samples/csharp_dotnetcore/48.qnamaker-active-learning-bot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/48.qnamaker-active-learning-bot/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/AdapterWithErrorHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 if (conversationState != null)

--- a/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/AdapterWithErrorHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 // Send a trace activity, which will be displayed in the Bot Framework Emulator

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/AdapterWithErrorHandler.cs
@@ -20,7 +20,7 @@ namespace Microsoft.BotBuilderSamples
 
                 // Note: Since this Messaging Extension does not have the messageTeamMembers permission
                 // in the manifest, the bot will not be allowed to message users.
-                // await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                // await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 // await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 // Send a trace activity, which will be displayed in the Bot Framework Emulator

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/AdapterWithErrorHandler.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 // Send a trace activity, which will be displayed in the Bot Framework Emulator

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/AdapterWithErrorHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 // Send a trace activity, which will be displayed in the Bot Framework Emulator

--- a/samples/csharp_dotnetcore/56.teams-file-upload/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/56.teams-file-upload/AdapterWithErrorHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encounted an error or bug.");
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 // Send a trace activity, which will be displayed in the Bot Framework Emulator

--- a/samples/csharp_webapi/13.core-bot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_webapi/13.core-bot/AdapterWithErrorHandler.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                var errorMessageText = "The bot encounted an error or bug.";
+                var errorMessageText = "The bot encountered an error or bug.";
                 var errorMessage = MessageFactory.Text(errorMessageText, errorMessageText, InputHints.ExpectingInput);
                 await turnContext.SendActivityAsync(errorMessage);
 

--- a/samples/javascript_nodejs/02.echo-bot/index.js
+++ b/samples/javascript_nodejs/02.echo-bot/index.js
@@ -47,7 +47,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 

--- a/samples/javascript_nodejs/03.welcome-users/index.js
+++ b/samples/javascript_nodejs/03.welcome-users/index.js
@@ -38,7 +38,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 

--- a/samples/javascript_nodejs/05.multi-turn-prompt/index.js
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/index.js
@@ -39,7 +39,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
     // Clear out state
     await conversationState.delete(context);

--- a/samples/javascript_nodejs/06.using-cards/index.js
+++ b/samples/javascript_nodejs/06.using-cards/index.js
@@ -40,7 +40,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
     // Clear out state
     await conversationState.delete(context);

--- a/samples/javascript_nodejs/07.using-adaptive-cards/index.js
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/index.js
@@ -36,7 +36,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 

--- a/samples/javascript_nodejs/08.suggested-actions/index.js
+++ b/samples/javascript_nodejs/08.suggested-actions/index.js
@@ -36,7 +36,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 

--- a/samples/javascript_nodejs/11.qnamaker/index.js
+++ b/samples/javascript_nodejs/11.qnamaker/index.js
@@ -46,7 +46,7 @@ adapter.onTurnError = async (context, error) => {
     await context.sendActivity(traceActivity);
 
     // Send a message to the user
-    await context.sendActivity(`The bot encounted an error or bug.`);
+    await context.sendActivity(`The bot encountered an error or bug.`);
     await context.sendActivity(`To continue to run this bot, please fix the bot source code.`);
 };
 

--- a/samples/javascript_nodejs/13.core-bot/index.js
+++ b/samples/javascript_nodejs/13.core-bot/index.js
@@ -48,7 +48,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    let onTurnErrorMessage = 'The bot encounted an error or bug.';
+    let onTurnErrorMessage = 'The bot encountered an error or bug.';
     await context.sendActivity(onTurnErrorMessage, onTurnErrorMessage, InputHints.ExpectingInput);
     onTurnErrorMessage = 'To continue to run this bot, please fix the bot source code.';
     await context.sendActivity(onTurnErrorMessage, onTurnErrorMessage, InputHints.ExpectingInput);

--- a/samples/javascript_nodejs/14.nlp-with-dispatch/index.js
+++ b/samples/javascript_nodejs/14.nlp-with-dispatch/index.js
@@ -40,7 +40,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 

--- a/samples/javascript_nodejs/15.handling-attachments/index.js
+++ b/samples/javascript_nodejs/15.handling-attachments/index.js
@@ -36,7 +36,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 

--- a/samples/javascript_nodejs/16.proactive-messages/index.js
+++ b/samples/javascript_nodejs/16.proactive-messages/index.js
@@ -41,7 +41,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 

--- a/samples/javascript_nodejs/17.multilingual-bot/index.js
+++ b/samples/javascript_nodejs/17.multilingual-bot/index.js
@@ -47,7 +47,7 @@ adapter.onTurnError = async (context, error) => {
     // Send a message to the user - send through the adapater to skip the translation middleware (because it might throw)
     const conversationReference = TurnContext.getConversationReference(context.activity);
     await context.adapter.sendActivities(context, [
-        TurnContext.applyConversationReference({ type: ActivityTypes.Message, text: 'The bot encounted an error or bug.' }, conversationReference),
+        TurnContext.applyConversationReference({ type: ActivityTypes.Message, text: 'The bot encountered an error or bug.' }, conversationReference),
         TurnContext.applyConversationReference({ type: ActivityTypes.Message, text: 'To continue to run this bot, please fix the bot source code.' }, conversationReference)]);
 };
 

--- a/samples/javascript_nodejs/18.bot-authentication/index.js
+++ b/samples/javascript_nodejs/18.bot-authentication/index.js
@@ -40,7 +40,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
     // Clear out state
     await conversationState.delete(context);

--- a/samples/javascript_nodejs/19.custom-dialogs/index.js
+++ b/samples/javascript_nodejs/19.custom-dialogs/index.js
@@ -68,7 +68,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
     // Clear out state
     await conversationState.clear(context);

--- a/samples/javascript_nodejs/23.facebook-events/index.js
+++ b/samples/javascript_nodejs/23.facebook-events/index.js
@@ -59,6 +59,6 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/index.js
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/index.js
@@ -38,7 +38,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
     // Clear out state
     await conversationState.delete(context);

--- a/samples/javascript_nodejs/43.complex-dialog/index.js
+++ b/samples/javascript_nodejs/43.complex-dialog/index.js
@@ -58,7 +58,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
     // Clear out state
     await conversationState.clear(context);

--- a/samples/javascript_nodejs/44.prompt-for-user-input/index.js
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/index.js
@@ -54,7 +54,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
     // Clear out state
     await conversationState.delete(context);

--- a/samples/javascript_nodejs/45.state-management/index.js
+++ b/samples/javascript_nodejs/45.state-management/index.js
@@ -57,7 +57,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
     // Clear out state
     await conversationState.delete(context);

--- a/samples/javascript_nodejs/46.teams-auth/index.js
+++ b/samples/javascript_nodejs/46.teams-auth/index.js
@@ -40,7 +40,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
     // Clear out state
     await conversationState.delete(context);

--- a/samples/javascript_nodejs/47.inspection/index.js
+++ b/samples/javascript_nodejs/47.inspection/index.js
@@ -58,7 +58,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
     // Clear out state
     await conversationState.clear(context);

--- a/samples/javascript_nodejs/48.qnamaker-active-learning-bot/index.js
+++ b/samples/javascript_nodejs/48.qnamaker-active-learning-bot/index.js
@@ -43,7 +43,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 

--- a/samples/javascript_nodejs/49.qnamaker-all-features/index.js
+++ b/samples/javascript_nodejs/49.qnamaker-all-features/index.js
@@ -49,7 +49,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 

--- a/samples/javascript_nodejs/51.teams-messaging-extensions-action/index.js
+++ b/samples/javascript_nodejs/51.teams-messaging-extensions-action/index.js
@@ -38,7 +38,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 

--- a/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/index.js
+++ b/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/index.js
@@ -38,7 +38,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 

--- a/samples/javascript_nodejs/54.teams-task-module/index.js
+++ b/samples/javascript_nodejs/54.teams-task-module/index.js
@@ -38,7 +38,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 

--- a/samples/javascript_nodejs/57.teams-conversation-bot/index.js
+++ b/samples/javascript_nodejs/57.teams-conversation-bot/index.js
@@ -39,7 +39,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 

--- a/samples/typescript_nodejs/00.empty-bot/src/index.ts
+++ b/samples/typescript_nodejs/00.empty-bot/src/index.ts
@@ -39,7 +39,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 

--- a/samples/typescript_nodejs/02.echo-bot/src/index.ts
+++ b/samples/typescript_nodejs/02.echo-bot/src/index.ts
@@ -46,7 +46,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 

--- a/samples/typescript_nodejs/13.core-bot/src/index.ts
+++ b/samples/typescript_nodejs/13.core-bot/src/index.ts
@@ -48,7 +48,7 @@ adapter.onTurnError = async (context, error) => {
     );
 
     // Send a message to the user
-    await context.sendActivity('The bot encounted an error or bug.');
+    await context.sendActivity('The bot encountered an error or bug.');
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
     // Clear out state
     await conversationState.delete(context);


### PR DESCRIPTION
## Proposed Changes
This primarily fixes the typo `encounted` and replaces it with `encountered`, with a couple other opportunistic typo fixes along the way.

This change should be purely cosmetic.

## Testing
As this just changes user facing string values (and code comments in only a couple places), I have not "tested" the fix.