### PR TITLE
Updated v3 samples to v3.30.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,6 +253,7 @@ paket-files/
 
 # Node
 /**/node_modules
+package-lock.json
 
 # Visual Studio Code
 .vscode/

--- a/CSharp/Blog-CustomChannelData/packages.config
+++ b/CSharp/Blog-CustomChannelData/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/capability-SimpleTaskAutomation/packages.config
+++ b/CSharp/capability-SimpleTaskAutomation/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/cards-AdaptiveCards/packages.config
+++ b/CSharp/cards-AdaptiveCards/packages.config
@@ -10,10 +10,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />

--- a/CSharp/cards-CarouselCards/packages.config
+++ b/CSharp/cards-CarouselCards/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/cards-RichCards/packages.config
+++ b/CSharp/cards-RichCards/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/core-AppInsights/packages.config
+++ b/CSharp/core-AppInsights/packages.config
@@ -17,10 +17,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/core-BasicMultiDialog/packages.config
+++ b/CSharp/core-BasicMultiDialog/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/core-ChannelData/packages.config
+++ b/CSharp/core-ChannelData/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/core-CreateNewConversation/packages.config
+++ b/CSharp/core-CreateNewConversation/packages.config
@@ -10,10 +10,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/core-CustomState/packages.config
+++ b/CSharp/core-CustomState/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.22.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/core-DirectLine/DirectLineBot/packages.config
+++ b/CSharp/core-DirectLine/DirectLineBot/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/core-DirectLineWebSockets/DirectLineBot/packages.config
+++ b/CSharp/core-DirectLineWebSockets/DirectLineBot/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/core-GetConversationMembers/packages.config
+++ b/CSharp/core-GetConversationMembers/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/core-GlobalMessageHandlers/packages.config
+++ b/CSharp/core-GlobalMessageHandlers/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/core-Middleware/packages.config
+++ b/CSharp/core-Middleware/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/core-MultiDialogs/packages.config
+++ b/CSharp/core-MultiDialogs/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/core-ReceiveAttachment/packages.config
+++ b/CSharp/core-ReceiveAttachment/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/core-SendAttachment/packages.config
+++ b/CSharp/core-SendAttachment/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/core-State/packages.config
+++ b/CSharp/core-State/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/core-proactiveMessages/simpleSendMessage/packages.config
+++ b/CSharp/core-proactiveMessages/simpleSendMessage/packages.config
@@ -10,10 +10,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/core-proactiveMessages/startNewDialog/packages.config
+++ b/CSharp/core-proactiveMessages/startNewDialog/packages.config
@@ -10,10 +10,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/core-proactiveMessages/startNewDialogWithPrompt/packages.config
+++ b/CSharp/core-proactiveMessages/startNewDialogWithPrompt/packages.config
@@ -10,10 +10,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/demo-CardsAttachments/public-TestBot/packages.config
+++ b/CSharp/demo-CardsAttachments/public-TestBot/packages.config
@@ -12,10 +12,10 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/demo-ContosoFlowers/ContosoFlowers.BotAssets/packages.config
+++ b/CSharp/demo-ContosoFlowers/ContosoFlowers.BotAssets/packages.config
@@ -4,9 +4,9 @@
   <package id="Chronic.Signed" version="0.3.2" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Location" version="2.1.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Logging" version="1.1.4" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.4.403061554" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Protocols" version="2.1.4" targetFramework="net46" />

--- a/CSharp/demo-ContosoFlowers/ContosoFlowers/packages.config
+++ b/CSharp/demo-ContosoFlowers/ContosoFlowers/packages.config
@@ -15,11 +15,11 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Location" version="2.1.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/demo-RollerSkill/packages.config
+++ b/CSharp/demo-RollerSkill/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/demo-Search/JobListingBot/packages.config
+++ b/CSharp/demo-Search/JobListingBot/packages.config
@@ -10,10 +10,10 @@
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.Azure.Search" version="3.0.1" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/demo-Search/RealEstateBot/packages.config
+++ b/CSharp/demo-Search/RealEstateBot/packages.config
@@ -10,10 +10,10 @@
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.Azure.Search" version="3.0.1" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/demo-Search/Search.Dialogs/packages.config
+++ b/CSharp/demo-Search/Search.Dialogs/packages.config
@@ -4,8 +4,8 @@
   <package id="Chronic.Signed" version="0.3.2" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Logging" version="1.1.4" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.4.403061554" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Protocols" version="2.1.4" targetFramework="net46" />

--- a/CSharp/intelligence-ImageCaption/packages.config
+++ b/CSharp/intelligence-ImageCaption/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/intelligence-LUIS-Translator/packages.config
+++ b/CSharp/intelligence-LUIS-Translator/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net461" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/intelligence-LUIS/packages.config
+++ b/CSharp/intelligence-LUIS/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/intelligence-SimilarProducts/packages.config
+++ b/CSharp/intelligence-SimilarProducts/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/intelligence-SpeechToText/packages.config
+++ b/CSharp/intelligence-SpeechToText/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.CognitiveServices.Speech" version="1.2.0" targetFramework="net461" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />

--- a/CSharp/intelligence-Zummer/packages.config
+++ b/CSharp/intelligence-Zummer/packages.config
@@ -10,10 +10,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/sample-KnowledgeBot/AzureSearchBot/packages.config
+++ b/CSharp/sample-KnowledgeBot/AzureSearchBot/packages.config
@@ -9,10 +9,10 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/sample-payments/PaymentsBot/packages.config
+++ b/CSharp/sample-payments/PaymentsBot/packages.config
@@ -12,10 +12,10 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.12.2.4" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/CSharp/skype-CallingBot/packages.config
+++ b/CSharp/skype-CallingBot/packages.config
@@ -13,11 +13,11 @@
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.Bing.Speech" version="2.0.2" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.14.1.1" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Azure" version="3.2.5" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.Calling" version="3.14.1.1" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder.History" version="3.12.2.4" targetFramework="net46" />
-  <package id="Microsoft.Bot.Connector" version="3.14.1.1" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder.History" version="3.30.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Connector" version="3.30.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/Node/blog-customChannelData/app.js
+++ b/Node/blog-customChannelData/app.js
@@ -18,7 +18,7 @@ app.listen(port, function () {
 // Default store: volatile in-memory store - Only for prototyping!
 // We provide adapters for Azure Table, CosmosDb, SQL Azure, or you can implement your own!
 // For samples and documentation, see: https://github.com/Microsoft/BotBuilder-Azure
-var inMemoryStorage = new builder.MemoryBotStorage();
+var inMemoryStorage = new botbuilder.MemoryBotStorage();
 
 //create a chat connector for the bot
 var connector = new botbuilder.ChatConnector({

--- a/Node/blog-customChannelData/package.json
+++ b/Node/blog-customChannelData/package.json
@@ -4,7 +4,7 @@
   "description": "Microsoft Bot Framework bot written in NodeJS to test issues.",
   "main": "node_bot.js",
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^2.0.0",
     "express": "^4.14.1",
     "request-promise": "^4.1.1",
@@ -13,7 +13,7 @@
   "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node node_bot.js"
+    "start": "node app.js"
   },
   "repository": {
     "type": "git",

--- a/Node/capability-SimpleTaskAutomation/package.json
+++ b/Node/capability-SimpleTaskAutomation/package.json
@@ -4,12 +4,13 @@
   "description": "Bot Build Sample - Simple Task Automation",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node app.js"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "restify": "^4.3.0",
     "uuid": "^3.0.1"
   },

--- a/Node/capability-middlewareLogging/package.json
+++ b/Node/capability-middlewareLogging/package.json
@@ -9,7 +9,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^2.0.0",
     "restify": "^4.3.0"
   }

--- a/Node/cards-AdaptiveCards/package.json
+++ b/Node/cards-AdaptiveCards/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "bluebird": "^3.5.0",
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^2.0.0",
     "lodash": "^4.17.4",
     "restify": "^4.3.0"

--- a/Node/cards-CarouselCards/package.json
+++ b/Node/cards-CarouselCards/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
   },
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^1.0.4",
     "restify": "^4.3.0"
   }

--- a/Node/cards-RichCards/package.json
+++ b/Node/cards-RichCards/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
   },
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^1.0.4",
     "restify": "^4.3.0"
   }

--- a/Node/core-AppInsights/package.json
+++ b/Node/core-AppInsights/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "applicationinsights": "^1.0.1",
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^1.0.4",
     "restify": "^4.3.0"
   }

--- a/Node/core-ChannelData/package.json
+++ b/Node/core-ChannelData/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
   },
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^1.0.4",
     "restify": "^4.3.0"
   }

--- a/Node/core-CreateNewConversation/package.json
+++ b/Node/core-CreateNewConversation/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
   },
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^1.0.4",
     "restify": "^4.3.0"
   }

--- a/Node/core-CustomState/package.json
+++ b/Node/core-CustomState/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
   },
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "botbuilder-azure": "^3.0.4",
     "dotenv-extended": "^1.0.4",
     "restify": "^4.3.0"

--- a/Node/core-DirectLine/DirectLineBot/package.json
+++ b/Node/core-DirectLine/DirectLineBot/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
   },
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^1.0.4",
     "restify": "^4.3.0"
   }

--- a/Node/core-DirectLineWebSockets/DirectLineBot/package.json
+++ b/Node/core-DirectLineWebSockets/DirectLineBot/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
   },
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^1.0.4",
     "restify": "^4.3.0"
   }

--- a/Node/core-GetConversationMembers/package.json
+++ b/Node/core-GetConversationMembers/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.7",
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^1.0.4",
     "restify": "^4.3.0",
     "swagger-client": "^2.1.26"

--- a/Node/core-MultiDialogs/package.json
+++ b/Node/core-MultiDialogs/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.7",
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^1.0.4",
     "restify": "^4.3.0"
   }

--- a/Node/core-ProgressDialog/package.json
+++ b/Node/core-ProgressDialog/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
   },
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "restify": "^4.3.0"
   }
 }

--- a/Node/core-ReceiveAttachment/package.json
+++ b/Node/core-ReceiveAttachment/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.7",
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^1.0.4",
     "request": "^2.79.0",
     "request-promise": "^4.1.1",

--- a/Node/core-SendAttachment/package.json
+++ b/Node/core-SendAttachment/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.7",
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^1.0.4",
     "restify": "^4.3.0",
     "swagger-client": "^2.1.32"

--- a/Node/core-State/package.json
+++ b/Node/core-State/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
   },
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^1.0.4",
     "restify": "^4.3.0"
   }

--- a/Node/core-basicMultiDialog/package.json
+++ b/Node/core-basicMultiDialog/package.json
@@ -2,8 +2,11 @@
     "name": "core-basic-multidialog",
     "version": "1.0.0",
     "dependencies": {
-        "botbuilder": "^3.13.1",
+        "botbuilder": "^3.30.0",
         "dotenv-extended": "^2.0.0",
         "restify": "^4.3.0"
+    },
+    "scripts": {
+        "start": "node app.js"
     }
 }

--- a/Node/core-globalMessageHandlers/package.json
+++ b/Node/core-globalMessageHandlers/package.json
@@ -2,8 +2,11 @@
   "name": "core-globalmessagehandlers",
   "version": "1.0.0",
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^2.0.0",
     "restify": "^4.3.0"
+  },
+  "scripts": {
+    "start": "node app.js"
   }
 }

--- a/Node/core-proactiveMessages/simpleSendMessage/package.json
+++ b/Node/core-proactiveMessages/simpleSendMessage/package.json
@@ -4,7 +4,8 @@
   "description": "demonstrate proactive sending of a simple message",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
   },
   "repository": {
     "type": "git",
@@ -23,7 +24,7 @@
   },
   "homepage": "https://github.com/MicrosoftDX/botFramework-proactiveMessages#readme",
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "restify": "^4.3.0"
   }
 }

--- a/Node/core-proactiveMessages/startNewDialog/package.json
+++ b/Node/core-proactiveMessages/startNewDialog/package.json
@@ -4,7 +4,8 @@
   "description": "demonstrate proactive starting of a new dialog",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
   },
   "repository": {
     "type": "git",
@@ -23,7 +24,7 @@
   },
   "homepage": "https://github.com/MicrosoftDX/botFramework-proactiveMessages#readme",
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "restify": "^4.3.0"
   }
 }

--- a/Node/core-proactiveMessages/startNewDialogWithPrompt/package.json
+++ b/Node/core-proactiveMessages/startNewDialogWithPrompt/package.json
@@ -4,7 +4,8 @@
   "description": "demonstrate proactive starting of a new dialog",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
   },
   "repository": {
     "type": "git",
@@ -23,7 +24,7 @@
   },
   "homepage": "https://github.com/MicrosoftDX/botFramework-proactiveMessages#readme",
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "restify": "^4.3.0"
   }
 }

--- a/Node/demo-ContosoFlowers/package.json
+++ b/Node/demo-ContosoFlowers/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "bluebird": "^3.4.7",
     "body-parser": "^1.15.2",
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "botbuilder-location": "^2.0.0",
     "dotenv-extended": "^1.0.4",
     "express": "^4.14.0",

--- a/Node/demo-RollerSkill/package.json
+++ b/Node/demo-RollerSkill/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
   },
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^2.0.0",
     "restify": "^4.3.0"
   }

--- a/Node/demo-Search/SearchDialogLibrary/package.json
+++ b/Node/demo-Search/SearchDialogLibrary/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
   },
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "lodash": "^4.17.4"
   }
 }

--- a/Node/demo-Search/package.json
+++ b/Node/demo-Search/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.7",
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^1.0.4",
     "lodash": "^4.17.4",
     "lorem-ipsum": "^1.0.3",

--- a/Node/intelligence-ImageCaption/package.json
+++ b/Node/intelligence-ImageCaption/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
   },
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^1.0.4",
     "needle": "^1.4.3",
     "request": "^2.79.0",

--- a/Node/intelligence-LUIS/package.json
+++ b/Node/intelligence-LUIS/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.7",
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^1.0.4",
     "request": "^2.79.0",
     "restify": "^4.3.0"

--- a/Node/intelligence-SimilarProducts/package.json
+++ b/Node/intelligence-SimilarProducts/package.json
@@ -8,7 +8,7 @@
   "author": "Microsoft Corp.",
   "license": "MIT",
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^1.0.4",
     "request": "^2.79.0",
     "restify": "^4.3.0",

--- a/Node/intelligence-SpeechToText/package.json
+++ b/Node/intelligence-SpeechToText/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
   },
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^1.0.4",
     "needle": "^1.4.3",
     "node-uuid": "^1.4.7",

--- a/Node/intelligence-Zummer/package.json
+++ b/Node/intelligence-Zummer/package.json
@@ -7,7 +7,7 @@
   },
   "author": "mmoussa",
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^1.0.4",
     "memory-cache": "^0.1.6",
     "restify": "^4.3.0",

--- a/Node/sample-knowledgeBot/package.json
+++ b/Node/sample-knowledgeBot/package.json
@@ -4,12 +4,13 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node app.js"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^2.0.0",
     "request": "^2.78.0",
     "restify": "^4.2.0"

--- a/Node/sample-payments/package.json
+++ b/Node/sample-payments/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "base64url": "^2.0.0",
     "bluebird": "^3.5.0",
-    "botbuilder": "^3.13.1",
+    "botbuilder": "^3.30.0",
     "dotenv-extended": "^1.0.4",
     "lodash": "^4.17.4",
     "restify": "^4.3.0",


### PR DESCRIPTION
Fixes #2277 

## Proposed Changes

**Node**

Update `package.json` of all of the JS v3 samples to use v3.30.0.

Also added some start scripts where they were missing so users can call `npm start`.

**C#**
Updated v3 sample packages to v3.30.0.

## Testing
Tested basic functionality of ~90% of the JS samples and they work fine.
Tested basic functionality of a few C# samples and some have major issues, not related to the update. After this PR is merged, I'll test all of every sample and create issues for each broken sample.