### PR TITLE
Python: Returning correct HTTP result codes in response to exceptions.

### DIFF
--- a/generators/python/app/templates/core/{{cookiecutter.bot_name}}/app.py
+++ b/generators/python/app/templates/core/{{cookiecutter.bot_name}}/app.py
@@ -17,6 +17,7 @@ from botbuilder.core import (
     MemoryStorage,
     UserState,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity
 
 from config import DefaultConfig
@@ -59,16 +60,13 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/generators/python/app/templates/echo/{{cookiecutter.bot_name}}/app.py
+++ b/generators/python/app/templates/echo/{{cookiecutter.bot_name}}/app.py
@@ -71,13 +71,10 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
 APP = web.Application(middlewares=[aiohttp_error_middleware])

--- a/generators/python/app/templates/empty/{{cookiecutter.bot_name}}/app.py
+++ b/generators/python/app/templates/empty/{{cookiecutter.bot_name}}/app.py
@@ -71,13 +71,10 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
 APP = web.Application(middlewares=[aiohttp_error_middleware])

--- a/samples/python/02.echo-bot/app.py
+++ b/samples/python/02.echo-bot/app.py
@@ -71,13 +71,10 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
 APP = web.Application(middlewares=[aiohttp_error_middleware])

--- a/samples/python/03.welcome-user/app.py
+++ b/samples/python/03.welcome-user/app.py
@@ -14,6 +14,7 @@ from botbuilder.core import (
     TurnContext,
     UserState,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity, ActivityTypes
 
 from bots import WelcomeUserBot
@@ -76,16 +77,13 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/samples/python/05.multi-turn-prompt/app.py
+++ b/samples/python/05.multi-turn-prompt/app.py
@@ -15,6 +15,7 @@ from botbuilder.core import (
     TurnContext,
     UserState,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity, ActivityTypes
 
 from config import DefaultConfig
@@ -86,16 +87,13 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/samples/python/06.using-cards/app.py
+++ b/samples/python/06.using-cards/app.py
@@ -15,6 +15,7 @@ from botbuilder.core import (
     TurnContext,
     UserState,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity, ActivityTypes
 
 from config import DefaultConfig
@@ -85,16 +86,13 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/samples/python/07.using-adaptive-cards/app.py
+++ b/samples/python/07.using-adaptive-cards/app.py
@@ -12,6 +12,7 @@ from botbuilder.core import (
     TurnContext,
     BotFrameworkAdapter,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity, ActivityTypes
 
 from bots import AdaptiveCardsBot
@@ -70,16 +71,13 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/samples/python/08.suggested-actions/app.py
+++ b/samples/python/08.suggested-actions/app.py
@@ -12,6 +12,7 @@ from botbuilder.core import (
     BotFrameworkAdapter,
     TurnContext,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity, ActivityTypes
 
 from bots import SuggestActionsBot
@@ -70,16 +71,13 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/samples/python/11.qnamaker/app.py
+++ b/samples/python/11.qnamaker/app.py
@@ -12,6 +12,7 @@ from botbuilder.core import (
     TurnContext,
     BotFrameworkAdapter,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity, ActivityTypes
 
 from bots import QnABot
@@ -70,16 +71,13 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/samples/python/13.core-bot/app.py
+++ b/samples/python/13.core-bot/app.py
@@ -17,6 +17,7 @@ from botbuilder.core import (
     MemoryStorage,
     UserState,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity
 
 from config import DefaultConfig
@@ -59,16 +60,13 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/samples/python/14.nlp-with-dispatch/app.py
+++ b/samples/python/14.nlp-with-dispatch/app.py
@@ -12,6 +12,7 @@ from botbuilder.core import (
     TurnContext,
     BotFrameworkAdapter,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity, ActivityTypes
 
 from bots import DispatchBot
@@ -70,16 +71,13 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/samples/python/15.handling-attachments/app.py
+++ b/samples/python/15.handling-attachments/app.py
@@ -12,6 +12,7 @@ from botbuilder.core import (
     TurnContext,
     BotFrameworkAdapter,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity, ActivityTypes
 
 from bots import AttachmentsBot
@@ -70,16 +71,13 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/samples/python/17.multilingual-bot/app.py
+++ b/samples/python/17.multilingual-bot/app.py
@@ -14,6 +14,7 @@ from botbuilder.core import (
     TurnContext,
     UserState,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity, ActivityTypes
 
 from bots import MultiLingualBot
@@ -84,16 +85,13 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/samples/python/18.bot-authentication/app.py
+++ b/samples/python/18.bot-authentication/app.py
@@ -15,6 +15,7 @@ from botbuilder.core import (
     TurnContext,
     UserState,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity, ActivityTypes
 
 from bots import AuthBot
@@ -85,16 +86,13 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/samples/python/19.custom-dialogs/app.py
+++ b/samples/python/19.custom-dialogs/app.py
@@ -15,6 +15,7 @@ from botbuilder.core import (
     TurnContext,
     UserState,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity, ActivityTypes
 
 from bots import DialogBot
@@ -82,16 +83,13 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/samples/python/23.facebook-events/app.py
+++ b/samples/python/23.facebook-events/app.py
@@ -12,6 +12,7 @@ from botbuilder.core import (
     TurnContext,
     BotFrameworkAdapter,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity, ActivityTypes
 
 from bots import FacebookBot
@@ -70,16 +71,13 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/samples/python/24.bot-authentication-msgraph/app.py
+++ b/samples/python/24.bot-authentication-msgraph/app.py
@@ -15,6 +15,7 @@ from botbuilder.core import (
     TurnContext,
     UserState,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity, ActivityTypes
 
 from bots import AuthBot
@@ -85,16 +86,13 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/samples/python/42.scaleout/app.py
+++ b/samples/python/42.scaleout/app.py
@@ -12,6 +12,7 @@ from botbuilder.core import (
     TurnContext,
     BotFrameworkAdapter,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity, ActivityTypes
 
 from bots import ScaleoutBot
@@ -78,16 +79,13 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/samples/python/43.complex-dialog/app.py
+++ b/samples/python/43.complex-dialog/app.py
@@ -15,6 +15,7 @@ from botbuilder.core import (
     TurnContext,
     UserState,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity, ActivityTypes
 
 from bots import DialogAndWelcomeBot
@@ -87,16 +88,13 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/samples/python/44.prompt-for-user-input/app.py
+++ b/samples/python/44.prompt-for-user-input/app.py
@@ -15,6 +15,7 @@ from botbuilder.core import (
     TurnContext,
     UserState,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity, ActivityTypes
 
 from bots import CustomPromptBot
@@ -83,15 +84,13 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
-APP = web.Application()
+
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/samples/python/45.state-management/app.py
+++ b/samples/python/45.state-management/app.py
@@ -15,6 +15,7 @@ from botbuilder.core import (
     TurnContext,
     UserState,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity, ActivityTypes
 
 from bots import StateManagementBot
@@ -83,16 +84,13 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/samples/python/53.teams-messaging-extensions-action-preview/app.py
+++ b/samples/python/53.teams-messaging-extensions-action-preview/app.py
@@ -13,6 +13,7 @@ from botbuilder.core import (
     TurnContext,
     BotFrameworkAdapter,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity, ActivityTypes
 from bots import TeamsMessagingExtensionsActionPreviewBot
 from config import DefaultConfig
@@ -70,22 +71,17 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        invoke_response = await ADAPTER.process_activity(
-            activity, auth_header, BOT.on_turn
+    invoke_response = await ADAPTER.process_activity(
+        activity, auth_header, BOT.on_turn
+    )
+    if invoke_response:
+        return json_response(
+            data=invoke_response.body, status=invoke_response.status
         )
-        if invoke_response:
-            return json_response(
-                data=invoke_response.body, status=invoke_response.status
-            )
-        return Response(status=201)
-    except PermissionError:
-        return Response(status=401)
-    except Exception:
-        return Response(status=500)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/samples/python/54.teams-task-module/app.py
+++ b/samples/python/54.teams-task-module/app.py
@@ -12,6 +12,7 @@ from botbuilder.core import (
     TurnContext,
     BotFrameworkAdapter,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity, ActivityTypes
 from bots import TeamsTaskModuleBot
 from config import DefaultConfig
@@ -69,22 +70,17 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        invoke_response = await ADAPTER.process_activity(
-            activity, auth_header, BOT.on_turn
+    invoke_response = await ADAPTER.process_activity(
+        activity, auth_header, BOT.on_turn
+    )
+    if invoke_response:
+        return json_response(
+            data=invoke_response.body, status=invoke_response.status
         )
-        if invoke_response:
-            return json_response(
-                data=invoke_response.body, status=invoke_response.status
-            )
-        return Response(status=201)
-    except PermissionError:
-        return Response(status=401)
-    except Exception:
-        return Response(status=500)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":

--- a/samples/python/55.teams-link-unfurling/app.py
+++ b/samples/python/55.teams-link-unfurling/app.py
@@ -59,6 +59,7 @@ ADAPTER.on_turn_error = on_error
 # Create the Bot
 BOT = LinkUnfurlingBot()
 
+
 # Listen for incoming requests on /api/messages.s
 async def messages(req: Request) -> Response:
     # Main bot message handler.
@@ -70,17 +71,14 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        invoke_response = await ADAPTER.process_activity(
-            activity, auth_header, BOT.on_turn
+    invoke_response = await ADAPTER.process_activity(
+        activity, auth_header, BOT.on_turn
+    )
+    if invoke_response:
+        return json_response(
+            data=invoke_response.body, status=invoke_response.status
         )
-        if invoke_response:
-            return json_response(
-                data=invoke_response.body, status=invoke_response.status
-            )
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    return Response(status=201)
 
 
 APP = web.Application(middlewares=[aiohttp_error_middleware])

--- a/samples/python/56.teams-file-upload/app.py
+++ b/samples/python/56.teams-file-upload/app.py
@@ -59,6 +59,7 @@ ADAPTER.on_turn_error = on_error
 # Create the Bot
 BOT = TeamsFileUploadBot()
 
+
 # Listen for incoming requests on /api/messages.s
 async def messages(req: Request) -> Response:
     # Main bot message handler.
@@ -70,17 +71,14 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        invoke_response = await ADAPTER.process_activity(
-            activity, auth_header, BOT.on_turn
+    invoke_response = await ADAPTER.process_activity(
+        activity, auth_header, BOT.on_turn
+    )
+    if invoke_response:
+        return json_response(
+            data=invoke_response.body, status=invoke_response.status
         )
-        if invoke_response:
-            return json_response(
-                data=invoke_response.body, status=invoke_response.status
-            )
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    return Response(status=201)
 
 
 APP = web.Application(middlewares=[aiohttp_error_middleware])

--- a/samples/python/57.teams-conversation-bot/app.py
+++ b/samples/python/57.teams-conversation-bot/app.py
@@ -13,6 +13,7 @@ from botbuilder.core import (
     TurnContext,
     BotFrameworkAdapter,
 )
+from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity, ActivityTypes
 
 from bots import TeamsConversationBot
@@ -76,16 +77,13 @@ async def messages(req: Request) -> Response:
     activity = Activity().deserialize(body)
     auth_header = req.headers["Authorization"] if "Authorization" in req.headers else ""
 
-    try:
-        response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
-        if response:
-            return json_response(data=response.body, status=response.status)
-        return Response(status=201)
-    except Exception as exception:
-        raise exception
+    response = await ADAPTER.process_activity(activity, auth_header, BOT.on_turn)
+    if response:
+        return json_response(data=response.body, status=response.status)
+    return Response(status=201)
 
 
-APP = web.Application()
+APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #2073 

Refactored Python samples to use the ```aiohttp_error_middleware``` class and the defer all exception handling (and corresponding HTTP result code) to it.

This relies on Python PR #571 to handle all auth failures correctly.