### PR TITLE
Dotnet: Send EndOfConversation to Skill in OnTurnError handler.

### DIFF
--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/Bots/EchoBot.cs
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/Bots/EchoBot.cs
@@ -26,5 +26,11 @@ namespace Microsoft.BotBuilderSamples.EchoSkillBot.Bots
                 await turnContext.SendActivityAsync(MessageFactory.Text("Say \"end\" or \"stop\" and I'll end the conversation and back to the parent."), cancellationToken);
             }
         }
+
+        protected override async Task OnEndOfConversationActivityAsync(ITurnContext<IEndOfConversationActivity> turnContext, CancellationToken cancellationToken)
+        {
+            var eocActivityMessage = $"Echo (dotnet): Received {ActivityTypes.EndOfConversation}, Code: {turnContext.Activity.Code}";
+            await turnContext.SendActivityAsync(MessageFactory.Text(eocActivityMessage), cancellationToken);
+        }
     }
 }

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/Bots/EchoBot.cs
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/Bots/EchoBot.cs
@@ -33,7 +33,7 @@ namespace Microsoft.BotBuilderSamples.EchoSkillBot.Bots
             // This will be called if the root bot is ending the conversation.  Sending additional messages should be
             // avoided as the conversation may have been deleted.
             // Perform cleanup of resources if needed.
-            return Task.FromResult(true);
+            return Task.CompletedTask;
         }
     }
 }

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/Bots/EchoBot.cs
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/Bots/EchoBot.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
@@ -27,10 +28,12 @@ namespace Microsoft.BotBuilderSamples.EchoSkillBot.Bots
             }
         }
 
-        protected override async Task OnEndOfConversationActivityAsync(ITurnContext<IEndOfConversationActivity> turnContext, CancellationToken cancellationToken)
+        protected override Task OnEndOfConversationActivityAsync(ITurnContext<IEndOfConversationActivity> turnContext, CancellationToken cancellationToken)
         {
-            var eocActivityMessage = $"Echo (dotnet): Received {ActivityTypes.EndOfConversation}, Code: {turnContext.Activity.Code}";
-            await turnContext.SendActivityAsync(MessageFactory.Text(eocActivityMessage), cancellationToken);
+            // This will be called if the root bot is ending the conversation.  Sending additional messages should be
+            // avoided as the conversation may have been deleted.
+            // Perform cleanup of resources if needed.
+            return Task.FromResult(true);
         }
     }
 }

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/SkillAdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/SkillAdapterWithErrorHandler.cs
@@ -31,6 +31,17 @@ namespace Microsoft.BotBuilderSamples.EchoSkillBot
                 errorMessage = MessageFactory.Text(errorMessageText, errorMessageText, InputHints.ExpectingInput);
                 await turnContext.SendActivityAsync(errorMessage);
 
+                // Send a trace activity, which will be displayed in the Bot Framework Emulator
+                // Note: we return the entire exception in the value property to help the developer, this should not be done in prod.
+                await turnContext.TraceActivityAsync("OnTurnError Trace", exception.ToString(), "https://www.botframework.com/schemas/error", "TurnError");
+
+                // Send and EndOfConversation activity to the skill caller with the error to end the conversation
+                // and let the caller decide what to do.
+                var endOfConversation = Activity.CreateEndOfConversationActivity();
+                endOfConversation.Code = "SkillError";
+                endOfConversation.Text = exception.Message;
+                await turnContext.SendActivityAsync(endOfConversation);
+
                 if (conversationState != null)
                 {
                     try
@@ -45,17 +56,6 @@ namespace Microsoft.BotBuilderSamples.EchoSkillBot
                         logger.LogError(ex, $"Exception caught on attempting to Delete ConversationState : {ex}");
                     }
                 }
-
-                // Send and EndOfConversation activity to the skill caller with the error to end the conversation
-                // and let the caller decide what to do.
-                var endOfConversation = Activity.CreateEndOfConversationActivity();
-                endOfConversation.Code = "SkillError";
-                endOfConversation.Text = exception.Message;
-                await turnContext.SendActivityAsync(endOfConversation);
-
-                // Send a trace activity, which will be displayed in the Bot Framework Emulator
-                // Note: we return the entire exception in the value property to help the developer, this should not be done in prod.
-                await turnContext.TraceActivityAsync("OnTurnError Trace", exception.ToString(), "https://www.botframework.com/schemas/error", "TurnError");
             };
         }
     }

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/AdapterWithErrorHandler.cs
@@ -2,9 +2,13 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
+using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Builder.TraceExtensions;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -13,7 +17,7 @@ namespace Microsoft.BotBuilderSamples.SimpleRootBot
 {
     public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger, ConversationState conversationState = null)
+        public AdapterWithErrorHandler(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger, ConversationState conversationState = null, SkillHttpClient skillClient = null, SkillsConfiguration skillsConfig = null)
             : base(configuration, logger)
         {
             OnTurnError = async (turnContext, exception) =>
@@ -34,6 +38,22 @@ namespace Microsoft.BotBuilderSamples.SimpleRootBot
                 {
                     try
                     {
+                        // Inform the active skill that the conversation is ended so that it has
+                        // a chance to clean up.
+                        // Note: "activeSkillProperty" is set by the RooBot while messages are being
+                        // forwarded to a Skill.
+                        var activeSkill = await conversationState.CreateProperty<BotFrameworkSkill>("activeSkillProperty").GetAsync(turnContext, () => null);
+                        if (skillClient != null && skillsConfig != null && activeSkill != null)
+                        {
+                            var botId = configuration.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey)?.Value;
+
+                            var endOfConversation = Activity.CreateEndOfConversationActivity();
+                            endOfConversation.Code = EndOfConversationCodes.Unknown;
+                            endOfConversation.ApplyConversationReference(turnContext.Activity.GetConversationReference(), true);
+
+                            await skillClient.PostActivityAsync(botId, activeSkill, skillsConfig.SkillHostEndpoint, (Activity)endOfConversation, CancellationToken.None);
+                        }
+
                         // Delete the conversationState for the current conversation to prevent the
                         // bot from getting stuck in a error-loop caused by being in a bad state.
                         // ConversationState should be thought of as similar to "cookie-state" in a Web pages.
@@ -47,7 +67,6 @@ namespace Microsoft.BotBuilderSamples.SimpleRootBot
 
                 // Send a trace activity, which will be displayed in the Bot Framework Emulator
                 await turnContext.TraceActivityAsync("OnTurnError Trace", exception.ToString(), "https://www.botframework.com/schemas/error", "TurnError");
-
             };
         }
     }

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/AdapterWithErrorHandler.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
@@ -17,57 +18,96 @@ namespace Microsoft.BotBuilderSamples.SimpleRootBot
 {
     public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
     {
+        private ConversationState _conversationState;
+        private IConfiguration _configuration;
+        private ILogger _logger;
+        private SkillHttpClient _skillClient;
+        private SkillsConfiguration _skillsConfig;
+
         public AdapterWithErrorHandler(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger, ConversationState conversationState = null, SkillHttpClient skillClient = null, SkillsConfiguration skillsConfig = null)
             : base(configuration, logger)
         {
-            OnTurnError = async (turnContext, exception) =>
+            _configuration = configuration;
+            _conversationState = conversationState;
+            _logger = logger;
+            _skillClient = skillClient;
+            _skillsConfig = skillsConfig;
+
+            OnTurnError = OnBotError;
+        }
+
+        private async Task OnBotError(ITurnContext turnContext, Exception exception)
+        {
+            // Log any leaked exception from the application.
+            _logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
+
+            await sendErrorMessageAsync(turnContext, exception);
+            await endSkillConversationAsync(turnContext);
+            await clearConversationStateAsync(turnContext);
+        }
+
+        protected async Task sendErrorMessageAsync(ITurnContext turnContext, Exception exception)
+        {
+            // Send a message to the user
+            var errorMessageText = "The bot encountered an error or bug.";
+            var errorMessage = MessageFactory.Text(errorMessageText, errorMessageText, InputHints.IgnoringInput);
+            await turnContext.SendActivityAsync(errorMessage);
+
+            errorMessageText = "To continue to run this bot, please fix the bot source code.";
+            errorMessage = MessageFactory.Text(errorMessageText, errorMessageText, InputHints.ExpectingInput);
+            await turnContext.SendActivityAsync(errorMessage);
+
+            // Send a trace activity, which will be displayed in the Bot Framework Emulator
+            await turnContext.TraceActivityAsync("OnTurnError Trace", exception.ToString(), "https://www.botframework.com/schemas/error", "TurnError");
+        }
+
+        private async Task<InvokeResponse> endSkillConversationAsync(ITurnContext turnContext)
+        {
+            if (_conversationState == null || _skillClient == null || _skillsConfig == null)
             {
-                // Log any leaked exception from the application.
-                logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
+                return null;
+            }
 
-                // Send a message to the user
-                var errorMessageText = "The bot encountered an error or bug.";
-                var errorMessage = MessageFactory.Text(errorMessageText, errorMessageText, InputHints.IgnoringInput);
-                await turnContext.SendActivityAsync(errorMessage);
+            try
+            {
+                await _conversationState.SaveChangesAsync(turnContext, true);
 
-                errorMessageText = "To continue to run this bot, please fix the bot source code.";
-                errorMessage = MessageFactory.Text(errorMessageText, errorMessageText, InputHints.ExpectingInput);
-                await turnContext.SendActivityAsync(errorMessage);
+                // Inform the active skill that the conversation is ended so that it has
+                // a chance to clean up.
+                // Note: "activeSkillProperty" is set by the RooBot while messages are being
+                // forwarded to a Skill.
+                var activeSkill = await _conversationState.CreateProperty<BotFrameworkSkill>("activeSkillProperty").GetAsync(turnContext, () => null);
+                var botId = _configuration.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey)?.Value;
 
-                if (conversationState != null)
+                var endOfConversation = Activity.CreateEndOfConversationActivity();
+                endOfConversation.Code = "RootSkillError";
+                endOfConversation.ApplyConversationReference(turnContext.Activity.GetConversationReference());
+
+                return await _skillClient.PostActivityAsync(botId, activeSkill, _skillsConfig.SkillHostEndpoint, (Activity)endOfConversation, CancellationToken.None);
+            }
+            catch(Exception ex)
+            {
+                _logger.LogError(ex, $"Exception caught on attempting to send EndOfConversation : {ex}");
+                return null;
+            }
+        }
+
+        private async Task clearConversationStateAsync(ITurnContext turnContext)
+        {
+            if (_conversationState != null)
+            {
+                try
                 {
-                    try
-                    {
-                        // Inform the active skill that the conversation is ended so that it has
-                        // a chance to clean up.
-                        // Note: "activeSkillProperty" is set by the RooBot while messages are being
-                        // forwarded to a Skill.
-                        var activeSkill = await conversationState.CreateProperty<BotFrameworkSkill>("activeSkillProperty").GetAsync(turnContext, () => null);
-                        if (skillClient != null && skillsConfig != null && activeSkill != null)
-                        {
-                            var botId = configuration.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey)?.Value;
-
-                            var endOfConversation = Activity.CreateEndOfConversationActivity();
-                            endOfConversation.Code = EndOfConversationCodes.Unknown;
-                            endOfConversation.ApplyConversationReference(turnContext.Activity.GetConversationReference(), true);
-
-                            await skillClient.PostActivityAsync(botId, activeSkill, skillsConfig.SkillHostEndpoint, (Activity)endOfConversation, CancellationToken.None);
-                        }
-
-                        // Delete the conversationState for the current conversation to prevent the
-                        // bot from getting stuck in a error-loop caused by being in a bad state.
-                        // ConversationState should be thought of as similar to "cookie-state" in a Web pages.
-                        await conversationState.DeleteAsync(turnContext);
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.LogError(ex, $"Exception caught on attempting to Delete ConversationState : {ex}");
-                    }
+                    // Delete the conversationState for the current conversation to prevent the
+                    // bot from getting stuck in a error-loop caused by being in a bad state.
+                    // ConversationState should be thought of as similar to "cookie-state" in a Web pages.
+                    await _conversationState.DeleteAsync(turnContext);
                 }
-
-                // Send a trace activity, which will be displayed in the Bot Framework Emulator
-                await turnContext.TraceActivityAsync("OnTurnError Trace", exception.ToString(), "https://www.botframework.com/schemas/error", "TurnError");
-            };
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, $"Exception caught on attempting to Delete ConversationState : {ex}");
+                }
+            }
         }
     }
 }

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/Bots/RootBot.cs
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/Bots/RootBot.cs
@@ -25,6 +25,8 @@ namespace Microsoft.BotBuilderSamples.SimpleRootBot.Bots
         private readonly SkillsConfiguration _skillsConfig;
         private readonly BotFrameworkSkill _targetSkill;
 
+        public const string ActiveSkillPropertyName = "activeSkillProperty";
+
         public RootBot(ConversationState conversationState, SkillsConfiguration skillsConfig, SkillHttpClient skillClient, IConfiguration configuration)
         {
             _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
@@ -49,7 +51,7 @@ namespace Microsoft.BotBuilderSamples.SimpleRootBot.Bots
             }
 
             // Create state property to track the active skill
-            _activeSkillProperty = conversationState.CreateProperty<BotFrameworkSkill>("activeSkillProperty");
+            _activeSkillProperty = conversationState.CreateProperty<BotFrameworkSkill>(ActiveSkillPropertyName);
         }
 
         protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)


### PR DESCRIPTION
Address 2101 for dotnet.

I did not resolve the active skill property name and it uses a magic string.  Since that error handler class is not terribly reusable, I didn't spend a lot of cycles on that aspect.  If you have a firm opinion on how you'd like it handled I'm open.

Also, there doesn't seem to be a good EndOfConversationCodes value.  I went with Unknown.