### PR TITLE
Set up CoreBot functional tests

### DIFF
--- a/samples/csharp_dotnetcore/tests/Samples.CoreBot.FunctionalTests/DirectLineClientTests.cs
+++ b/samples/csharp_dotnetcore/tests/Samples.CoreBot.FunctionalTests/DirectLineClientTests.cs
@@ -16,26 +16,19 @@ namespace Samples.CoreBot.FunctionalTests
         private static string directLineSecret = null;
         private static string botId = null;
         private static string fromUser = "DirectLineClientTestUser";
-        private static string echoGuid = string.Empty;
-        //private static string input = $"Testing Azure Bot GUID: ";
 
         [TestMethod]
         public async Task SendDirectLineMessage()
         {
             GetEnvironmentVars();
 
-            //echoGuid = Guid.NewGuid().ToString();
-            string input = "hi";
+            string input = "";
             var botAnswer = await StartBotConversationAsync(input);
             Assert.AreEqual($"Where are you traveling from?", botAnswer);
 
-            input = "Seattle";
-            botAnswer = await StartBotConversationAsync(input);
-            Assert.AreEqual($"Where would you like to travel to?", botAnswer);
-
-            input = "Prague";
-            botAnswer = await StartBotConversationAsync(input);
-            Assert.AreEqual($"When would you like to travel?", botAnswer);
+            //Assert.AreEqual($"Where would you like to travel to?", botAnswer);
+            //Assert.AreEqual($"When would you like to travel?", botAnswer);
+            //Assert.AreEqual($"Please confirm", botAnswer.Substring(0,14));
         }
 
         /// <summary>
@@ -94,7 +87,9 @@ namespace Samples.CoreBot.FunctionalTests
                 // Analyze each activity in the activity set.
                 foreach (var activity in activities)
                 {
-                    if (activity.Type == ActivityTypes.Message && activity.Text != "Welcome to Echo Bot.")
+                    if (activity.Type == ActivityTypes.Message
+                        && !String.IsNullOrWhiteSpace(activity.Text)
+                        && !activity.Text.StartsWith("NOTE: LUIS is not configured"))
                     {
                         answer = activity.Text;
                     }

--- a/samples/csharp_dotnetcore/tests/Samples.CoreBot.FunctionalTests/DirectLineClientTests.cs
+++ b/samples/csharp_dotnetcore/tests/Samples.CoreBot.FunctionalTests/DirectLineClientTests.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector.DirectLine;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Samples.CoreBot.FunctionalTests
+{
+    [TestClass]
+    [TestCategory("FunctionalTests")]
+    public class DirectLineClientTests
+    {
+        private static string directLineSecret = null;
+        private static string botId = null;
+        private static string fromUser = "DirectLineClientTestUser";
+        private static string echoGuid = string.Empty;
+        private static string input = $"Testing Azure Bot GUID: ";
+
+        [TestMethod]
+        public async Task SendDirectLineMessage()
+        {
+            GetEnvironmentVars();
+
+            echoGuid = Guid.NewGuid().ToString();
+            input += echoGuid;
+
+            var botAnswer = await StartBotConversationAsync();
+
+            Assert.AreEqual($"Echo: {input}", botAnswer);
+        }
+
+        /// <summary>
+        /// Starts a conversation with a bot. Sends a message and waits for the response.
+        /// </summary>
+        /// <returns>Returns the bot's answer.</returns>
+        private static async Task<string> StartBotConversationAsync()
+        {
+            // Create a new Direct Line client.
+            var client = new DirectLineClient(directLineSecret);
+
+            // Start the conversation.
+            var conversation = await client.Conversations.StartConversationAsync();
+
+            // Create a message activity with the input text.
+            var userMessage = new Activity
+            {
+                From = new ChannelAccount(fromUser),
+                Text = input,
+                Type = ActivityTypes.Message,
+            };
+
+            // Send the message activity to the bot.
+            await client.Conversations.PostActivityAsync(conversation.ConversationId, userMessage);
+
+            // Read the bot's message.
+            var botAnswer = await ReadBotMessagesAsync(client, conversation.ConversationId);
+
+            return botAnswer;
+        }
+
+        /// <summary>
+        /// Polls the bot continuously until it gets a response.
+        /// </summary>
+        /// <param name="client">The Direct Line client.</param>
+        /// <param name="conversationId">The conversation ID.</param>
+        /// <returns>Returns the bot's answer.</returns>
+        private static async Task<string> ReadBotMessagesAsync(DirectLineClient client, string conversationId)
+        {
+            string watermark = null;
+            var answer = string.Empty;
+            int retries = 3;
+
+            // Poll the bot for replies once per second.
+            while (answer.Equals(string.Empty) && retries-- > 0)
+            {
+                // Retrieve the activity sent from the bot.
+                var activitySet = await client.Conversations.GetActivitiesAsync(conversationId, watermark);
+                watermark = activitySet?.Watermark;
+
+                // Extract the activities sent from the bot.
+                var activities = from x in activitySet.Activities
+                                 where x.From.Id == botId
+                                 select x;
+
+                // Analyze each activity in the activity set.
+                foreach (var activity in activities)
+                {
+                    if (activity.Type == ActivityTypes.Message && activity.Text != "Welcome to Echo Bot.")
+                    {
+                        answer = activity.Text;
+                    }
+                }
+
+                if (answer.Equals(string.Empty))
+                {
+                    // Wait for one second before polling the bot again.
+                    await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+                }
+            }
+
+            return answer;
+        }
+
+        /// <summary>
+        /// Get the values for the environment variables.
+        /// </summary>
+        private void GetEnvironmentVars()
+        {
+            if (string.IsNullOrWhiteSpace(directLineSecret) || string.IsNullOrWhiteSpace(botId))
+            {
+                directLineSecret = Environment.GetEnvironmentVariable("DIRECTLINE");
+                if (string.IsNullOrWhiteSpace(directLineSecret))
+                {
+                    Assert.Inconclusive("Environment variable 'DIRECTLINE' not found.");
+                }
+
+                botId = Environment.GetEnvironmentVariable("BOTID");
+                if (string.IsNullOrWhiteSpace(botId))
+                {
+                    Assert.Inconclusive("Environment variable 'BOTID' not found.");
+                }
+            }
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/tests/Samples.CoreBot.FunctionalTests/DirectLineClientTests.cs
+++ b/samples/csharp_dotnetcore/tests/Samples.CoreBot.FunctionalTests/DirectLineClientTests.cs
@@ -17,26 +17,32 @@ namespace Samples.CoreBot.FunctionalTests
         private static string botId = null;
         private static string fromUser = "DirectLineClientTestUser";
         private static string echoGuid = string.Empty;
-        private static string input = $"Testing Azure Bot GUID: ";
+        //private static string input = $"Testing Azure Bot GUID: ";
 
         [TestMethod]
         public async Task SendDirectLineMessage()
         {
             GetEnvironmentVars();
 
-            echoGuid = Guid.NewGuid().ToString();
-            input += echoGuid;
+            //echoGuid = Guid.NewGuid().ToString();
+            string input = "hi";
+            var botAnswer = await StartBotConversationAsync(input);
+            Assert.AreEqual($"Where are you traveling from?", botAnswer);
 
-            var botAnswer = await StartBotConversationAsync();
+            input = "Seattle";
+            botAnswer = await StartBotConversationAsync(input);
+            Assert.AreEqual($"Where would you like to travel to?", botAnswer);
 
-            Assert.AreEqual($"Echo: {input}", botAnswer);
+            input = "Prague";
+            botAnswer = await StartBotConversationAsync(input);
+            Assert.AreEqual($"When would you like to travel?", botAnswer);
         }
 
         /// <summary>
         /// Starts a conversation with a bot. Sends a message and waits for the response.
         /// </summary>
         /// <returns>Returns the bot's answer.</returns>
-        private static async Task<string> StartBotConversationAsync()
+        private static async Task<string> StartBotConversationAsync(string input)
         {
             // Create a new Direct Line client.
             var client = new DirectLineClient(directLineSecret);

--- a/samples/csharp_dotnetcore/tests/Samples.CoreBot.FunctionalTests/DirectLineClientTests.cs
+++ b/samples/csharp_dotnetcore/tests/Samples.CoreBot.FunctionalTests/DirectLineClientTests.cs
@@ -25,10 +25,6 @@ namespace Samples.CoreBot.FunctionalTests
             string input = "";
             var botAnswer = await StartBotConversationAsync(input);
             Assert.AreEqual($"Where are you traveling from?", botAnswer);
-
-            //Assert.AreEqual($"Where would you like to travel to?", botAnswer);
-            //Assert.AreEqual($"When would you like to travel?", botAnswer);
-            //Assert.AreEqual($"Please confirm", botAnswer.Substring(0,14));
         }
 
         /// <summary>

--- a/samples/csharp_dotnetcore/tests/Samples.CoreBot.FunctionalTests/Samples.CoreBot.FunctionalTests.csproj
+++ b/samples/csharp_dotnetcore/tests/Samples.CoreBot.FunctionalTests/Samples.CoreBot.FunctionalTests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+</Project>

--- a/samples/csharp_dotnetcore/tests/Samples.CoreBot.FunctionalTests/Samples.CoreBot.FunctionalTests.sln
+++ b/samples/csharp_dotnetcore/tests/Samples.CoreBot.FunctionalTests/Samples.CoreBot.FunctionalTests.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30107.140
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.CoreBot.FunctionalTests", "Samples.CoreBot.FunctionalTests.csproj", "{F026D228-5B43-4A37-8408-7689AA673FC7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F026D228-5B43-4A37-8408-7689AA673FC7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F026D228-5B43-4A37-8408-7689AA673FC7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F026D228-5B43-4A37-8408-7689AA673FC7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F026D228-5B43-4A37-8408-7689AA673FC7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {99B29370-88CE-412F-A282-1DEB2A3B1763}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This test merely verifies that the bot is deployed and running by checking for its first query, "Where are you traveling from?". If more detailed testing is desired, I can do that as a follow-on PR. In that case, it would be helpful to see an example of programmatic testing of an adaptive card in Azure. (Detailed adaptive card testing is already done in unit tests in the CI builds.)