### PR TITLE
requirements.txt files missing botbuilder.dialogs

### DIFF
--- a/samples/python/18.bot-authentication/requirements.txt
+++ b/samples/python/18.bot-authentication/requirements.txt
@@ -1,1 +1,2 @@
 botbuilder-integration-aiohttp>=4.8.0
+botbuilder-dialogs>=4.8.0

--- a/samples/python/19.custom-dialogs/requirements.txt
+++ b/samples/python/19.custom-dialogs/requirements.txt
@@ -1,1 +1,2 @@
 botbuilder-integration-aiohttp>=4.8.0
+botbuilder-dialogs>=4.8.0

--- a/samples/python/24.bot-authentication-msgraph/requirements.txt
+++ b/samples/python/24.bot-authentication-msgraph/requirements.txt
@@ -1,3 +1,4 @@
 botbuilder-integration-aiohttp>=4.8.0
+botbuilder-dialogs>=4.8.0
 requests_oauthlib
 

--- a/samples/python/42.scaleout/requirements.txt
+++ b/samples/python/42.scaleout/requirements.txt
@@ -1,3 +1,4 @@
 jsonpickle
 botbuilder-integration-aiohttp>=4.8.0
+botbuilder-dialogs>=4.8.0
 azure>=4.0.0

--- a/samples/python/46.teams-auth/requirements.txt
+++ b/samples/python/46.teams-auth/requirements.txt
@@ -1,1 +1,2 @@
 botbuilder-integration-aiohttp>=4.8.0
+botbuilder-dialogs>=4.8.0


### PR DESCRIPTION
Fixes #2298

## Proposed Changes
Added botbuilder.dialogs>=4.8.0 to the following samples:
  - 18.bot-authentication
  - 19.custom-dialogs
  - 24.bot-authetication-msgraph
  - 42.scaleout
  - 46.teams-auth

## Testing
None.