### PR TITLE
[Sample 48 C#] Fix cancellationToken error

### DIFF
--- a/samples/csharp_dotnetcore/48.qnamaker-active-learning-bot/Dialog/DialogHelper.cs
+++ b/samples/csharp_dotnetcore/48.qnamaker-active-learning-bot/Dialog/DialogHelper.cs
@@ -75,7 +75,7 @@ namespace Microsoft.BotBuilderSamples
 
             stepContext.Values[QnAData] = new List<QueryResult>(filteredResponse);
             stepContext.Values[CurrentQuery] = stepContext.Context.Activity.Text;
-            return await stepContext.NextAsync(cancellationToken);
+            return await stepContext.NextAsync(null, cancellationToken);
         }
 
         private async Task<DialogTurnResult> FilterLowVariationScoreList(WaterfallStepContext stepContext, CancellationToken cancellationToken)


### PR DESCRIPTION
## Proposed Changes

Sample 48 has:

```csharp
return await stepContext.NextAsync(cancellationToken);
```
which results in:

![image](https://user-images.githubusercontent.com/40401643/72476649-973fec80-37a2-11ea-9b8a-48c204325e82.png)

and:

![image](https://user-images.githubusercontent.com/40401643/72476710-bc345f80-37a2-11ea-8c92-b9f19f1ae7ac.png)

## Changes

```csharp
return await stepContext.NextAsync(cancellationToken);
```

to

```csharp
return await stepContext.NextAsync(null, cancellationToken);
```

## Testing

![image](https://user-images.githubusercontent.com/40401643/72476759-d53d1080-37a2-11ea-8d14-49943e836fa3.png)
