### PR TITLE
add notes about TrustServiceUrl

### DIFF
--- a/samples/csharp_dotnetcore/16.proactive-messages/Controllers/NotifyController.cs
+++ b/samples/csharp_dotnetcore/16.proactive-messages/Controllers/NotifyController.cs
@@ -55,6 +55,8 @@ namespace ProactiveBot.Controllers
 
         private async Task BotCallback(ITurnContext turnContext, CancellationToken cancellationToken)
         {
+            // If you encounter permission-related errors when sending this message, see
+            // https://aka.ms/BotTrustServiceUrl
             await turnContext.SendActivityAsync("proactive hello");
         }
     }

--- a/samples/csharp_dotnetcore/16.proactive-messages/README.md
+++ b/samples/csharp_dotnetcore/16.proactive-messages/README.md
@@ -86,6 +86,10 @@ In order to send a proactive message using Bot Framework, the bot must first cap
 
 To send proactive messages, acquire a conversation reference, then use `adapter.continueConversation()` to create a TurnContext object that will allow the bot to deliver the new outgoing message.
 
+### Avoiding Permission-Related Errors
+
+You may encounter permission-related errors when sending a proactive message. This can often be mitigated by using `MicrosoftAppCredentials.TrustServiceUrl()`. See [the documentation](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-proactive-message?view=azure-bot-service-4.0&tabs=csharp#avoiding-401-unauthorized-errors) for more information.
+
 ## Deploy this bot to Azure
 
 To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.

--- a/samples/javascript_nodejs/16.proactive-messages/README.md
+++ b/samples/javascript_nodejs/16.proactive-messages/README.md
@@ -86,6 +86,10 @@ In order to send a proactive message using Bot Framework, the bot must first cap
 
 To send proactive messages, acquire a conversation reference, then use `adapter.continueConversation()` to create a TurnContext object that will allow the bot to deliver the new outgoing message.
 
+### Avoiding Permission-Related Errors
+
+You may encounter permission-related errors when sending a proactive message. This can often be mitigated by using `MicrosoftAppCredentials.trustServiceUrl()`. See [the documentation](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-proactive-message?view=azure-bot-service-4.0&tabs=javascript#avoiding-401-unauthorized-errors) for more information.
+
 ## Deploy this bot to Azure
 
 To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.

--- a/samples/javascript_nodejs/16.proactive-messages/index.js
+++ b/samples/javascript_nodejs/16.proactive-messages/index.js
@@ -69,6 +69,8 @@ server.post('/api/messages', (req, res) => {
 server.get('/api/notify', async (req, res) => {
     for (const conversationReference of Object.values(conversationReferences)) {
         await adapter.continueConversation(conversationReference, async turnContext => {
+            // If you encounter permission-related errors when sending this message, see
+            // https://aka.ms/BotTrustServiceUrl
             await turnContext.sendActivity('proactive hello');
         });
     }


### PR DESCRIPTION
## Proposed Changes

Adds additional notes to the README's and Proactive controllers about using `TrustServiceUrl()` to avoid permissions issue when sending proactive messages.

We [have documentation for this](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-proactive-message?view=azure-bot-service-4.0&tabs=csharp#avoiding-401-unauthorized-errors), but still see this issue relatively frequently. I also received this email this morning:

![image](https://user-images.githubusercontent.com/40401643/70815188-e8af2300-1d81-11ea-8612-ce82775d99eb.png)

Alternatively, we could just add that code to the sample, but I don't know what kind of security risk that creates for bots.