### PR TITLE
Add endOfConversation listener (v3 skill sample)

### DIFF
--- a/MigrationV3V4/Node/Skills/v3-booking-bot-skill/app.js
+++ b/MigrationV3V4/Node/Skills/v3-booking-bot-skill/app.js
@@ -107,6 +107,13 @@ bot.dialog('helpDialog', function (session) {
 // Add global endConversation() action bound to the 'Goodbye' intent
 bot.endConversationAction('endAction', "Ok... See you later.", { matches: 'End' });
 
+// Listen for endOfConversation activities from other sources
+bot.on('endOfConversation', (message) => {
+    bot.loadSession(message.address, (err, session) => {
+        endConversation(session, null, 'completedSuccessfully');
+    });
+})
+
 // log any bot errors into the console
 bot.on('error', function (e) {
     console.log('And error ocurred', e);


### PR DESCRIPTION
## Proposed Changes

Adds a listener for `endOfConversation` events in the v3 skill sample.

Only included in the Booking sample since the Echo sample doesn't store any user/convo data.

## Testing
Manually tested. Also made sure this listener isn't called during a "normal" `endConversation` event; it's not.