### PR TITLE
Fixing serverFarmId

### DIFF
--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/DeploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/DeploymentTemplates/preexisting-rg-parameters.json
@@ -32,6 +32,9 @@
         "existingAppServicePlan": {
             "value": ""
         },
+        "existingAppServicePlanResourceGroup": {
+            "value": ""
+        },        
         "newWebAppName": {
             "value": ""
         }

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -60,6 +60,13 @@
                 "description": "Name of the existing App Service Plan used to create the Web App for the bot."
             }
         },
+        "existingAppServicePlanResourceGroup": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Name of the resource group for the existing App Service Plan used to create the Web App for the bot."
+            }
+        },        
         "newWebAppName": {
             "type": "string",
             "defaultValue": "",
@@ -102,7 +109,7 @@
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[concat('/subscriptions/', Subscription().SubscriptionId,'/resourceGroups/', parameters('existingAppServicePlanResourceGroup'), '/providers/Microsoft.Web/serverfarms/', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/DeploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/DeploymentTemplates/preexisting-rg-parameters.json
@@ -32,6 +32,9 @@
         "existingAppServicePlan": {
             "value": ""
         },
+        "existingAppServicePlanResourceGroup": {
+            "value": ""
+        },
         "newWebAppName": {
             "value": ""
         }

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -60,6 +60,13 @@
                 "description": "Name of the existing App Service Plan used to create the Web App for the bot."
             }
         },
+        "existingAppServicePlanResourceGroup": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Name of the resource group for the existing App Service Plan used to create the Web App for the bot."
+            }
+        },        
         "newWebAppName": {
             "type": "string",
             "defaultValue": "",
@@ -102,7 +109,7 @@
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[concat('/subscriptions/', Subscription().SubscriptionId,'/resourceGroups/', parameters('existingAppServicePlanResourceGroup'), '/providers/Microsoft.Web/serverfarms/', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {


### PR DESCRIPTION
Fixes # N/A

## Proposed Changes
The ARM templates for sample `\samples\csharp_dotnetcore\80.skills-simple-bot-to-bot\` for deploying to an existing resource group and using an existing app service plan fails to deploy with the error

> "ServerFarmNotFound - The specified app service plan was not found"


I have amended the templates following the workaround suggested in this issue for the Virtual Assistant: [https://github.com/microsoft/botframework-solutions/issues/2762](url)

