### PR TITLE
Fixed #2185

### DIFF
--- a/samples/csharp_dotnetcore/46.teams-auth/Dialogs/LogoutDialog.cs
+++ b/samples/csharp_dotnetcore/46.teams-auth/Dialogs/LogoutDialog.cs
@@ -48,7 +48,7 @@ namespace Microsoft.BotBuilderSamples
                 var text = innerDc.Context.Activity.Text.ToLowerInvariant();
 
                 // Allow logout anywhere in the command
-                if (text.IndexOf("logout") > 0)
+                if (text.IndexOf("logout") >= 0)
                 {
                     // The bot adapter encapsulates the authentication processes.
                     var botAdapter = (BotFrameworkAdapter)innerDc.Context.Adapter;


### PR DESCRIPTION
This commit fixes the issue of "logout" command not working.

Fixes #2185 

- "logout" command is not working because the if condition is only true when text.IndexOf("logout") > 0, which would be false in case of text = "logout" as it'll return 0 index. It'll work for other commands like "please logout" etc. but not "logout". Hence, I changed the condition to text.IndexOf("logout") >= 0 so that "logout" command also works.


![image](https://user-images.githubusercontent.com/26645175/74367111-51a12e80-4df7-11ea-9272-76e03ea9d06a.png)



## Testing
Tested on web chat. 