### PR TITLE
Changed SkillEndpoint to 39783 in .env to match port bot's running on

### DIFF
--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/.env
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/.env
@@ -4,4 +4,4 @@ SkillHostEndpoint=http://localhost:3978/api/skills/
 
 SkillId=DialogSkillBot
 SkillAppId=
-SkillEndpoint=http://localhost:3979/api/messages
+SkillEndpoint=http://localhost:39783/api/messages


### PR DESCRIPTION
Fixes #2369

## Proposed Changes
Changes mismatched .env SkillEndpoint value to 39783, which is the port that the skill actually runs on. This aligns with what is in C# as well.