### PR TITLE
fix bug in preexisting-rg templates

### DIFF
--- a/MigrationV3V4/Node/Skills/v4-root-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/MigrationV3V4/Node/Skills/v4-root-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/MigrationV3V4/Node/core-MultiDialogs-v4/deploymentTemplates/template-with-preexisting-rg.json
+++ b/MigrationV3V4/Node/core-MultiDialogs-v4/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/experimental/adapter-oauth/deploymentTemplates/template-with-preexisting-rg.json
+++ b/experimental/adapter-oauth/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/experimental/adaptive-dialog/javascript_nodejs/08.todo-bot-with-luis-qnamaker/deploymentTemplates/template-with-preexisting-rg.json
+++ b/experimental/adaptive-dialog/javascript_nodejs/08.todo-bot-with-luis-qnamaker/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/experimental/adaptive-dialog/javascript_nodejs/09.integrating-composer-dialogs/dialogs/ComposerDialogs/main-without-luis/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/experimental/adaptive-dialog/javascript_nodejs/09.integrating-composer-dialogs/dialogs/ComposerDialogs/main-without-luis/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -164,12 +164,12 @@
       "location": "[variables('resourcesLocation')]",
       "kind": "app",
       "dependsOn": [
-        "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+        "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
       ],
       "name": "[variables('webAppName')]",
       "properties": {
         "name": "[variables('webAppName')]",
-        "serverFarmId": "[variables('servicePlanName')]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
         "siteConfig": {
           "appSettings": [
             {

--- a/experimental/directline-app-service-extension/csharp_dotnetcore/02.echo-bot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/experimental/directline-app-service-extension/csharp_dotnetcore/02.echo-bot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/experimental/directline-app-service-extension/csharp_dotnetcore/13.core-bot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/experimental/directline-app-service-extension/csharp_dotnetcore/13.core-bot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/experimental/directline-speech/javascript_nodejs/02.echo-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/experimental/directline-speech/javascript_nodejs/02.echo-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/experimental/sso-with-skills/RootBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/experimental/sso-with-skills/RootBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -104,7 +104,7 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {

--- a/experimental/sso-with-skills/SkillBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/experimental/sso-with-skills/SkillBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -104,7 +104,7 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/generators/generator-botbuilder/generators/app/templates/core/deploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/generator-botbuilder/generators/app/templates/core/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/generators/generator-botbuilder/generators/app/templates/echo/deploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/generator-botbuilder/generators/app/templates/echo/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/generators/generator-botbuilder/generators/app/templates/empty/deploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/generator-botbuilder/generators/app/templates/empty/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/generators/python/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/python/app/templates/core/{{cookiecutter.bot_name}}/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/generators/python/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/python/app/templates/echo/{{cookiecutter.bot_name}}/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/generators/python/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/python/app/templates/empty/{{cookiecutter.bot_name}}/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot-Core21/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot-Core21/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests-Core21/CoreBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests-Core21/CoreBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot-Core21/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot-Core21/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot-Core21/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot-Core21/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/02.echo-bot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/02.echo-bot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/03.welcome-user/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/03.welcome-user/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/06.using-cards/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/06.using-cards/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/08.suggested-actions/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/08.suggested-actions/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/11.qnamaker/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/11.qnamaker/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/13.core-bot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/13.core-bot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/14.nlp-with-dispatch/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/14.nlp-with-dispatch/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/15.handling-attachments/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/15.handling-attachments/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/16.proactive-messages/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/16.proactive-messages/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/17.multilingual-bot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/18.bot-authentication/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/18.bot-authentication/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/19.custom-dialogs/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/21.corebot-app-insights/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/21.corebot-app-insights/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/23.facebook-events/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/23.facebook-events/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/25.message-reaction/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/25.message-reaction/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/46.teams-auth/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/46.teams-auth/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/47.inspection/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/47.inspection/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/48.qnamaker-active-learning-bot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/48.qnamaker-active-learning-bot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/55.teams-link-unfurling/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/55.teams-link-unfurling/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/60.slack-adapter/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/60.slack-adapter/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/61.facebook-adapter/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/61.facebook-adapter/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/62.webex-adapter/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/62.webex-adapter/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/63.twilio-adapter/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/63.twilio-adapter/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/70.qnamaker-multiturn-sample/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/70.qnamaker-multiturn-sample/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -104,7 +104,7 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -104,7 +104,7 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -104,7 +104,7 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -104,7 +104,7 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {

--- a/samples/csharp_dotnetcore/adaptive-dialog/09.integrating-composer-dialogs/Dialogs/ComposerDialogs/main-without-luis/scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/adaptive-dialog/09.integrating-composer-dialogs/Dialogs/ComposerDialogs/main-without-luis/scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -164,12 +164,12 @@
       "location": "[variables('resourcesLocation')]",
       "kind": "app",
       "dependsOn": [
-        "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+        "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
       ],
       "name": "[variables('webAppName')]",
       "properties": {
         "name": "[variables('webAppName')]",
-        "serverFarmId": "[variables('servicePlanName')]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
         "siteConfig": {
           "appSettings": [
             {

--- a/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/language-generation/05.multi-turn-prompt/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/language-generation/05.multi-turn-prompt/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/language-generation/06.using-cards/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/language-generation/06.using-cards/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/language-generation/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/language-generation/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/csharp_dotnetcore/language-generation/20.extending-with-custom-functions/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/language-generation/20.extending-with-custom-functions/DeploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/06.using-cards/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/06.using-cards/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/11.qnamaker/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/11.qnamaker/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/14.nlp-with-dispatch/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/14.nlp-with-dispatch/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/25.message-reaction/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/25.message-reaction/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/46.teams-auth/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/46.teams-auth/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/47.inspection/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/47.inspection/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/48.qnamaker-active-learning-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/48.qnamaker-active-learning-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/49.qnamaker-all-features/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/49.qnamaker-all-features/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/50.teams-messaging-extensions-search/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/50.teams-messaging-extensions-search/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/51.teams-messaging-extensions-action/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/51.teams-messaging-extensions-action/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/54.teams-task-module/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/54.teams-task-module/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/55.teams-link-unfurling/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/55.teams-link-unfurling/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/56.teams-file-upload/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/56.teams-file-upload/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/57.teams-conversation-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/57.teams-conversation-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/70.qnamaker-multiturn-sample/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/70.qnamaker-multiturn-sample/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/language-generation/06.using-cards/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/language-generation/06.using-cards/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/language-generation/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/language-generation/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/javascript_nodejs/language-generation/20.custom-functions/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/language-generation/20.custom-functions/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/python/02.echo-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/02.echo-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/03.welcome-user/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/03.welcome-user/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/05.multi-turn-prompt/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/05.multi-turn-prompt/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/06.using-cards/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/06.using-cards/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/07.using-adaptive-cards/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/07.using-adaptive-cards/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/08.suggested-actions/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/08.suggested-actions/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/11.qnamaker/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/11.qnamaker/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/14.nlp-with-dispatch/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/14.nlp-with-dispatch/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/15.handling-attachments/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/15.handling-attachments/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/16.proactive-messages/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/16.proactive-messages/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/17.multilingual-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/17.multilingual-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/18.bot-authentication/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/18.bot-authentication/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/19.custom-dialogs/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/19.custom-dialogs/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/21.corebot-app-insights/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/21.corebot-app-insights/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/23.facebook-events/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/23.facebook-events/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/24.bot-authentication-msgraph/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/24.bot-authentication-msgraph/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/42.scaleout/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/42.scaleout/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/43.complex-dialog/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/43.complex-dialog/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/44.prompt-for-user-input/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/44.prompt-for-user-input/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/45.state-management/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/45.state-management/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/46.teams-auth/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/46.teams-auth/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/47.inspection/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/47.inspection/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/49.qnamaker-all-features/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/49.qnamaker-all-features/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/50.teams-messaging-extension-search/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/50.teams-messaging-extension-search/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/51.teams-messaging-extensions-action/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/51.teams-messaging-extensions-action/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/52.teams-messaging-extensions-search-auth-config/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/52.teams-messaging-extensions-search-auth-config/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/53.teams-messaging-extensions-action-preview/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/53.teams-messaging-extensions-action-preview/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/54.teams-task-module/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/54.teams-task-module/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/55.teams-link-unfurling/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/55.teams-link-unfurling/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/56.teams-file-upload/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/56.teams-file-upload/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/57.teams-conversation-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/57.teams-conversation-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/58.teams-start-thread-in-channel/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/58.teams-start-thread-in-channel/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/60.slack-adapter/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/60.slack-adapter/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/81.skills-skilldialog/dialog-root-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/81.skills-skilldialog/dialog-root-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/81.skills-skilldialog/dialog-skill-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/81.skills-skilldialog/dialog-skill-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/wip/python_quart/02.echo-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/wip/python_quart/02.echo-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/wip/python_quart/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/wip/python_quart/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/wip/python_tornado/02.echo-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/wip/python_tornado/02.echo-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/python/wip/python_tornado/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/wip/python_tornado/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "location": "[variables('resourcesLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "kind": "app,linux",
             "properties": {

--- a/samples/typescript_nodejs/00.empty-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/typescript_nodejs/00.empty-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/typescript_nodejs/03.welcome-users/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/typescript_nodejs/03.welcome-users/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/typescript_nodejs/05.multi-turn-prompt/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/typescript_nodejs/05.multi-turn-prompt/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/typescript_nodejs/06.using-cards/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/typescript_nodejs/06.using-cards/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/typescript_nodejs/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/typescript_nodejs/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/samples/typescript_nodejs/16.proactive-messages/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/typescript_nodejs/16.proactive-messages/deploymentTemplates/template-with-preexisting-rg.json
@@ -97,12 +97,12 @@
             "location": "[variables('resourcesLocation')]",
             "kind": "app",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {


### PR DESCRIPTION
Fixes serverFarmId bug in preexisting-rg ARM templates

See: https://github.com/MicrosoftDocs/bot-docs-pr/pull/2172

## Proposed Changes
  - Use `"serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"` instead of `"serverFarmId": "[variables('servicePlanName')]"`

## Testing
Tested via creating a new bot in an existing RG with an existing AppServicePlan.

@zxyanliu is testing an new AppServicePlan in an existing RG