### PR TITLE
Changed the Icon file names

### DIFF
--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/TeamsAppManifest/manifest.json
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/TeamsAppManifest/manifest.json
@@ -11,8 +11,8 @@
     "termsOfUseUrl": "https://dev.botframework.com"
   },
   "icons": {
-    "color": "color.png",
-    "outline": "outline.png"
+    "color": "icon-color.png",
+    "outline": "icon-outline.png"
   },
   "name": {
     "short": "Config Auth Search",


### PR DESCRIPTION
The icon file names were icon-color.png icon-and outline.png, however in the manifest were missing the prefix icon-. This caused an error to occur when uploading the manifest.zip file to teams.
