### PR TITLE
add webSocket support to TS sample echo-bot

### DIFF
--- a/generators/generator-botbuilder/generators/app/templates/core/dialogs/flightBookingRecognizer.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/dialogs/flightBookingRecognizer.js
@@ -7,7 +7,13 @@ class FlightBookingRecognizer {
     constructor(config) {
         const luisIsConfigured = config && config.applicationId && config.endpointKey && config.endpoint;
         if (luisIsConfigured) {
-            this.recognizer = new LuisRecognizer(config, {}, true);
+            // Set the recognizer options depending on which endpoint version you want to use e.g v2 or v3.
+            // More details can be found in https://docs.microsoft.com/en-gb/azure/cognitive-services/luis/luis-migration-api-v3
+            const recognizerOptions = {
+                apiVersion: 'v3'
+            };
+
+            this.recognizer = new LuisRecognizer(config, recognizerOptions);
         }
     }
 

--- a/generators/generator-botbuilder/generators/app/templates/core/dialogs/flightBookingRecognizer.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/dialogs/flightBookingRecognizer.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { RecognizerResult, TurnContext } from 'botbuilder';
-import { LuisApplication, LuisRecognizer } from 'botbuilder-ai';
+import { LuisApplication, LuisRecognizer, LuisRecognizerOptionsV3 } from 'botbuilder-ai';
 
 export class FlightBookingRecognizer {
     private recognizer: LuisRecognizer;
@@ -10,7 +10,13 @@ export class FlightBookingRecognizer {
     constructor(config: LuisApplication) {
         const luisIsConfigured = config && config.applicationId && config.endpoint && config.endpointKey;
         if (luisIsConfigured) {
-            this.recognizer = new LuisRecognizer(config, {}, true);
+            // Set the recognizer options depending on which endpoint version you want to use e.g LuisRecognizerOptionsV2 or LuisRecognizerOptionsV3.
+            // More details can be found in https://docs.microsoft.com/en-gb/azure/cognitive-services/luis/luis-migration-api-v3
+            const recognizerOptions: LuisRecognizerOptionsV3 = {
+                apiVersion : 'v3'
+            };
+
+            this.recognizer = new LuisRecognizer(config, recognizerOptions);
         }
     }
 

--- a/generators/generator-botbuilder/generators/app/templates/core/index.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/index.js
@@ -33,7 +33,7 @@ const adapter = new BotFrameworkAdapter({
 });
 
 // Catch-all for errors.
-adapter.onTurnError = async (context, error) => {
+const onTurnErrorHandler = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
     //       application insights.
@@ -55,6 +55,9 @@ adapter.onTurnError = async (context, error) => {
     // Clear out state
     await conversationState.delete(context);
 };
+
+// Set the onTurnError for the singleton BotFrameworkAdapter.
+adapter.onTurnError = onTurnErrorHandler;
 
 // Define a state store for your bot. See https://aka.ms/about-bot-state to learn more about using MemoryStorage.
 // A bot requires a state store to persist the dialog and user state between messages.
@@ -91,5 +94,22 @@ server.post('/api/messages', (req, res) => {
     adapter.processActivity(req, res, async (turnContext) => {
         // route to bot activity handler.
         await bot.run(turnContext);
+    });
+});
+
+// Listen for Upgrade requests for Streaming.
+server.on('upgrade', (req, socket, head) => {
+    // Create an adapter scoped to this WebSocket connection to allow storing session data.
+    const streamingAdapter = new BotFrameworkAdapter({
+        appId: process.env.MicrosoftAppId,
+        appPassword: process.env.MicrosoftAppPassword
+    });
+    // Set onTurnError for the BotFrameworkAdapter created for each connection.
+    streamingAdapter.onTurnError = onTurnErrorHandler;
+
+    streamingAdapter.useWebSocket(req, socket, head, async (context) => {
+        // After connecting via WebSocket, run this logic for every request sent over
+        // the WebSocket connection.
+        await bot.run(context);
     });
 });

--- a/generators/generator-botbuilder/generators/app/templates/echo/bot.js
+++ b/generators/generator-botbuilder/generators/app/templates/echo/bot.js
@@ -1,24 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-const { ActivityHandler } = require('botbuilder');
+const { ActivityHandler, MessageFactory } = require('botbuilder');
 
 class EchoBot extends ActivityHandler {
     constructor() {
         super();
         // See https://aka.ms/about-bot-activity-message to learn more about the message and other activity types.
         this.onMessage(async (context, next) => {
-            await context.sendActivity(`You said '${ context.activity.text }'`);
-
+            const replyText = `Echo: ${ context.activity.text }`;
+            await context.sendActivity(MessageFactory.text(replyText, replyText));
             // By calling next() you ensure that the next BotHandler is run.
             await next();
         });
 
         this.onMembersAdded(async (context, next) => {
             const membersAdded = context.activity.membersAdded;
+            const welcomeText = 'Hello and welcome!';
             for (let cnt = 0; cnt < membersAdded.length; ++cnt) {
                 if (membersAdded[cnt].id !== context.activity.recipient.id) {
-                    await context.sendActivity('Hello and welcome!');
+                    await context.sendActivity(MessageFactory.text(welcomeText, welcomeText));
                 }
             }
             // By calling next() you ensure that the next BotHandler is run.

--- a/generators/generator-botbuilder/generators/app/templates/echo/bot.ts
+++ b/generators/generator-botbuilder/generators/app/templates/echo/bot.ts
@@ -1,23 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { ActivityHandler } from 'botbuilder';
+import { ActivityHandler, MessageFactory } from 'botbuilder';
 
 export class EchoBot extends ActivityHandler {
     constructor() {
         super();
         // See https://aka.ms/about-bot-activity-message to learn more about the message and other activity types.
         this.onMessage(async (context, next) => {
-            await context.sendActivity(`You said '${ context.activity.text }'`);
+            const replyText = `Echo: ${ context.activity.text }`;
+            await context.sendActivity(MessageFactory.text(replyText, replyText));
             // By calling next() you ensure that the next BotHandler is run.
             await next();
         });
 
         this.onMembersAdded(async (context, next) => {
             const membersAdded = context.activity.membersAdded;
+            const welcomeText = 'Hello and welcome!';
             for (const member of membersAdded) {
                 if (member.id !== context.activity.recipient.id) {
-                    await context.sendActivity('Hello and welcome!');
+                    await context.sendActivity(MessageFactory.text(welcomeText, welcomeText));
                 }
             }
             // By calling next() you ensure that the next BotHandler is run.

--- a/generators/generator-botbuilder/generators/app/templates/echo/index.js
+++ b/generators/generator-botbuilder/generators/app/templates/echo/index.js
@@ -32,7 +32,7 @@ const adapter = new BotFrameworkAdapter({
 });
 
 // Catch-all for errors.
-adapter.onTurnError = async (context, error) => {
+const onTurnErrorHandler = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
     //       application insights.
@@ -51,6 +51,9 @@ adapter.onTurnError = async (context, error) => {
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 
+// Set the onTurnError for the singleton BotFrameworkAdapter.
+adapter.onTurnError = onTurnErrorHandler;
+
 // Create the main dialog.
 const myBot = new EchoBot();
 
@@ -58,6 +61,23 @@ const myBot = new EchoBot();
 server.post('/api/messages', (req, res) => {
     adapter.processActivity(req, res, async (context) => {
         // Route to main dialog.
+        await myBot.run(context);
+    });
+});
+
+// Listen for Upgrade requests for Streaming.
+server.on('upgrade', (req, socket, head) => {
+    // Create an adapter scoped to this WebSocket connection to allow storing session data.
+    const streamingAdapter = new BotFrameworkAdapter({
+        appId: process.env.MicrosoftAppId,
+        appPassword: process.env.MicrosoftAppPassword
+    });
+    // Set onTurnError for the BotFrameworkAdapter created for each connection.
+    streamingAdapter.onTurnError = onTurnErrorHandler;
+
+    streamingAdapter.useWebSocket(req, socket, head, async (context) => {
+        // After connecting via WebSocket, run this logic for every request sent over
+        // the WebSocket connection.
         await myBot.run(context);
     });
 });

--- a/generators/generator-botbuilder/generators/app/templates/echo/index.ts
+++ b/generators/generator-botbuilder/generators/app/templates/echo/index.ts
@@ -31,7 +31,7 @@ const adapter = new BotFrameworkAdapter({
 });
 
 // Catch-all for errors.
-adapter.onTurnError = async (context, error) => {
+const onTurnErrorHandler = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
     //       application insights.
@@ -50,6 +50,9 @@ adapter.onTurnError = async (context, error) => {
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 
+// Set the onTurnError for the singleton BotFrameworkAdapter.
+adapter.onTurnError = onTurnErrorHandler;
+
 // Create the main dialog.
 const myBot = new EchoBot();
 
@@ -57,6 +60,23 @@ const myBot = new EchoBot();
 server.post('/api/messages', (req, res) => {
     adapter.processActivity(req, res, async (context) => {
         // Route to main dialog.
+        await myBot.run(context);
+    });
+});
+
+// Listen for Upgrade requests for Streaming.
+server.on('upgrade', (req, socket, head) => {
+    // Create an adapter scoped to this WebSocket connection to allow storing session data.
+    const streamingAdapter = new BotFrameworkAdapter({
+        appId: process.env.MicrosoftAppId,
+        appPassword: process.env.MicrosoftAppPassword
+    });
+    // Set onTurnError for the BotFrameworkAdapter created for each connection.
+    streamingAdapter.onTurnError = onTurnErrorHandler;
+
+    streamingAdapter.useWebSocket(req, socket, head, async (context) => {
+        // After connecting via WebSocket, run this logic for every request sent over
+        // the WebSocket connection.
         await myBot.run(context);
     });
 });

--- a/samples/javascript_nodejs/02.echo-bot/bot.js
+++ b/samples/javascript_nodejs/02.echo-bot/bot.js
@@ -1,24 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-const { ActivityHandler } = require('botbuilder');
+const { ActivityHandler, MessageFactory } = require('botbuilder');
 
 class EchoBot extends ActivityHandler {
     constructor() {
         super();
         // See https://aka.ms/about-bot-activity-message to learn more about the message and other activity types.
         this.onMessage(async (context, next) => {
-            await context.sendActivity(`You said '${ context.activity.text }'`);
-
+            const replyText = `Echo: ${ context.activity.text }`;
+            await context.sendActivity(MessageFactory.text(replyText, replyText));
             // By calling next() you ensure that the next BotHandler is run.
             await next();
         });
 
         this.onMembersAdded(async (context, next) => {
             const membersAdded = context.activity.membersAdded;
+            const welcomeText = 'Hello and welcome!';
             for (let cnt = 0; cnt < membersAdded.length; ++cnt) {
                 if (membersAdded[cnt].id !== context.activity.recipient.id) {
-                    await context.sendActivity('Hello and welcome!');
+                    await context.sendActivity(MessageFactory.text(welcomeText, welcomeText));
                 }
             }
             // By calling next() you ensure that the next BotHandler is run.

--- a/samples/javascript_nodejs/02.echo-bot/index.js
+++ b/samples/javascript_nodejs/02.echo-bot/index.js
@@ -32,7 +32,7 @@ const adapter = new BotFrameworkAdapter({
 });
 
 // Catch-all for errors.
-adapter.onTurnError = async (context, error) => {
+const onTurnErrorHandler = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
     //       application insights.
@@ -51,6 +51,9 @@ adapter.onTurnError = async (context, error) => {
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 
+// Set the onTurnError for the singleton BotFrameworkAdapter.
+adapter.onTurnError = onTurnErrorHandler;
+
 // Create the main dialog.
 const myBot = new EchoBot();
 
@@ -58,6 +61,23 @@ const myBot = new EchoBot();
 server.post('/api/messages', (req, res) => {
     adapter.processActivity(req, res, async (context) => {
         // Route to main dialog.
+        await myBot.run(context);
+    });
+});
+
+// Listen for Upgrade requests for Streaming.
+server.on('upgrade', (req, socket, head) => {
+    // Create an adapter scoped to this WebSocket connection to allow storing session data.
+    const streamingAdapter = new BotFrameworkAdapter({
+        appId: process.env.MicrosoftAppId,
+        appPassword: process.env.MicrosoftAppPassword
+    });
+    // Set onTurnError for the BotFrameworkAdapter created for each connection.
+    streamingAdapter.onTurnError = onTurnErrorHandler;
+
+    streamingAdapter.useWebSocket(req, socket, head, async (context) => {
+        // After connecting via WebSocket, run this logic for every request sent over
+        // the WebSocket connection.
         await myBot.run(context);
     });
 });

--- a/samples/javascript_nodejs/13.core-bot/index.js
+++ b/samples/javascript_nodejs/13.core-bot/index.js
@@ -33,7 +33,7 @@ const adapter = new BotFrameworkAdapter({
 });
 
 // Catch-all for errors.
-adapter.onTurnError = async (context, error) => {
+const onTurnErrorHandler = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
     //       application insights.
@@ -55,6 +55,9 @@ adapter.onTurnError = async (context, error) => {
     // Clear out state
     await conversationState.delete(context);
 };
+
+// Set the onTurnError for the singleton BotFrameworkAdapter.
+adapter.onTurnError = onTurnErrorHandler;
 
 // Define a state store for your bot. See https://aka.ms/about-bot-state to learn more about using MemoryStorage.
 // A bot requires a state store to persist the dialog and user state between messages.
@@ -91,5 +94,22 @@ server.post('/api/messages', (req, res) => {
     adapter.processActivity(req, res, async (turnContext) => {
         // route to bot activity handler.
         await bot.run(turnContext);
+    });
+});
+
+// Listen for Upgrade requests for Streaming.
+server.on('upgrade', (req, socket, head) => {
+    // Create an adapter scoped to this WebSocket connection to allow storing session data.
+    const streamingAdapter = new BotFrameworkAdapter({
+        appId: process.env.MicrosoftAppId,
+        appPassword: process.env.MicrosoftAppPassword
+    });
+    // Set onTurnError for the BotFrameworkAdapter created for each connection.
+    streamingAdapter.onTurnError = onTurnErrorHandler;
+
+    streamingAdapter.useWebSocket(req, socket, head, async (context) => {
+        // After connecting via WebSocket, run this logic for every request sent over
+        // the WebSocket connection.
+        await bot.run(context);
     });
 });

--- a/samples/typescript_nodejs/02.echo-bot/src/bot.ts
+++ b/samples/typescript_nodejs/02.echo-bot/src/bot.ts
@@ -1,23 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { ActivityHandler } from 'botbuilder';
+import { ActivityHandler, MessageFactory } from 'botbuilder';
 
 export class EchoBot extends ActivityHandler {
     constructor() {
         super();
         // See https://aka.ms/about-bot-activity-message to learn more about the message and other activity types.
         this.onMessage(async (context, next) => {
-            await context.sendActivity(`You said '${ context.activity.text }'`);
+            const replyText = `Echo: ${ context.activity.text }`;
+            await context.sendActivity(MessageFactory.text(replyText, replyText));
             // By calling next() you ensure that the next BotHandler is run.
             await next();
         });
 
         this.onMembersAdded(async (context, next) => {
             const membersAdded = context.activity.membersAdded;
+            const welcomeText = 'Hello and welcome!';
             for (const member of membersAdded) {
                 if (member.id !== context.activity.recipient.id) {
-                    await context.sendActivity('Hello and welcome!');
+                    await context.sendActivity(MessageFactory.text(welcomeText, welcomeText));
                 }
             }
             // By calling next() you ensure that the next BotHandler is run.

--- a/samples/typescript_nodejs/02.echo-bot/src/index.ts
+++ b/samples/typescript_nodejs/02.echo-bot/src/index.ts
@@ -31,7 +31,7 @@ const adapter = new BotFrameworkAdapter({
 });
 
 // Catch-all for errors.
-adapter.onTurnError = async (context, error) => {
+const onTurnErrorHandler = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
     //       application insights.
@@ -50,6 +50,9 @@ adapter.onTurnError = async (context, error) => {
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 
+// Set the onTurnError for the singleton BotFrameworkAdapter.
+adapter.onTurnError = onTurnErrorHandler;
+
 // Create the main dialog.
 const myBot = new EchoBot();
 
@@ -57,6 +60,23 @@ const myBot = new EchoBot();
 server.post('/api/messages', (req, res) => {
     adapter.processActivity(req, res, async (context) => {
         // Route to main dialog.
+        await myBot.run(context);
+    });
+});
+
+// Listen for Upgrade requests for Streaming.
+server.on('upgrade', (req, socket, head) => {
+    // Create an adapter scoped to this WebSocket connection to allow storing session data.
+    const streamingAdapter = new BotFrameworkAdapter({
+        appId: process.env.MicrosoftAppId,
+        appPassword: process.env.MicrosoftAppPassword
+    });
+    // Set onTurnError for the BotFrameworkAdapter created for each connection.
+    streamingAdapter.onTurnError = onTurnErrorHandler;
+
+    streamingAdapter.useWebSocket(req, socket, head, async (context) => {
+        // After connecting via WebSocket, run this logic for every request sent over
+        // the WebSocket connection.
         await myBot.run(context);
     });
 });


### PR DESCRIPTION
FYI @Kaiqb, @JonathanFingold, @dargilco, @DDEfromOR   

Fixes: #2058

## Proposed Changes
  - Refactor Echo Bot samples & generators to support WebSocket connections (i.e. connections from the Direct Line Speech channel)
    - Echo bot samples now also send responses with the `speak` tag set via MessageFactory.Text().
  - Refactor Core Bot samples & generators to support WebSocket connections (i.e. connections from the Direct Line Speech channel)
    - Also applied v3 LUIS Endpoint support changes to the generators via #2083
  - 


## Testing
Tested with JS/TS samples with multiple WebSocket connections and via the Test in Web Chat blade via Azure