### PR TITLE
[QnAMaker] Support configuration keys both ‘QnAEndpointKey’ and ‘QnAAuthKey from Application Configuration

### DIFF
--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/BotServices.cs
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/BotServices.cs
@@ -35,7 +35,7 @@ namespace Microsoft.BotBuilderSamples
             return hostname;
         }
 
-        private static string GetHostname(IConfiguration configuration)
+        private static string GetAuthKey(IConfiguration configuration)
         {
             var authKey = configuration["QnAEndpointKey"];
             if(string.IsNullOrEmpty(authKey))

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/BotServices.cs
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/BotServices.cs
@@ -12,9 +12,9 @@ namespace Microsoft.BotBuilderSamples
         {
             QnAMakerService = new QnAMaker(new QnAMakerEndpoint
             {
-                KnowledgeBaseId = configuration["QnAKnowledgebaseId"],
-                EndpointKey = GetAuthKey(configuration),
-                Host = GetHostname(configuration["QnAEndpointHostName"])
+                KnowledgeBaseId = configuration["QnAKnowledgebaseId"],                
+                Host = GetHostname(configuration["QnAEndpointHostName"]),
+                EndpointKey = GetEndpointKey(configuration)
             });
         }
 
@@ -35,16 +35,19 @@ namespace Microsoft.BotBuilderSamples
             return hostname;
         }
 
-        private static string GetAuthKey(IConfiguration configuration)
+        private static string GetEndpointKey(IConfiguration configuration)
         {
-            var authKey = configuration["QnAEndpointKey"];
-            if(string.IsNullOrEmpty(authKey))
+            var endpointKey = configuration["QnAEndpointKey"];
+
+            // To support appsettings key name for code downloaded from Azure Create Bot flow
+            // For reference <ref>https://docs.microsoft.com/en-us/azure/bot-service/abs-quickstart?view=azure-bot-service-4.0#download-code</>
+            if(string.IsNullOrWhiteSpace(endpointKey))
             {
-                authKey = configuration["QnAAuthKey"];
+                endpointKey = configuration["QnAAuthKey"];
             }
 
-            return authKey;
-
+            return endpointKey;
+            
         }
     }
 }

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/BotServices.cs
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/BotServices.cs
@@ -39,10 +39,9 @@ namespace Microsoft.BotBuilderSamples
         {
             var endpointKey = configuration["QnAEndpointKey"];
 
-            // To support appsettings key name for code downloaded from Azure Create Bot flow
-            // For reference <ref>https://docs.microsoft.com/en-us/azure/bot-service/abs-quickstart?view=azure-bot-service-4.0#download-code</>
             if(string.IsNullOrWhiteSpace(endpointKey))
             {
+                // To support backward compatibility for Key Names
                 endpointKey = configuration["QnAAuthKey"];
             }
 

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/BotServices.cs
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/BotServices.cs
@@ -13,7 +13,7 @@ namespace Microsoft.BotBuilderSamples
             QnAMakerService = new QnAMaker(new QnAMakerEndpoint
             {
                 KnowledgeBaseId = configuration["QnAKnowledgebaseId"],
-                EndpointKey = configuration["QnAEndpointKey"],
+                EndpointKey = GetAuthKey(configuration),
                 Host = GetHostname(configuration["QnAEndpointHostName"])
             });
         }
@@ -33,6 +33,18 @@ namespace Microsoft.BotBuilderSamples
             }
 
             return hostname;
+        }
+
+        private static string GetHostname(IConfiguration configuration)
+        {
+            var authKey = configuration["QnAEndpointKey"];
+            if(string.IsNullOrEmpty(authKey))
+            {
+                authKey = configuration["QnAAuthKey"];
+            }
+
+            return authKey;
+
         }
     }
 }

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/BotServices.cs
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/BotServices.cs
@@ -41,7 +41,13 @@ namespace Microsoft.BotBuilderSamples
 
             if(string.IsNullOrWhiteSpace(endpointKey))
             {
-                // To support backward compatibility for Key Names
+                // This features sample is copied as is for "azure bot service" default "createbot" template.
+                // Post this sample change merged into "azure bot service" template repo, "Azure Bot Service"
+                // will make the web app config change to use "QnAEndpointKey".But, the the old "QnAAuthkey"
+                // required for backward compact. This is a requirement from docs to keep app setting name
+                // consistent with "QnAEndpointKey". This is tracked in Github issue:
+                // https://github.com/microsoft/BotBuilder-Samples/issues/2532
+
                 endpointKey = configuration["QnAAuthKey"];
             }
 

--- a/samples/javascript_nodejs/49.qnamaker-all-features/index.js
+++ b/samples/javascript_nodejs/49.qnamaker-all-features/index.js
@@ -71,10 +71,9 @@ if (!endpointHostName.includes('/v5.0') && !endpointHostName.endsWith('/qnamaker
 
 var endpointKey = process.env.QnAEndpointKey;
 
-// To support appsettings key name for code downloaded from Azure Create Bot flow
-// For reference <ref>https://docs.microsoft.com/en-us/azure/bot-service/abs-quickstart?view=azure-bot-service-4.0#download-code</>
 if (!endpointKey || 0 === endpointKey.length)
 {
+   // To support backward compatibility for Key Names
     endpointKey = process.env.QnAAuthKey;
 }
 

--- a/samples/javascript_nodejs/49.qnamaker-all-features/index.js
+++ b/samples/javascript_nodejs/49.qnamaker-all-features/index.js
@@ -70,6 +70,9 @@ if (!endpointHostName.includes('/v5.0') && !endpointHostName.endsWith('/qnamaker
 }
 
 var endpointKey = process.env.QnAEndpointKey;
+
+// To support appsettings key name for code downloaded from Azure Create Bot flow
+// For reference <ref>https://docs.microsoft.com/en-us/azure/bot-service/abs-quickstart?view=azure-bot-service-4.0#download-code</>
 if (!endpointKey || 0 === endpointKey.length)
 {
     endpointKey = process.env.QnAAuthKey;

--- a/samples/javascript_nodejs/49.qnamaker-all-features/index.js
+++ b/samples/javascript_nodejs/49.qnamaker-all-features/index.js
@@ -69,8 +69,14 @@ if (!endpointHostName.includes('/v5.0') && !endpointHostName.endsWith('/qnamaker
     endpointHostName = endpointHostName + '/qnamaker';
 }
 
+var endpointKey = process.env.QnAEndpointKey;
+if (!endpointKey || 0 === endpointKey.length)
+{
+    endpointKey = process.env.QnAAuthKey;
+}
+
 // Create the main dialog.
-const dialog = new RootDialog(process.env.QnAKnowledgebaseId, process.env.QnAEndpointKey, endpointHostName);
+const dialog = new RootDialog(process.env.QnAKnowledgebaseId, endpointKey, endpointHostName);
 
 // Create the bot's main handler.
 const bot = new QnABot(conversationState, userState, dialog);


### PR DESCRIPTION
Fixes #2532

Proposed Changes:

To support both the Key Names from appsettings/env  : "QnAEndpointKey" and  "QnAAuthKey". 

Context:

QnAMakerSample uses "QnAMakerEndpointKey" as Key Name and  QnAMaker CreateBot Template uses "QnAMakerAuthKey" as Key Name, for the same value. For backward compatibility and same code supporting both Key Names, this change is proposed.
 