### PR TITLE
change getAskFor => getxxxPromptText

### DIFF
--- a/experimental/generation/generator/templates/booleanEntity.en-us.lg.lg
+++ b/experimental/generation/generator/templates/booleanEntity.en-us.lg.lg
@@ -5,7 +5,7 @@
 
 # template
 - ```
-${'#'} booleanEntity_getEntityValueText(value)
+${'#'} booleanEntity_getValueText(value)
 - SWITCH: \${value}
 - CASE: \${'true'}
     - true  

--- a/experimental/generation/generator/templates/booleanProperty.lg.lg
+++ b/experimental/generation/generator/templates/booleanProperty.lg.lg
@@ -17,6 +17,6 @@ ${valueTemplate()}
 - ```
 > Template for prompting the user for the '${property}' property.
 ${'#'} ${property}_getPromptText
-- \${getAskForBooleanText('${property}')}
+- \${getBooleanPromptText('${property}')}
 ```
 

--- a/experimental/generation/generator/templates/enumArrayEntity.lg.lg
+++ b/experimental/generation/generator/templates/enumArrayEntity.lg.lg
@@ -23,7 +23,7 @@ ${'#'} ${property}Entity_getChooseEntityText
 
 # namePlusSwitch
 -```
-${'#'} ${property}Entity_getEntityValueText(value) 
+${'#'} ${property}Entity_getValueText(value) 
 - SWITCH: \${value}```
 
 # case(option)

--- a/experimental/generation/generator/templates/enumArrayProperty.lg.lg
+++ b/experimental/generation/generator/templates/enumArrayProperty.lg.lg
@@ -17,7 +17,7 @@ ${ValueTemplate()}
 - ```
 > Template for prompting the user for the '${property}' property.
 ${'#'} ${property}_getPromptText
-- \${getAskForEnumArrayText('${property}')}```
+- \${getEnumArrayPromptText('${property}')}```
 
 # ValueTemplate
 - ```

--- a/experimental/generation/generator/templates/enumArrayProperty.lg.lg
+++ b/experimental/generation/generator/templates/enumArrayProperty.lg.lg
@@ -22,6 +22,6 @@ ${'#'} ${property}_getPromptText
 # ValueTemplate
 - ```
 > Template for generating display text for the value of the '${property}' property.
-${'#'} ${property}_getPropertyValueText(values)
+${'#'} ${property}_getValueText(values)
 - \${getEnumArrayValueText('${property}', values)}```
 

--- a/experimental/generation/generator/templates/enumEntity.en-us.lg.lg
+++ b/experimental/generation/generator/templates/enumEntity.en-us.lg.lg
@@ -22,7 +22,7 @@ ${'#'} ${property}Entity_getChooseEntityText
 
 # namePlusSwitch
 -```
-${'#'} ${property}Entity_getEntityValueText(value) 
+${'#'} ${property}Entity_getValueText(value) 
 - SWITCH: \${value}```
 
 # case(option)

--- a/experimental/generation/generator/templates/enumProperty.lg.lg
+++ b/experimental/generation/generator/templates/enumProperty.lg.lg
@@ -23,7 +23,7 @@ ${'#'} ${property}_getPromptText
 # ValueTemplate
 - ```
 > Template for generating display text for the value of the '${property}' property.
-${'#'} ${property}_getPropertyValueText(val)
+${'#'} ${property}_getValueText(val)
 - \${getValueText(val)}
 ```
 

--- a/experimental/generation/generator/templates/generator.lg
+++ b/experimental/generation/generator/templates/generator.lg
@@ -55,7 +55,7 @@ ${'#'} ${property}_getPropertyNameText
 # valueTemplate
 -```
 > Template for generating display text for the value of the '${property}' property.
-${'#'} ${property}_getPropertyValueText(val)
+${'#'} ${property}_getValueText(val)
  - IF: \${val}
  - \${val}
  - ELSE:
@@ -65,7 +65,7 @@ ${'#'} ${property}_getPropertyValueText(val)
 # entityDisplay
 -```
 > Template for generating display text for the value of the '${property}Entity' entity.
-${'#'} ${property}Entity_getEntityValueText(val)
+${'#'} ${property}Entity_getValueText(val)
  - IF: \${val}
  - \${val}
  - ELSE:

--- a/experimental/generation/generator/templates/integerProperty.lg.lg
+++ b/experimental/generation/generator/templates/integerProperty.lg.lg
@@ -17,7 +17,7 @@ ${valueTemplate()}
 - ```
 > Template for prompting the user for the '${property}' property.
 ${'#'} ${property}_getPromptText
-- \${getAskForNumberText('${property}')}
+- \${getIntegerPromptText('${property}')}
 ```
 
 

--- a/experimental/generation/generator/templates/library-Missing.en-us.lg
+++ b/experimental/generation/generator/templates/library-Missing.en-us.lg
@@ -48,4 +48,4 @@ Enter a value for ${getPropertyNameText(property)}: true or false
 - ${if(values, if(isArray(values), join(values, ', '), values), 'no value')}
 
 # getEnumArrayValueText(property, values)
-- ${if(isArray(values), join(foreach(values, value, template(`${property}_getPropertyValueText`, value)), ', '), template(`${property}_getPropertyValueText`, values))}
+- ${if(isArray(values), join(foreach(values, value, template(`${property}_getValueText`, value)), ', '), template(`${property}_getValueText`, values))}

--- a/experimental/generation/generator/templates/library-Missing.en-us.lg
+++ b/experimental/generation/generator/templates/library-Missing.en-us.lg
@@ -7,13 +7,16 @@ ${getAskForHelpText()}
 Which value do you want for ${getPropertyNameText(property)}?
 ```
 
-# getAskForEnumArrayText(property)
+# getEnumArrayPromptText(property)
 - ```
 ${getAskForHelpText()}
 What values do you want to add for ${getPropertyNameText(property)}?
 ```
 
-# getAskForNumberText(property)
+# getIntegerPromptText(property)
+- ${getNumberPromptText(property)}
+
+# getNumberPromptText(property)
 - IF: ${dialogClass.schema.properties[property].minimum && dialogClass.schema.properties[property].maximum}
 - Enter a number for ${getPropertyNameText(property)} between ${dialogClass.schema.properties[property].minimum} and ${dialogClass.schema.properties[property].maximum}
 - ELSEIF:  ${dialogClass.schema.properties[property].minimum}
@@ -23,19 +26,19 @@ What values do you want to add for ${getPropertyNameText(property)}?
 - ELSE:
 - Enter a number for ${getPropertyNameText(property)}
 
-# getAskForStringText(property)
+# getStringPromptText(property)
 - ```
 ${getAskForHelpText()}
 Enter a value for ${getPropertyNameText(property)}
 ```
 
-# getAskForStringArray(property)
+# getStringArrayPromptText(property)
 -```
 ${getAskForHelpText()}
 What values do you want to add for ${getPropertyNameText(property)}?
 ```
 
-# getAskForBooleanText(property)
+# getBooleanPromptText(property)
 - ```
 ${getAskForHelpText()}
 Enter a value for ${getPropertyNameText(property)}: true or false

--- a/experimental/generation/generator/templates/library-PROPERTYName.en-us.lg.lg
+++ b/experimental/generation/generator/templates/library-PROPERTYName.en-us.lg.lg
@@ -8,7 +8,7 @@
 
 # namePlusSwitch
 -```
-${'#'} PROPERTYName_getPropertyValueText(value) 
+${'#'} PROPERTYName_getValueText(value) 
 - SWITCH: \${value}```
 
 # case(option)

--- a/experimental/generation/generator/templates/library.en-us.lg
+++ b/experimental/generation/generator/templates/library.en-us.lg
@@ -12,10 +12,10 @@
 - ${template(`${property}_getPropertyNameText`)}
 
 # getPropertyValueText(property, val)
-- ${template(`${property}_getPropertyValueText`, val)}
+- ${template(`${property}_getValueText`, val)}
 
 # getEntityValueText(property, val)
-- ${template(`${property}Entity_getEntityValueText`, val)}
+- ${template(`${property}Entity_getValueText`, val)}
 
 > Display a value handling arrays and objects
 # getValueText(val)

--- a/experimental/generation/generator/templates/library.en-us.lg
+++ b/experimental/generation/generator/templates/library.en-us.lg
@@ -9,7 +9,7 @@
 - Welcome!
 
 # getPropertyNameText(property)
-- ${template(`${property}_getPropertyName`)}
+- ${template(`${property}_getPropertyNameText`)}
 
 # getPropertyValueText(property, val)
 - ${template(`${property}_getPropertyValueText`, val)}
@@ -70,5 +70,5 @@
 # isMissingProperty(propertyName)
 - !dialog[propertyName] || $PropertyToChange == `${propertyName}`
 
-# isExpectingProperty(propertyName)
+# isRequiredProperty(propertyName)
 - =indexOf(dialog.getRequiredPropertiesTextText, propertyName)

--- a/experimental/generation/generator/templates/numberProperty.lg.lg
+++ b/experimental/generation/generator/templates/numberProperty.lg.lg
@@ -17,7 +17,7 @@ ${valueTemplate()}
 - ```
 > Template for prompting the user for the '${property}' property.
 ${'#'} ${property}_getPromptText
-- \${getAskForNumberText('${property}')}
+- \${getNumberPromptText('${property}')}
 ```
 
 

--- a/experimental/generation/generator/templates/objectProperty.lg.lg
+++ b/experimental/generation/generator/templates/objectProperty.lg.lg
@@ -22,6 +22,6 @@ ${'#'} ${property}_getPromptText
 # ValueTemplate
 -```
 > Template for generating display text for the value of the '${property}' property.
-${'#'} ${property}_getPropertyValueText(val)
+${'#'} ${property}_getValueText(val)
 - \${getValueText(val)}
 ```

--- a/experimental/generation/generator/templates/objectProperty.lg.lg
+++ b/experimental/generation/generator/templates/objectProperty.lg.lg
@@ -16,7 +16,7 @@ ${ValueTemplate()}
 - ```
 > Template for prompting the user for the '${property}' property.
 ${'#'} ${property}_getPromptText
-- \${getAskForStringText('${property}')}
+- \${getStringPromptText('${property}')}
 ```
 
 # ValueTemplate

--- a/experimental/generation/generator/templates/stringArrayEntity.lg.lg
+++ b/experimental/generation/generator/templates/stringArrayEntity.lg.lg
@@ -23,7 +23,7 @@ ${'#'} ${property}Entity_Choose
 
 # namePlusSwitch
 -```
-${'#'} ${property}Entity_getEntityValueText(value) 
+${'#'} ${property}Entity_getValueText(value) 
 - SWITCH: \${value}```
 
 # case(option)

--- a/experimental/generation/generator/templates/stringArrayProperty.lg.lg
+++ b/experimental/generation/generator/templates/stringArrayProperty.lg.lg
@@ -17,7 +17,7 @@ ${ValueTemplate()}
 - ```
 > Template for prompting the user for the '${property}' property.
 ${'#'} ${property}_getPromptText
-- \${getAskForStringArray('${property}')}```
+- \${getStringArrayPromptText('${property}')}```
 
 # ValueTemplate
 - ```

--- a/experimental/generation/generator/templates/stringProperty.lg.lg
+++ b/experimental/generation/generator/templates/stringProperty.lg.lg
@@ -17,7 +17,7 @@ ${valueTemplate()}
 - ```
 > Template for prompting the user for the '${property}' property.
 ${'#'} ${property}_getPromptText
-- \${getAskForStringText('${property}')}
+- \${getStringPromptText('${property}')}
 ```
 
 


### PR DESCRIPTION
getAskFor didn't really follow the pattern

instead of getAskForNumberText() it's now getNumberPromptText()
get{TYPE}PromptText pattern
* getAskForStringText() => getStringPromptText()
* getAskForEnumArrayText() => getEnumArrayPromptText()
* etc.

also, _getPropertyValueText and _getEntityValueText is redundent with the prefix
* xxx_getPropertyValueText() => xxx_getValueText()
* xxxEntity_getEntityValueText() => xxxEntity_getValueText()
