### PR TITLE
python/15.handling-attachments: await for connector

### DIFF
--- a/samples/python/15.handling-attachments/bots/attachments_bot.py
+++ b/samples/python/15.handling-attachments/bots/attachments_bot.py
@@ -180,7 +180,7 @@ class AttachmentsBot(ActivityHandler):
         ) as in_file:
             image_data = in_file.read()
 
-        connector = turn_context.adapter.create_connector_client(
+        connector = await turn_context.adapter.create_connector_client(
             turn_context.activity.service_url
         )
         conversation_id = turn_context.activity.conversation.id


### PR DESCRIPTION
Partially Fixes https://github.com/microsoft/BotBuilder-Samples/issues/2170

## Proposed Changes

Wait for creation of connector client.
Absence of `await` creates run time error

