### PR TITLE
Fix "UserProfile" property creation in conversation_state

### DIFF
--- a/samples/python/44.prompt-for-user-input/bots/custom_prompt_bot.py
+++ b/samples/python/44.prompt-for-user-input/bots/custom_prompt_bot.py
@@ -41,7 +41,7 @@ class CustomPromptBot(ActivityHandler):
         self.user_state = user_state
 
         self.flow_accessor = self.conversation_state.create_property("ConversationFlow")
-        self.profile_accessor = self.conversation_state.create_property("UserProfile")
+        self.profile_accessor = self.user_state.create_property("UserProfile")
 
     async def on_message_activity(self, turn_context: TurnContext):
         # Get the state properties from the turn context.


### PR DESCRIPTION
The "UserProfile" property was created in the conversation state, though it should be in the user state, as it is in C# and JS samples. Maybe this is a copy-past error. So, I've edited the file, and now "UserProfile" property is created in user state.