### PR TITLE
Small fix for Sample 80 error handler

### DIFF
--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/index.js
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/index.js
@@ -63,9 +63,16 @@ adapter.onTurnError = async (context, error) => {
     const endOfConversation = {
         type: ActivityTypes.EndOfConversation,
         code: 'SkillError',
-        text: error
+        text: JSON.stringify(error)
     };
     await context.sendActivity(endOfConversation);
+
+    try {
+        // Clear out state
+        await conversationState.delete(context);
+    } catch (err) {
+        console.error(`\n [onTurnError] Exception caught on attempting to Delete ConversationState : ${ err }`);
+    }
 };
 
 // Create the main dialog.

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/index.js
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/index.js
@@ -63,16 +63,9 @@ adapter.onTurnError = async (context, error) => {
     const endOfConversation = {
         type: ActivityTypes.EndOfConversation,
         code: 'SkillError',
-        text: JSON.stringify(error)
+        text: error.toString()
     };
     await context.sendActivity(endOfConversation);
-
-    try {
-        // Clear out state
-        await conversationState.delete(context);
-    } catch (err) {
-        console.error(`\n [onTurnError] Exception caught on attempting to Delete ConversationState : ${ err }`);
-    }
 };
 
 // Create the main dialog.


### PR DESCRIPTION
The error handler for the skill needs to stringify the error in the `text` value of the `endOfConversation` activity (it throws an error about it otherwise)

Note: Removed the conversationState part because there is no state in the skill
