### PR TITLE
Updated AdapterWithErrorHandler to match simple sample

### DIFF
--- a/experimental/skills/DialogToDialog/DialogRootBot/AdapterWithErrorHandler.cs
+++ b/experimental/skills/DialogToDialog/DialogRootBot/AdapterWithErrorHandler.cs
@@ -2,28 +2,55 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
+using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
-using Microsoft.BotBuilderSamples.DialogRootBot.Middleware;
+using Microsoft.BotBuilderSamples.DialogRootBot.Dialogs;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Console;
 
 namespace Microsoft.BotBuilderSamples.DialogRootBot
 {
     public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, ICredentialProvider credentialProvider, AuthenticationConfiguration authConfig, ILogger<AdapterWithErrorHandler> logger, ConversationState conversationState = null)
-            : base(configuration, credentialProvider, authConfig, logger: logger)
-        {
-            OnTurnError = async (turnContext, exception) =>
-            {
-                // Log any leaked exception from the application.
-                logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
+        private readonly IConfiguration _configuration;
+        private readonly ConversationState _conversationState;
+        private readonly ILogger _logger;
+        private readonly SkillHttpClient _skillClient;
+        private readonly SkillsConfiguration _skillsConfig;
 
+        public AdapterWithErrorHandler(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger, ConversationState conversationState = null, SkillHttpClient skillClient = null, SkillsConfiguration skillsConfig = null)
+            : base(configuration, logger)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _conversationState = conversationState;
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _skillClient = skillClient;
+            _skillsConfig = skillsConfig;
+
+            OnTurnError = HandleTurnError;
+        }
+
+        private async Task HandleTurnError(ITurnContext turnContext, Exception exception)
+        {
+            // Log any leaked exception from the application.
+            _logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
+
+            await SendErrorMessageAsync(turnContext, exception);
+            await EndSkillConversationAsync(turnContext);
+            await ClearConversationStateAsync(turnContext);
+        }
+
+        private async Task SendErrorMessageAsync(ITurnContext turnContext, Exception exception)
+        {
+            try
+            {
                 // Send a message to the user
                 var errorMessageText = "The bot encountered an error or bug.";
                 var errorMessage = MessageFactory.Text(errorMessageText, errorMessageText, InputHints.IgnoringInput);
@@ -33,26 +60,63 @@ namespace Microsoft.BotBuilderSamples.DialogRootBot
                 errorMessage = MessageFactory.Text(errorMessageText, errorMessageText, InputHints.ExpectingInput);
                 await turnContext.SendActivityAsync(errorMessage);
 
-                if (conversationState != null)
-                {
-                    try
-                    {
-                        // Delete the conversationState for the current conversation to prevent the
-                        // bot from getting stuck in a error-loop caused by being in a bad state.
-                        // ConversationState should be thought of as similar to "cookie-state" in a Web pages.
-                        await conversationState.DeleteAsync(turnContext);
-                    }
-                    catch (Exception e)
-                    {
-                        logger.LogError(e, $"Exception caught on attempting to Delete ConversationState : {e.Message}");
-                    }
-                }
-
                 // Send a trace activity, which will be displayed in the Bot Framework Emulator
                 await turnContext.TraceActivityAsync("OnTurnError Trace", exception.ToString(), "https://www.botframework.com/schemas/error", "TurnError");
-            };
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Exception caught in SendErrorMessageAsync : {ex}");
+            }
+        }
 
-            Use(new LoggerMiddleware(logger));
+        private async Task EndSkillConversationAsync(ITurnContext turnContext)
+        {
+            if (_conversationState == null || _skillClient == null || _skillsConfig == null)
+            {
+                return;
+            }
+
+            try
+            {
+                // Inform the active skill that the conversation is ended so that it has
+                // a chance to clean up.
+                // Note: ActiveSkillPropertyName is set by the RooBot while messages are being
+                // forwarded to a Skill.
+                var activeSkill = await _conversationState.CreateProperty<BotFrameworkSkill>(SkillDialog.ActiveSkillPropertyName).GetAsync(turnContext, () => null);
+                if (activeSkill != null)
+                {
+                    var botId = _configuration.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey)?.Value;
+
+                    var endOfConversation = Activity.CreateEndOfConversationActivity();
+                    endOfConversation.Code = "RootSkillError";
+                    endOfConversation.ApplyConversationReference(turnContext.Activity.GetConversationReference(), true);
+
+                    await _conversationState.SaveChangesAsync(turnContext, true);
+                    await _skillClient.PostActivityAsync(botId, activeSkill, _skillsConfig.SkillHostEndpoint, (Activity)endOfConversation, CancellationToken.None);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Exception caught on attempting to send EndOfConversation : {ex}");
+            }
+        }
+
+        private async Task ClearConversationStateAsync(ITurnContext turnContext)
+        {
+            if (_conversationState != null)
+            {
+                try
+                {
+                    // Delete the conversationState for the current conversation to prevent the
+                    // bot from getting stuck in a error-loop caused by being in a bad state.
+                    // ConversationState should be thought of as similar to "cookie-state" in a Web pages.
+                    await _conversationState.DeleteAsync(turnContext);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, $"Exception caught on attempting to Delete ConversationState : {ex}");
+                }
+            }
         }
     }
 }

--- a/experimental/skills/DialogToDialog/DialogRootBot/Dialogs/SkillDialog.cs
+++ b/experimental/skills/DialogToDialog/DialogRootBot/Dialogs/SkillDialog.cs
@@ -32,6 +32,8 @@ namespace Microsoft.BotBuilderSamples.DialogRootBot.Dialogs
         private readonly SkillHttpClient _skillClient;
         private readonly SkillsConfiguration _skillsConfig;
 
+        public static readonly string ActiveSkillPropertyName = $"{typeof(SkillDialog).FullName}.ActiveSkillProperty";
+
         public SkillDialog(ConversationState conversationState, SkillHttpClient skillClient, SkillsConfiguration skillsConfig, IConfiguration configuration)
             : base(nameof(SkillDialog))
         {
@@ -49,7 +51,7 @@ namespace Microsoft.BotBuilderSamples.DialogRootBot.Dialogs
             _skillClient = skillClient ?? throw new ArgumentNullException(nameof(skillClient));
             _skillsConfig = skillsConfig ?? throw new ArgumentNullException(nameof(skillsConfig));
             _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
-            _activeSkillProperty = conversationState.CreateProperty<string>($"{typeof(SkillDialog).FullName}.ActiveSkillProperty");
+            _activeSkillProperty = conversationState.CreateProperty<string>(ActiveSkillPropertyName);
         }
 
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default)

--- a/experimental/skills/DialogToDialog/DialogRootBot/README.md
+++ b/experimental/skills/DialogToDialog/DialogRootBot/README.md
@@ -1,21 +1,3 @@
 ﻿# DialogRootBot (**DRAFT**)
 
-Bot Framework v4 Skills with Dialogs sample.
-
-This bot has been created using [Bot Framework](https://dev.botframework.com), it shows how to create a root bot that 
-can consume a remote skill capabilities using a SkillDialog to manage the conversation state.
-
-## Key concepts
-
-- A [root dialog](Dialogs/MainDialog.cs) that can call different tasks on a skill using a [SkillDialog](Dialogs/SkillDialog.cs):
-    - Event Tasks
-    - Message Tasks
-    - Invoke Tasks
-- How to send an EndOfConversation activity to remotely let a skill that it needs to end a conversation.
-- How to Implement a [ClaimsValidator](Authentication/AllowedCallersClaimsValidator.cs) that allows a parent bot to validate that a response is coming from a skill that is allowed to talk to the parent.
-- A sample [SkillDialog](Dialogs/SkillDialog.cs) that can be used to keep track of multiturn interactions with a skill using the dialog stack.
-- A [Logger Middleware](Middleware/LoggerMiddleware.cs) that shows how to handle and log activities coming from a skill
-- A [SkillConversationIdFactory](SkillConversationIdFactory.cs) based on IStorage to create and maintain conversation IDs to interact with a skill.
-- A [SkillsConfiguration](SkillsConfiguration.cs) class that can load skill definitions from appsettings.
-- A [startup](Startup.cs) class that shows how to register the different skills components for DI.
-- A [SkillController](Controllers/SkillController.cs) that handles skill responses.
+See [DialogToDialog](../) for details on how to configure and run this sample.

--- a/experimental/skills/DialogToDialog/DialogRootBot/SkillConversationIdFactory.cs
+++ b/experimental/skills/DialogToDialog/DialogRootBot/SkillConversationIdFactory.cs
@@ -42,7 +42,7 @@ namespace Microsoft.BotBuilderSamples.DialogRootBot
                 throw new NullReferenceException($"ChannelId in {nameof(conversationReference)} can't be null.");
             }
 
-            var storageKey = $"{conversationReference.Conversation.Id}-{conversationReference.ChannelId}-skillconvo";
+            var storageKey = $"{conversationReference.ChannelId}-{conversationReference.Conversation.Id}";
             var skillConversationInfo = new Dictionary<string, object> { { storageKey, JObject.FromObject(conversationReference) } };
             await _storage.WriteAsync(skillConversationInfo, cancellationToken).ConfigureAwait(false);
 

--- a/experimental/skills/DialogToDialog/DialogSkillBot/README.md
+++ b/experimental/skills/DialogToDialog/DialogSkillBot/README.md
@@ -1,13 +1,3 @@
 ﻿# DialogSkillBot (**DRAFT**)
 
-Bot Framework v4 Skills with Dialogs sample.
-
-This bot has been created using [Bot Framework](https://dev.botframework.com), it shows how to create a skill bot that 
-can perform different tasks based on requests received from a root bot.
-
-## Key concepts
-
-- A sample [IBot](Bots/SkillBot.cs) that shows how to handle and return EndOfConversation based on the status of the dialog in the skill.
-- An [ActivityRouterDialog](Bots/ActivityRouterDialog.cs) that handles Events, Messages and Invoke activities coming from a parent and perform different tasks. 
-- How to receive and return values in a skill.
-- A [sample skill manifest](wwwroot/manifest/dialogchildbot-manifest-1.0.json) that describes what the skill can do.
+See [DialogToDialog](../) for details on how to configure and run this sample.

--- a/experimental/skills/DialogToDialog/DialogSkillBot/wwwroot/manifest/dialogchildbot-manifest-1.0.json
+++ b/experimental/skills/DialogToDialog/DialogSkillBot/wwwroot/manifest/dialogchildbot-manifest-1.0.json
@@ -47,6 +47,11 @@
         "$ref": "#/definitions/weatherReport"
       }
     },
+    "authCardTest": {
+      "description": "Tests the sign in card using OAuth (event, multi turn)",
+      "type": "event",
+      "name": "OAuthTest"
+    },
     "passthroughMessage": {
       "type": "message",
       "description": "Receives the user's utterance and attempts to resolve it using the skill's LUIS models",

--- a/experimental/skills/DialogToDialog/README.md
+++ b/experimental/skills/DialogToDialog/README.md
@@ -13,16 +13,41 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
   dotnet --version
   ```
 
-## Key concepts
+## Key concepts in this sample
 
-- A [DialogRootBot](DialogRootBot/README.md) that can consume skills.
-- A [DialogSkillBot](DialogSkillBot/README.md) that handle requests from a parent bot.
+The solution uses dialogs and includes a parent bot (`DialogRootBot`) and a skill bot (`DialogSkillBot`) and shows how the parent bot can post activities to the skill bot and returns the skill responses to the user.
+
+- `DialogRootBot`: this project shows how to consume a skill bot using a `SkillDialog` and includes:
+    - A [root dialog](DialogRootBot/Dialogs/MainDialog.cs) that can call different tasks on a skill using a [SkillDialog](DialogRootBot/Dialogs/SkillDialog.cs):
+        - Event Tasks
+        - Message Tasks
+        - Invoke Tasks
+    - How to send an `EndOfConversation` activity to remotely let a skill that it needs to end a conversation.
+    - How to Implement a [ClaimsValidator](DialogRootBot/Authentication/AllowedCallersClaimsValidator.cs) that allows a parent bot to validate that a response is coming from a skill that is allowed to talk to the parent.
+    - A sample [SkillDialog](DialogRootBot/Dialogs/SkillDialog.cs) that can be used to keep track of multiturn interactions with a skill using the dialog stack.
+    - A [Logger Middleware](DialogRootBot/Middleware/LoggerMiddleware.cs) that shows how to handle and log activities coming from a skill
+    - A [SkillConversationIdFactory](DialogRootBot/SkillConversationIdFactory.cs) based on IStorage to create and maintain conversation IDs to interact with a skill.
+    - A [SkillsConfiguration](DialogRootBot/SkillsConfiguration.cs) class that can load skill definitions from appsettings.
+    - A [startup](DialogRootBot/Startup.cs) class that shows how to register the different skills components for DI.
+    - A [SkillController](DialogRootBot/Controllers/SkillController.cs) that handles skill responses.
+
+- `DialogSkillBot`: this project shows a simple echo skill that receives message activities from the parent bot and echoes what the user said. This project includes:
+    - A sample [IBot](DialogSkillBot/Bots/SkillBot.cs) that shows how to handle and return EndOfConversation based on the status of the dialog in the skill.
+    - An [ActivityRouterDialog](DialogSkillBot/Bots/ActivityRouterDialog.cs) that handles Events, Messages and Invoke activities coming from a parent and perform different tasks. 
+    - How to receive and return values in a skill.
+    - A [sample skill manifest](DialogSkillBot/wwwroot/manifest/dialogchildbot-manifest-1.0.json) that describes what the skill can do.
 
 ## To try this sample
+
+- Clone the repository
+
+    ```bash
+    git clone https://github.com/microsoft/botbuilder-samples.git
+    ```
 
 - Create a bot registration in the azure portal for the DialogSkillBot and update [DialogSkillBot/appsettings.json](DialogSkillBot/appsettings.json) with the AppId and password.
 - Create a bot registration in the azure portal for the DialogRootBot and update [DialogRootBot/appsettings.json](DialogRootBot/appsettings.json) with the AppId and password. 
 - Update the BotFrameworkSkills section in [DialogRootBot/appsettings.json](DialogRootBot/appsettings.json) with the AppId for the skill you created in the previou step.
-- Configure Visual Studio to run both applications at the same time.
 - (Optional) Configure the bot registration for [DialogSkillBot](DialogSkillBot) with an OAuth connection if you want to test acquiring OAuth tokens from the skill.
 - (Optional) Configure the LuisAppId, LuisAPIKey and LuisAPIHostName section in the [DialogSkillBot configuration](DialogSkillBot/appsettings.json) if you want to run message activities through LUIS.
+- Open the `DialogToDialog.sln` solution and configure it to [start debugging with multiple processes](https://docs.microsoft.com/en-us/visualstudio/debugger/debug-multiple-processes?view=vs-2019#start-debugging-with-multiple-processes)

--- a/experimental/skills/README.md
+++ b/experimental/skills/README.md
@@ -1,6 +1,7 @@
-# Skill Examples
+# Experimental Skill Examples
 
-This folder contains to sample scenarios for Skills:
+This folder contains experimental sample scenarios for Skills:
 
-- A [simple bot to bot](SimpleBotToBot) example that shows the basics on how to consume an Echo Skill from a root bot.
-- A more advanced [dialog based](DialogToDialog) example that shows how to consume a skill that can perform several activities using a SkillDialog.
+- An advanced [dialog based](DialogToDialog) example that shows how to consume a skill that can perform several activities using a SkillDialog.
+
+Note: these samples are provided as is, some of the things shown in this example may or may not make it into the framework. 


### PR DESCRIPTION
Updated AdapterWithErrorHandler to send end of conversation to the sill on catastrophic failure (like SimpleBotToBotSample does).

Also in this PR:
Updated readmes.
Added OAuthTest action to the sample manifest.
Updated skillconversationIdfactory to use a different pattern