### PR TITLE
Fixed Incorrect referencing of Server Farm ID in template-with-preexisting-rg.json

### DIFF
--- a/samples/csharp_dotnetcore/11.qnamaker/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/11.qnamaker/DeploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {


### PR DESCRIPTION
## Proposed Changes
The template-with-preexisting-rg.json was not referencing the Server Farm ID.  It was referencing the Server Farm Name.  This prevented the deployment from running with following error:


```
Azure Error: InvalidTemplateDeployment
Message: The template deployment 'phi-qnamaker-botsvc-12292019_130846' is not valid according to the validation procedure. The tracking id is '9efa7622-88a2-4db1-8a11-a6304ab7d984'. See inner errors for details.
Exception Details:
        Error Code: ValidationForResourceFailed
        Message: Validation failed for a resource. Check 'Error.Details[0]' for more information.

using Get-AzureRMLog -CorrelationId "9efa7622-88a2-4db1-8a11-a6304ab7d984" -DetailedOutput provided more details;

statusMessage  : {"error":{"code":"InvalidTemplateDeployment","message":"The template deployment 'phi-qnamaker-botsvc-12292019_130846' is not valid according to the validation procedure. The tracking id is
                       '9efa7622-88a2-4db1-8a11-a6304ab7d984'. See inner errors for details.","details":[{"code":"ValidationForResourceFailed","message":"Validation failed for a resource. Check 'Error.Details[0]' for more
                       information.","details":[{"code":"ServerFarmNotFound","message":"The specified app service plan was not found."}]}]}}


```

adding the fixed template yields:
![Deployfix](https://user-images.githubusercontent.com/6508334/71562583-c5ee6100-2a47-11ea-8a63-783ef6a9648f.PNG)

