### PR TITLE
[DO NOT MERGE] Add telemetry link to catch all error handler comments

### DIFF
--- a/samples/csharp_dotnetcore/02.echo-bot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/02.echo-bot/AdapterWithErrorHandler.cs
@@ -16,6 +16,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/03.welcome-user/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/03.welcome-user/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/06.using-cards/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/06.using-cards/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/08.suggested-actions/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/08.suggested-actions/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/11.qnamaker/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/11.qnamaker/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/13.core-bot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/13.core-bot/AdapterWithErrorHandler.cs
@@ -19,6 +19,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/14.nlp-with-dispatch/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/14.nlp-with-dispatch/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/15.handling-attachments/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/15.handling-attachments/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/16.proactive-messages/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/16.proactive-messages/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/17.multilingual-bot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/AdapterWithErrorHandler.cs
@@ -29,6 +29,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/18.bot-authentication/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/18.bot-authentication/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/19.custom-dialogs/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/21.corebot-app-insights/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/21.corebot-app-insights/AdapterWithErrorHandler.cs
@@ -34,9 +34,12 @@ namespace Microsoft.BotBuilderSamples
                 {{"Bot exception caught in", $"{nameof(AdapterWithErrorHandler)} - {nameof(OnTurnError)}"}};
 
                 //Send the exception telemetry:
-                _adapterBotTelemetryClient.TrackException(exception, properties);                
+                _adapterBotTelemetryClient.TrackException(exception, properties);
 
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/23.facebook-events/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/23.facebook-events/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/25.message-reaction/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/25.message-reaction/AdapterWithErrorHandler.cs
@@ -15,6 +15,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError($"Exception caught : {exception.Message}");
 
                 // Send a catch-all apology to the user.

--- a/samples/csharp_dotnetcore/42.scaleout/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/42.scaleout/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/43.complex-dialog/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/43.complex-dialog/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/44.prompt-users-for-input/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/44.prompt-users-for-input/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/45.state-management/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/45.state-management/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/46.teams-auth/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/46.teams-auth/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/48.qnamaker-active-learning-bot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/48.qnamaker-active-learning-bot/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/AdapterWithErrorHandler.cs
@@ -16,6 +16,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/AdapterWithErrorHandler.cs
@@ -16,6 +16,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Note: Since this Messaging Extension does not have the messageTeamMembers permission

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/AdapterWithErrorHandler.cs
@@ -21,6 +21,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/AdapterWithErrorHandler.cs
@@ -16,6 +16,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/54.teams-task-module/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/54.teams-task-module/AdapterWithErrorHandler.cs
@@ -15,6 +15,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError($"Exception caught : {exception.Message}");
 
                 // Send a catch-all apology to the user.

--- a/samples/csharp_dotnetcore/55.teams-link-unfurling/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/55.teams-link-unfurling/AdapterWithErrorHandler.cs
@@ -16,6 +16,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Note: Since this Messaging Extension does not have the messageTeamMembers permission

--- a/samples/csharp_dotnetcore/56.teams-file-upload/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/56.teams-file-upload/AdapterWithErrorHandler.cs
@@ -16,6 +16,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/AdapterWithErrorHandler.cs
@@ -16,6 +16,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError($"Exception caught : {exception.Message}");
 
                 // Send a catch-all apology to the user.

--- a/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/AdapterWithErrorHandler.cs
@@ -16,6 +16,9 @@ namespace Microsoft.BotBuilderSamples
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError($"Exception caught : {exception.Message}");
 
                 // Send a catch-all apology to the user.

--- a/samples/csharp_dotnetcore/70.qnamaker-multiturn-sample/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/70.qnamaker-multiturn-sample/AdapterWithErrorHandler.cs
@@ -18,6 +18,9 @@ namespace QnAMultiturnBot
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.
+                // NOTE: In production environment, you should consider logging this to
+                // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+                // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/AdapterWithErrorHandler.cs
@@ -40,6 +40,9 @@ namespace Microsoft.BotBuilderSamples.SimpleRootBot
         private async Task HandleTurnError(ITurnContext turnContext, Exception exception)
         {
             // Log any leaked exception from the application.
+            // NOTE: In production environment, you should consider logging this to
+            // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+            // to add telemetry capture to your bot.
             _logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
             await SendErrorMessageAsync(turnContext, exception);

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/AdapterWithErrorHandler.cs
@@ -42,6 +42,9 @@ namespace Microsoft.BotBuilderSamples.DialogRootBot
         private async Task HandleTurnError(ITurnContext turnContext, Exception exception)
         {
             // Log any leaked exception from the application.
+            // NOTE: In production environment, you should consider logging this to
+            // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
+            // to add telemetry capture to your bot.
             _logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
             await SendErrorMessageAsync(turnContext, exception);

--- a/samples/javascript_nodejs/02.echo-bot/index.js
+++ b/samples/javascript_nodejs/02.echo-bot/index.js
@@ -36,7 +36,8 @@ const adapter = new BotFrameworkAdapter({
 const onTurnErrorHandler = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/03.welcome-users/index.js
+++ b/samples/javascript_nodejs/03.welcome-users/index.js
@@ -26,7 +26,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/05.multi-turn-prompt/index.js
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/index.js
@@ -27,7 +27,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/06.using-cards/index.js
+++ b/samples/javascript_nodejs/06.using-cards/index.js
@@ -28,7 +28,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/07.using-adaptive-cards/index.js
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/index.js
@@ -24,7 +24,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/08.suggested-actions/index.js
+++ b/samples/javascript_nodejs/08.suggested-actions/index.js
@@ -24,7 +24,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/11.qnamaker/index.js
+++ b/samples/javascript_nodejs/11.qnamaker/index.js
@@ -39,7 +39,8 @@ adapter.onTurnError = async (context, error) => {
     };
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/13.core-bot/index.js
+++ b/samples/javascript_nodejs/13.core-bot/index.js
@@ -37,7 +37,8 @@ const adapter = new BotFrameworkAdapter({
 const onTurnErrorHandler = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/14.nlp-with-dispatch/index.js
+++ b/samples/javascript_nodejs/14.nlp-with-dispatch/index.js
@@ -28,7 +28,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/15.handling-attachments/index.js
+++ b/samples/javascript_nodejs/15.handling-attachments/index.js
@@ -24,7 +24,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/16.proactive-messages/index.js
+++ b/samples/javascript_nodejs/16.proactive-messages/index.js
@@ -29,7 +29,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/17.multilingual-bot/index.js
+++ b/samples/javascript_nodejs/17.multilingual-bot/index.js
@@ -33,7 +33,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/18.bot-authentication/index.js
+++ b/samples/javascript_nodejs/18.bot-authentication/index.js
@@ -28,7 +28,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/19.custom-dialogs/index.js
+++ b/samples/javascript_nodejs/19.custom-dialogs/index.js
@@ -56,7 +56,8 @@ server.post('/api/messages', (req, res) => {
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/21.corebot-app-insights/index.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/index.js
@@ -38,7 +38,8 @@ const adapter = new BotFrameworkAdapter({
 const onTurnErrorHandler = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/23.facebook-events/index.js
+++ b/samples/javascript_nodejs/23.facebook-events/index.js
@@ -47,7 +47,8 @@ server.post('/api/messages', (req, res) => {
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/index.js
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/index.js
@@ -26,7 +26,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/25.message-reaction/index.js
+++ b/samples/javascript_nodejs/25.message-reaction/index.js
@@ -28,7 +28,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/43.complex-dialog/index.js
+++ b/samples/javascript_nodejs/43.complex-dialog/index.js
@@ -46,7 +46,8 @@ const bot = new DialogAndWelcomeBot(conversationState, userState, dialog);
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/44.prompt-for-user-input/index.js
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/index.js
@@ -42,7 +42,8 @@ const bot = new CustomPromptBot(conversationState, userState);
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/45.state-management/index.js
+++ b/samples/javascript_nodejs/45.state-management/index.js
@@ -45,7 +45,8 @@ const bot = new StateManagementBot(conversationState, userState);
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/46.teams-auth/index.js
+++ b/samples/javascript_nodejs/46.teams-auth/index.js
@@ -28,7 +28,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/47.inspection/index.js
+++ b/samples/javascript_nodejs/47.inspection/index.js
@@ -46,7 +46,8 @@ adapter.use(new InspectionMiddleware(inspectionState, userState, conversationSta
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/48.qnamaker-active-learning-bot/index.js
+++ b/samples/javascript_nodejs/48.qnamaker-active-learning-bot/index.js
@@ -31,7 +31,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/49.qnamaker-all-features/index.js
+++ b/samples/javascript_nodejs/49.qnamaker-all-features/index.js
@@ -36,7 +36,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/50.teams-messaging-extensions-search/index.js
+++ b/samples/javascript_nodejs/50.teams-messaging-extensions-search/index.js
@@ -27,7 +27,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/51.teams-messaging-extensions-action/index.js
+++ b/samples/javascript_nodejs/51.teams-messaging-extensions-action/index.js
@@ -26,7 +26,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/index.js
+++ b/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/index.js
@@ -26,7 +26,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/index.js
+++ b/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/index.js
@@ -26,7 +26,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/54.teams-task-module/index.js
+++ b/samples/javascript_nodejs/54.teams-task-module/index.js
@@ -26,7 +26,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/55.teams-link-unfurling/index.js
+++ b/samples/javascript_nodejs/55.teams-link-unfurling/index.js
@@ -27,7 +27,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/56.teams-file-upload/index.js
+++ b/samples/javascript_nodejs/56.teams-file-upload/index.js
@@ -27,7 +27,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/57.teams-conversation-bot/index.js
+++ b/samples/javascript_nodejs/57.teams-conversation-bot/index.js
@@ -27,7 +27,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/index.js
+++ b/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/index.js
@@ -27,7 +27,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/70.qnamaker-multiturn-sample/index.js
+++ b/samples/javascript_nodejs/70.qnamaker-multiturn-sample/index.js
@@ -37,7 +37,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     // Send a trace activity, which will be displayed in Bot Framework Emulator

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/index.js
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/index.js
@@ -34,7 +34,8 @@ const adapter = new BotFrameworkAdapter({
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to the console log, instead of to app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     await sendErrorMessage(context, error);

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/index.js
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/index.js
@@ -44,7 +44,8 @@ adapter.use(new LoggerMiddleware());
 const onTurnErrorHandler = async (context, error) => {
     // This check writes out errors to the console log, instead of to app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     await sendErrorMessage(context, error);

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/index.js
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/index.js
@@ -39,7 +39,8 @@ const adapter = new BotFrameworkAdapter({
 const onTurnErrorHandler = async (context, error) => {
     // This check writes out errors to the console log, instead of to app insights.
     // NOTE: In a production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights.  See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(`\n [onTurnError] unhandled error: ${ error }`);
 
     await sendErrorMessage(context, error);

--- a/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/index.js
+++ b/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/index.js
@@ -34,7 +34,8 @@ const multiLangLG = new MultiLanguageLG(templatesPerLocale);
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     let langResponse = multiLangLG.generate('SomethingWentWrong', {
         message: `${ error }`
     }, context.activity.locale);

--- a/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/index.js
+++ b/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/index.js
@@ -31,7 +31,8 @@ const lgTemplates = Templates.parseFile('./Resources/AdapterWithErrorHandler.lg'
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(lgTemplates.evaluate('SomethingWentWrong', {
         message: `${ error }`
     }));

--- a/samples/javascript_nodejs/language-generation/06.using-cards/index.js
+++ b/samples/javascript_nodejs/language-generation/06.using-cards/index.js
@@ -32,7 +32,8 @@ const lgTemplates = Templates.parseFile('./resources/AdapterWithErrorHandler.lg'
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(lgTemplates.evaluate('SomethingWentWrong', {
         message: `${ error }`
     }));

--- a/samples/javascript_nodejs/language-generation/13.core-bot/index.js
+++ b/samples/javascript_nodejs/language-generation/13.core-bot/index.js
@@ -41,7 +41,8 @@ const lgTemplates = Templates.parseFile(path.join(__dirname, './resources/Adapte
 adapter.onTurnError = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(lgTemplates.evaluate('SomethingWentWrong', {
         message: `${ error }`
     }));

--- a/samples/javascript_nodejs/language-generation/20.custom-functions/index.js
+++ b/samples/javascript_nodejs/language-generation/20.custom-functions/index.js
@@ -38,7 +38,8 @@ const lgTemplates = Templates.parseFile(path.join(__dirname, './resources/Adapte
 const onTurnErrorHandler = async (context, error) => {
     // This check writes out errors to console log .vs. app insights.
     // NOTE: In production environment, you should consider logging this to Azure
-    //       application insights.
+    //       application insights. See https://aka.ms/bottelemetry for telemetry 
+    //       configuration instructions.
     console.error(lgTemplates.evaluate('SomethingWentWrong', {
         message: `${ error }`
     }));


### PR DESCRIPTION
Fixes #1909 

Adds aka.ms link to catch all error handler comments, advising the developer to consider using App Insights in production and linking to the configuration instructions.

Note: This is currently blocked until this PR is updated https://github.com/MicrosoftDocs/bot-docs-pr/pull/1845 with the latest JS instructions and is published, so that the aka.ms link contains the correct information.