### PR TITLE
Updated schema URL for Skills Manifests

### DIFF
--- a/experimental/skills/DialogToDialog/DialogSkillBot/wwwroot/manifest/dialogchildbot-manifest-1.0.json
+++ b/experimental/skills/DialogToDialog/DialogSkillBot/wwwroot/manifest/dialogchildbot-manifest-1.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/botframework-sdk/master/schemas/skills/skill-manifest-2.0.0.json",
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
   "$id": "DialogSkillBot",
   "name": "Skill bot with dialogs",
   "version": "1.0",

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/wwwroot/manifest/echoskillbot-manifest-1.0.json
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/wwwroot/manifest/echoskillbot-manifest-1.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/botframework-sdk/master/schemas/skills/skill-manifest-2.0.0.json",
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
   "$id": "EchoSkillBot",
   "name": "Echo Skill bot",
   "version": "1.0",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/manifest/echoskillbot-manifest-1.0.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/manifest/echoskillbot-manifest-1.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/botframework-sdk/master/schemas/skills/skill-manifest-2.0.0.json",
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
   "$id": "EchoSkillBot",
   "name": "Echo Skill bot",
   "version": "1.0",


### PR DESCRIPTION
Updated manifest schema URLs to point to https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json