### PR TITLE
[V3 Skill Sample] Catch exceptions during EndofConversation

### DIFF
--- a/MigrationV3V4/CSharp/Skills/V3EchoBot/Controllers/MessagesController.cs
+++ b/MigrationV3V4/CSharp/Skills/V3EchoBot/Controllers/MessagesController.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
@@ -46,16 +47,23 @@ namespace Microsoft.Bot.Sample.EchoBot
             {
                 Trace.TraceInformation($"EndOfConversation: {message}");
 
-                // Clear the dialog stack if the root bot has ended the conversation.
-                using (var scope = DialogModule.BeginLifetimeScope(Conversation.Container, message))
+                try
                 {
-                    var botData = scope.Resolve<IBotData>();
-                    await botData.LoadAsync(default(CancellationToken));
+                    // Clear the dialog stack if the root bot has ended the conversation.
+                    using (var scope = DialogModule.BeginLifetimeScope(Conversation.Container, message))
+                    {
+                        var botData = scope.Resolve<IBotData>();
+                        await botData.LoadAsync(default(CancellationToken));
 
-                    var stack = scope.Resolve<IDialogStack>();
-                    stack.Reset();
+                        var stack = scope.Resolve<IDialogStack>();
+                        stack.Reset();
 
-                    await botData.FlushAsync(default(CancellationToken));
+                        await botData.FlushAsync(default(CancellationToken));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceError(ex.Message);
                 }
             }
             else if (messageType == ActivityTypes.DeleteUserData)

--- a/MigrationV3V4/CSharp/Skills/V3SimpleSandwichBot/ConversationHelper.cs
+++ b/MigrationV3V4/CSharp/Skills/V3SimpleSandwichBot/ConversationHelper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Configuration;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
@@ -54,20 +55,27 @@ namespace Microsoft.Bot.Sample.SimpleSandwichBot
         /// <param name="activity">The incoming activity to use for scoping the Conversation.Container.</param>
         internal static async Task ClearState(Activity activity)
         {
-            using (var scope = DialogModule.BeginLifetimeScope(Conversation.Container, activity))
+            try
             {
-                var botData = scope.Resolve<IBotData>();
-                await botData.LoadAsync(default(CancellationToken));
+                using (var scope = DialogModule.BeginLifetimeScope(Conversation.Container, activity))
+                {
+                    var botData = scope.Resolve<IBotData>();
+                    await botData.LoadAsync(default(CancellationToken));
 
-                // Some skills might persist data between invokations.
-                botData.UserData.Clear();
-                botData.ConversationData.Clear();
-                botData.PrivateConversationData.Clear();
+                    // Some skills might persist data between invocations.
+                    botData.UserData.Clear();
+                    botData.ConversationData.Clear();
+                    botData.PrivateConversationData.Clear();
 
-                var stack = scope.Resolve<IDialogStack>();
-                stack.Reset();
+                    var stack = scope.Resolve<IDialogStack>();
+                    stack.Reset();
 
-                await botData.FlushAsync(default(CancellationToken));
+                    await botData.FlushAsync(default(CancellationToken));
+                }
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceError(ex.Message);
             }
         }
     }


### PR DESCRIPTION
PVA sends EndOfConversation during manifest validation.  Since there is no active conversation, this will result in an exception.  This PR catches and ignores the exception.