### PR TITLE
[V3 c# Skills Sample] Do not attempt to clear state if EndOfConversation activity has no Recipient

### DIFF
--- a/MigrationV3V4/CSharp/Skills/V3EchoBot/Controllers/MessagesController.cs
+++ b/MigrationV3V4/CSharp/Skills/V3EchoBot/Controllers/MessagesController.cs
@@ -46,16 +46,21 @@ namespace Microsoft.Bot.Sample.EchoBot
             {
                 Trace.TraceInformation($"EndOfConversation: {message}");
 
-                // Clear the dialog stack if the root bot has ended the conversation.
-                using (var scope = DialogModule.BeginLifetimeScope(Conversation.Container, message))
+                // This Recipient null check is required for PVA manifest validation.
+                // PVA will send an EOC activity with null Recipient.
+                if (message.Recipient != null)
                 {
-                    var botData = scope.Resolve<IBotData>();
-                    await botData.LoadAsync(default(CancellationToken));
+                    // Clear the dialog stack if the root bot has ended the conversation.
+                    using (var scope = DialogModule.BeginLifetimeScope(Conversation.Container, message))
+                    {
+                        var botData = scope.Resolve<IBotData>();
+                        await botData.LoadAsync(default(CancellationToken));
 
-                    var stack = scope.Resolve<IDialogStack>();
-                    stack.Reset();
+                        var stack = scope.Resolve<IDialogStack>();
+                        stack.Reset();
 
-                    await botData.FlushAsync(default(CancellationToken));
+                        await botData.FlushAsync(default(CancellationToken));
+                    }
                 }
             }
             else if (messageType == ActivityTypes.DeleteUserData)

--- a/MigrationV3V4/CSharp/Skills/V3PizzaBot/ConversationHelper.cs
+++ b/MigrationV3V4/CSharp/Skills/V3PizzaBot/ConversationHelper.cs
@@ -54,6 +54,11 @@ namespace Microsoft.Bot.Sample.PizzaBot
         /// <param name="activity">The incoming activity to use for scoping the Conversation.Container.</param>
         internal static async Task ClearState(Activity activity)
         {
+            // This is required for PVA manifest validation.
+            // PVA will send an EOC activity with null Recipient.
+            if (activity.Recipient == null)
+                return;
+
             using (var scope = DialogModule.BeginLifetimeScope(Conversation.Container, activity))
             {
                 var botData = scope.Resolve<IBotData>();

--- a/MigrationV3V4/CSharp/Skills/V3SimpleSandwichBot/ConversationHelper.cs
+++ b/MigrationV3V4/CSharp/Skills/V3SimpleSandwichBot/ConversationHelper.cs
@@ -54,6 +54,11 @@ namespace Microsoft.Bot.Sample.SimpleSandwichBot
         /// <param name="activity">The incoming activity to use for scoping the Conversation.Container.</param>
         internal static async Task ClearState(Activity activity)
         {
+            // This Recipient null check is required for PVA manifest validation.
+            // PVA will send an EOC activity with null Recipient.
+            if (activity.Recipient == null)
+                return;
+
             using (var scope = DialogModule.BeginLifetimeScope(Conversation.Container, activity))
             {
                 var botData = scope.Resolve<IBotData>();


### PR DESCRIPTION
Fixes an issue with PVA manifest validation, where they send EndOfConversation with no Recipient.