### PR TITLE
Add link to specific teams attachment sample from sample 15.

### DIFF
--- a/samples/csharp_dotnetcore/15.handling-attachments/README.md
+++ b/samples/csharp_dotnetcore/15.handling-attachments/README.md
@@ -4,6 +4,9 @@ Bot Framework v4 handling attachments bot sample
 
 This bot has been created using [Bot Framework](https://dev.botframework.com), it shows how to send outgoing attachments and how to save attachments to disk.
 
+> **NOTE: A specific example for Microsoft Teams, demonstrating how to
+upload files to Teams from a bot and how to receive a file sent to a bot as an attachment, can be found [here](../56.teams-file-upload)**
+
 ## Prerequisites
 
 - [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1

--- a/samples/javascript_nodejs/15.handling-attachments/README.md
+++ b/samples/javascript_nodejs/15.handling-attachments/README.md
@@ -4,6 +4,9 @@ Bot Framework v4 handling attachments bot sample
 
 This bot has been created using [Bot Framework](https://dev.botframework.com), it shows how to send outgoing attachments and how to save attachments to disk.
 
+> **NOTE: A specific example for Microsoft Teams, demonstrating how to
+upload files to Teams from a bot and how to receive a file sent to a bot as an attachment, can be found [here](../56.teams-file-upload)**
+
 ## Prerequisites
 
 - [Node.js](https://nodejs.org) version 10.14 or higher

--- a/samples/python/15.handling-attachments/README.md
+++ b/samples/python/15.handling-attachments/README.md
@@ -4,6 +4,9 @@ Bot Framework v4 handling attachments bot sample
 
 This bot has been created using [Bot Framework](https://dev.botframework.com), it shows how to send outgoing attachments and how to save attachments to disk.
 
+> **NOTE: A specific example for Microsoft Teams, demonstrating how to
+upload files to Teams from a bot and how to receive a file sent to a bot as an attachment, can be found [here](../56.teams-file-upload)**
+
 ## Running the sample
 - Clone the repository
 ```bash


### PR DESCRIPTION
Fixes #2175 

Adds note to sample 15 in C#, JS and Python to call out to specific Teams upload sample.