### PR TITLE
QnA: use DefaultAnswer config if passed in

### DIFF
--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/Dialog/QnAMakerBaseDialog.cs
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/Dialog/QnAMakerBaseDialog.cs
@@ -7,6 +7,7 @@ using Microsoft.Bot.Builder.AI.QnA;
 using Microsoft.Bot.Builder.AI.QnA.Dialogs;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.BotBuilderSamples.Dialog
 {
@@ -22,15 +23,17 @@ namespace Microsoft.BotBuilderSamples.Dialog
         public const string DefaultCardNoMatchResponse = "Thanks for the feedback.";
 
         private readonly IBotServices _services;
+        private readonly IConfiguration _configuration;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="QnAMakerBaseDialog"/> class.
         /// Dialog helper to generate dialogs.
         /// </summary>
         /// <param name="services">Bot Services.</param>
-        public QnAMakerBaseDialog(IBotServices services): base()
+        public QnAMakerBaseDialog(IBotServices services, IConfiguration configuration) : base()
         {
             this._services = services;
+            this._configuration = configuration;
         }
 
         protected async override Task<IQnAMakerClient> GetQnAMakerClientAsync(DialogContext dc)
@@ -53,7 +56,7 @@ namespace Microsoft.BotBuilderSamples.Dialog
         protected async override Task<QnADialogResponseOptions> GetQnAResponseOptionsAsync(DialogContext dc)
         {
             var noAnswer = (Activity)Activity.CreateMessageActivity();
-            noAnswer.Text = DefaultNoAnswer;
+            noAnswer.Text = this._configuration["DefaultAnswer"] ?? DefaultNoAnswer;
 
             var cardNoMatchResponse = (Activity)MessageFactory.Text(DefaultCardNoMatchResponse);
 

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/Dialog/RootDialog.cs
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/Dialog/RootDialog.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.AI.QnA.Dialogs;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.BotBuilderSamples.Dialog
 {
@@ -22,10 +23,10 @@ namespace Microsoft.BotBuilderSamples.Dialog
         /// Initializes a new instance of the <see cref="RootDialog"/> class.
         /// </summary>
         /// <param name="services">Bot Services.</param>
-        public RootDialog(IBotServices services)
+        public RootDialog(IBotServices services, IConfiguration configuration)
             : base("root")
         {
-            AddDialog(new QnAMakerBaseDialog(services));
+            AddDialog(new QnAMakerBaseDialog(services, configuration));
 
             AddDialog(new WaterfallDialog(InitialDialog)
                .AddStep(InitialStepAsync));


### PR DESCRIPTION
## Proposed Changes

The default QnA services chat bot initalizes with a value for `DefaultAnswer` in the azure configuration keys (implying that editing it would change the behavior).  Also, the documentation on how to [set default answer for a knowledge base](https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/how-to/change-default-answer) indicates that you can set the value via the configuration key `DefaultAnswer` as well.

However, this sample project doesn't read in that value anywhere, and instead falls back to the constant [`DefaultNoAnswer `](https://github.com/microsoft/BotBuilder-Samples/blob/gary/4.8-dotnet-templates/samples/csharp_dotnetcore/49.qnamaker-all-features/Dialog/QnAMakerBaseDialog.cs#L23):

```cs
public const string DefaultNoAnswer = "No QnAMaker answers found.";
```

This update reads in the configuration value if it exists and falls back to the hard coded constant if it doesn't:

```diff
- noAnswer.Text = DefaultNoAnswer;
+ noAnswer.Text = this._configuration["DefaultAnswer"] ?? DefaultNoAnswer;
```

This issue came up in this question on [How can i set default answer in Q&A Azure bot](https://stackoverflow.com/a/60768373/1366033) as well