### PR TITLE
Load .env variables earlier than bots in 02.echo-bot and 13.core

### DIFF
--- a/samples/javascript_nodejs/02.echo-bot/index.js
+++ b/samples/javascript_nodejs/02.echo-bot/index.js
@@ -1,8 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-const dotenv = require('dotenv');
 const path = require('path');
+
+const dotenv = require('dotenv');
+// Import required bot configuration.
+const ENV_FILE = path.join(__dirname, '.env');
+dotenv.config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -12,9 +17,6 @@ const { BotFrameworkAdapter } = require('botbuilder');
 // This bot's main dialog.
 const { EchoBot } = require('./bot');
 
-// Import required bot configuration.
-const ENV_FILE = path.join(__dirname, '.env');
-dotenv.config({ path: ENV_FILE });
 
 // Create HTTP server
 const server = restify.createServer();

--- a/samples/javascript_nodejs/13.core-bot/index.js
+++ b/samples/javascript_nodejs/13.core-bot/index.js
@@ -5,6 +5,11 @@
 
 // Import required packages
 const path = require('path');
+
+// Note: Ensure you have a .env file and include LuisAppId, LuisAPIKey and LuisAPIHostName.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -21,9 +26,6 @@ const { MainDialog } = require('./dialogs/mainDialog');
 const { BookingDialog } = require('./dialogs/bookingDialog');
 const BOOKING_DIALOG = 'bookingDialog';
 
-// Note: Ensure you have a .env file and include LuisAppId, LuisAPIKey and LuisAPIHostName.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.

--- a/samples/typescript_nodejs/02.echo-bot/src/index.ts
+++ b/samples/typescript_nodejs/02.echo-bot/src/index.ts
@@ -1,8 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { config } from 'dotenv';
 import * as path from 'path';
+
+import { config } from 'dotenv';
+const ENV_FILE = path.join(__dirname, '..', '.env');
+config({ path: ENV_FILE });
+
 import * as restify from 'restify';
 
 // Import required bot services.
@@ -12,8 +16,6 @@ import { BotFrameworkAdapter } from 'botbuilder';
 // This bot's main dialog.
 import { EchoBot } from './bot';
 
-const ENV_FILE = path.join(__dirname, '..', '.env');
-config({ path: ENV_FILE });
 
 // Create HTTP server.
 const server = restify.createServer();

--- a/samples/typescript_nodejs/13.core-bot/src/index.ts
+++ b/samples/typescript_nodejs/13.core-bot/src/index.ts
@@ -1,8 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { config } from 'dotenv';
 import * as path from 'path';
+
+import { config } from 'dotenv';
+// Note: Ensure you have a .env file and include LuisAppId, LuisAPIKey and LuisAPIHostName.
+const ENV_FILE = path.join(__dirname, '..', '.env');
+config({ path: ENV_FILE });
+
 import * as restify from 'restify';
 
 // Import required bot services.
@@ -21,9 +26,6 @@ const BOOKING_DIALOG = 'bookingDialog';
 // The helper-class recognizer that calls LUIS
 import { FlightBookingRecognizer } from './dialogs/flightBookingRecognizer';
 
-// Note: Ensure you have a .env file and include LuisAppId, LuisAPIKey and LuisAPIHostName.
-const ENV_FILE = path.join(__dirname, '..', '.env');
-config({ path: ENV_FILE });
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.


### PR DESCRIPTION
Fixes #2404 

## Proposed Changes
In `index` files, load .env variables before loading the bot, to ensure that all the values are available when you'd expect them to be.