### PR TITLE
Linted & updated dependencies for echo and core bots

### DIFF
--- a/samples/javascript_nodejs/02.echo-bot/.eslintrc.js
+++ b/samples/javascript_nodejs/02.echo-bot/.eslintrc.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 module.exports = {
     "extends": "standard",
     "rules": {    

--- a/samples/javascript_nodejs/02.echo-bot/README.md
+++ b/samples/javascript_nodejs/02.echo-bot/README.md
@@ -43,7 +43,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 [Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
 
-- Install the Bot Framework Emulator version 4.3.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
+- Install the Bot Framework Emulator version 4.9.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
 
 ### Connect to the bot using Bot Framework Emulator
 

--- a/samples/javascript_nodejs/02.echo-bot/index.js
+++ b/samples/javascript_nodejs/02.echo-bot/index.js
@@ -17,7 +17,6 @@ const { BotFrameworkAdapter } = require('botbuilder');
 // This bot's main dialog.
 const { EchoBot } = require('./bot');
 
-
 // Create HTTP server
 const server = restify.createServer();
 server.listen(process.env.port || process.env.PORT || 3978, () => {

--- a/samples/javascript_nodejs/02.echo-bot/package.json
+++ b/samples/javascript_nodejs/02.echo-bot/package.json
@@ -18,15 +18,15 @@
     "dependencies": {
         "botbuilder": "~4.9.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.4.0"
+        "restify": "~8.5.1"
     },
     "devDependencies": {
-        "eslint": "^6.6.0",
-        "eslint-config-standard": "^14.1.0",
-        "eslint-plugin-import": "^2.18.2",
-        "eslint-plugin-node": "^10.0.0",
+        "eslint": "^7.0.0",
+        "eslint-config-standard": "^14.1.1",
+        "eslint-plugin-import": "^2.20.2",
+        "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^4.2.1",
         "eslint-plugin-standard": "^4.0.1",
-        "nodemon": "~1.19.4"
+        "nodemon": "~2.0.4"
     }
 }

--- a/samples/javascript_nodejs/13.core-bot/.eslintrc.js
+++ b/samples/javascript_nodejs/13.core-bot/.eslintrc.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 module.exports = {
     "extends": "standard",
     "rules": {    

--- a/samples/javascript_nodejs/13.core-bot/README.md
+++ b/samples/javascript_nodejs/13.core-bot/README.md
@@ -70,7 +70,7 @@ LuisAPIHostName = "Your LUIS App region here (i.e: westus.api.cognitive.microsof
 
 [Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
 
-- Install the Bot Framework Emulator version 4.3.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
+- Install the Bot Framework Emulator version 4.9.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
 
 ### Connect to the bot using Bot Framework Emulator
 

--- a/samples/javascript_nodejs/13.core-bot/index.js
+++ b/samples/javascript_nodejs/13.core-bot/index.js
@@ -26,7 +26,6 @@ const { MainDialog } = require('./dialogs/mainDialog');
 const { BookingDialog } = require('./dialogs/bookingDialog');
 const BOOKING_DIALOG = 'bookingDialog';
 
-
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.
 const adapter = new BotFrameworkAdapter({

--- a/samples/javascript_nodejs/13.core-bot/package.json
+++ b/samples/javascript_nodejs/13.core-bot/package.json
@@ -16,23 +16,23 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "@microsoft/recognizers-text-data-types-timex-expression": "~1.3.0",
+        "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
         "botbuilder": "~4.9.0",
         "botbuilder-ai": "~4.9.0",
         "botbuilder-dialogs": "~4.9.0",
         "botbuilder-testing": "~4.9.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.4.0"
+        "restify": "~8.5.1"
     },
     "devDependencies": {
-        "eslint": "^6.6.0",
-        "eslint-config-standard": "^14.1.0",
-        "eslint-plugin-import": "^2.18.2",
-        "eslint-plugin-node": "^10.0.0",
+        "eslint": "^7.0.0",
+        "eslint-config-standard": "^14.1.1",
+        "eslint-plugin-import": "^2.20.2",
+        "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^4.2.1",
         "eslint-plugin-standard": "^4.0.1",
-        "mocha": "^6.2.2",
-        "nodemon": "~1.19.4",
-        "nyc": "^14.1.1"
+        "mocha": "^7.1.2",
+        "nodemon": "~2.0.4",
+        "nyc": "^15.0.1"
     }
 }

--- a/samples/typescript_nodejs/00.empty-bot/package.json
+++ b/samples/typescript_nodejs/00.empty-bot/package.json
@@ -18,14 +18,14 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.8.0",
+        "botbuilder": "~4.9.0",
         "replace": "~1.1.1",
-        "restify": "~8.4.0"
+        "restify": "~8.5.1"
     },
     "devDependencies": {
-        "@types/restify": "8.4.1",
-        "nodemon": "~1.19.4",
-        "tslint": "~5.20.0",
-        "typescript": "~3.6.4"
+        "@types/restify": "8.4.2",
+        "nodemon": "~2.0.4",
+        "tslint": "~6.1.2",
+        "typescript": "~3.9.2"
     }
 }

--- a/samples/typescript_nodejs/02.echo-bot/package.json
+++ b/samples/typescript_nodejs/02.echo-bot/package.json
@@ -18,16 +18,16 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.8.0",
+        "botbuilder": "~4.9.0",
         "dotenv": "^8.2.0",
         "replace": "~1.1.1",
-        "restify": "~8.4.0"
+        "restify": "~8.5.1"
     },
     "devDependencies": {
         "@types/dotenv": "6.1.1",
-        "@types/restify": "8.4.1",
-        "nodemon": "~1.19.4",
-        "tslint": "~5.20.0",
-        "typescript": "~3.6.4"
+        "@types/restify": "8.4.2",
+        "nodemon": "~2.0.4",
+        "tslint": "~6.1.2",
+        "typescript": "~3.9.2"
     }
 }

--- a/samples/typescript_nodejs/02.echo-bot/src/index.ts
+++ b/samples/typescript_nodejs/02.echo-bot/src/index.ts
@@ -16,7 +16,6 @@ import { BotFrameworkAdapter } from 'botbuilder';
 // This bot's main dialog.
 import { EchoBot } from './bot';
 
-
 // Create HTTP server.
 const server = restify.createServer();
 server.listen(process.env.port || process.env.PORT || 3978, () => {

--- a/samples/typescript_nodejs/13.core-bot/.eslintrc.js
+++ b/samples/typescript_nodejs/13.core-bot/.eslintrc.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 module.exports = {
     "extends": "standard",
     "rules": {    

--- a/samples/typescript_nodejs/13.core-bot/README.md
+++ b/samples/typescript_nodejs/13.core-bot/README.md
@@ -75,7 +75,7 @@ LuisAPIHostName = "Your LUIS App region here (i.e: westus.api.cognitive.microsof
 
 [Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
 
-- Install the Bot Framework Emulator version 4.3.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
+- Install the Bot Framework Emulator version 4.9.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
 
 ### Connect to the bot using Bot Framework Emulator
 

--- a/samples/typescript_nodejs/13.core-bot/package.json
+++ b/samples/typescript_nodejs/13.core-bot/package.json
@@ -13,6 +13,10 @@
         "test": "tsc --build && nyc mocha lib/tests/**/*.test.js",
         "watch": "nodemon --watch ./src -e ts --exec \"npm run start\""
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
+    },
     "nyc": {
         "extension": [
             ".ts",
@@ -34,23 +38,23 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.8.0",
-        "botbuilder-ai": "~4.8.0",
-        "botbuilder-dialogs": "~4.8.0",
-        "botbuilder-testing": "~4.8.0",
+        "botbuilder": "~4.9.0",
+        "botbuilder-ai": "~4.9.0",
+        "botbuilder-dialogs": "~4.9.0",
+        "botbuilder-testing": "~4.9.0",
         "dotenv": "^8.2.0",
-        "replace": "~1.1.1",
-        "restify": "~8.4.0"
+        "replace": "~1.2.0",
+        "restify": "~8.5.1"
     },
     "devDependencies": {
         "@types/dotenv": "6.1.1",
-        "@types/mocha": "^5.2.7",
-        "@types/restify": "8.4.1",
-        "mocha": "^6.2.2",
-        "nodemon": "~1.19.4",
-        "nyc": "^14.1.1",
-        "ts-node": "^8.4.1",
-        "tslint": "~5.20.0",
-        "typescript": "~3.6.4"
+        "@types/mocha": "^7.0.2",
+        "@types/restify": "8.4.2",
+        "mocha": "^7.1.2",
+        "nodemon": "~2.0.4",
+        "nyc": "^15.0.1",
+        "ts-node": "^8.10.1",
+        "tslint": "~6.1.2",
+        "typescript": "~3.9.2"
     }
 }

--- a/samples/typescript_nodejs/13.core-bot/src/bots/dialogBot.ts
+++ b/samples/typescript_nodejs/13.core-bot/src/bots/dialogBot.ts
@@ -48,7 +48,7 @@ export class DialogBot extends ActivityHandler {
     /**
      * Override the ActivityHandler.run() method to save state changes after the bot logic completes.
      */
-    async run(context): Promise<void> {
+    public async run(context): Promise<void> {
         await super.run(context);
 
         // Save any state changes. The load happened during the execution of the Dialog.

--- a/samples/typescript_nodejs/13.core-bot/src/index.ts
+++ b/samples/typescript_nodejs/13.core-bot/src/index.ts
@@ -26,7 +26,6 @@ const BOOKING_DIALOG = 'bookingDialog';
 // The helper-class recognizer that calls LUIS
 import { FlightBookingRecognizer } from './dialogs/flightBookingRecognizer';
 
-
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.
 const adapter = new BotFrameworkAdapter({


### PR DESCRIPTION
Fixes #2407

### Proposed Changes
Ultimately want yeoman templates and the bots in samples to make the same bot without discrepancies between the two.

*The following changes applied to both JS and TS versions of `02.echo-bot` and `13.core-bot` samples. These are the same changes done in yeoman generators [PR#2410](https://github.com/microsoft/BotBuilder-Samples/pull/2410)*:

> updates all samples to use 4.9.0 of Bot Framework SDK
updates all other nom dependencies to latest versions
updates typescript generated to to use TS 3.9.2
fix lint errors
update readme's to recommend emulator 4.9

#### Additional differences from generators vs. "general" echo and core bot samples that still exists
- For TS's core-bot, also made `run` method `public` as it needs its accessibility level explicitly declared
   - This change is not applied to generators, as core-bot in generators doesn't use `run` method
   - See comment for more details
- General node samples there's no JS empty bot sample (only in TS)