### PR TITLE
Fix up the 01 adaptive dialog sample

### DIFF
--- a/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/AdapterWithErrorHandler.cs
@@ -18,6 +18,8 @@ namespace Microsoft.BotBuilderSamples
             UserState userState, ConversationState conversationState, IConfiguration configuration)
             : base(credentialProvider)
         {
+            // These methods add middleware to the adapter. The middleware adds the storage and state objects to the
+            // turn context each turn so that the dialog manager can retrieve them.
             this.UseStorage(storage);
             this.UseBotState(userState);
             this.UseBotState(conversationState);

--- a/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/Bots/DialogBot.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/Bots/DialogBot.cs
@@ -1,165 +1,37 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using AdaptiveExpressions.Properties;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Builder.Dialogs.Adaptive;
-using Microsoft.Bot.Builder.Dialogs.Adaptive.Actions;
-using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
-using Microsoft.Bot.Builder.Dialogs.Adaptive.Generators;
-using Microsoft.Bot.Builder.Dialogs.Adaptive.Input;
-using Microsoft.Bot.Builder.Dialogs.Adaptive.Templates;
-using Microsoft.Bot.Builder.LanguageGeneration;
-using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    // This IBot implementation can run any type of Dialog. The use of type parameterization is to allows multiple different bots
-    // to be run at different endpoints within the same project. This can be achieved by defining distinct Controller types
-    // each with dependency on distinct IBot types, this way ASP Dependency Injection can glue everything together without ambiguity.
-    // The ConversationState is used by the Dialog system. The UserState isn't, however, it might have been used in a Dialog implementation,
-    // and the requirement is that all BotState objects are saved at the end of a turn.
-    public class DialogBot : ActivityHandler
+    // This IBot implementation can run any type of dialog. The type parameter allows multiple different bots
+    // to run at different endpoints within the same project. To do so, define multiple distinct controller types,
+    // each with a dependency on a distinct IBot type. This allows ASP dependency injection to glue everything together without ambiguity.
+    // The dialog manager has access to user state and conversation state from the turn context, and
+    // it will save state changes before exiting.
+    public class DialogBot<T> : ActivityHandler
+        where T : Dialog
     {
-        protected readonly BotState ConversationState;
+        private readonly DialogManager DialogManager;
         protected readonly ILogger Logger;
-        protected readonly BotState UserState;
-        private DialogManager DialogManager;
-        protected Dialog adaptiveDialog;
 
-        public DialogBot(ConversationState conversationState, UserState userState, ILogger<DialogBot> logger)
+        public DialogBot(T rootDialog, ILogger<DialogBot<T>> logger)
         {
-            ConversationState = conversationState;
-            UserState = userState;
             Logger = logger;
-            string[] paths = { ".", "Dialogs", $"RootDialog.lg" };
-            string fullPath = Path.Combine(paths);
-            // Create instance of adaptive dialog. 
-            adaptiveDialog = new AdaptiveDialog(nameof(AdaptiveDialog))
-            {
-                // These steps are executed when this Adaptive Dialog begins
-                Triggers = new List<OnCondition>()
-                {
-                    // Add a rule to welcome user
-                    new OnConversationUpdateActivity()
-                    {
-                        Actions = WelcomeUserSteps()
-                    },
 
-                    // Respond to user on message activity
-                    new OnUnknownIntent()
-                    {
-                        Actions = OnBeginDialogSteps()
-                    }
-                },
-                Generator = new TemplateEngineLanguageGenerator(Templates.ParseFile(fullPath))
-            };
-
-            DialogManager = new DialogManager(adaptiveDialog);
+            DialogManager = new DialogManager(rootDialog);
         }
 
-        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
+        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
         {
             Logger.LogInformation("Running dialog with Activity.");
             await DialogManager.OnTurnAsync(turnContext, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
-        private static List<Dialog> WelcomeUserSteps()
-        {
-            return new List<Dialog>()
-            {
-                // Iterate through membersAdded list and greet user added to the conversation.
-                new Foreach()
-                {
-                    ItemsProperty = "turn.activity.membersAdded",
-                    Actions = new List<Dialog>()
-                    {
-                        // Note: Some channels send two conversation update events - one for the Bot added to the conversation and another for user.
-                        // Filter cases where the bot itself is the recipient of the message. 
-                        new IfCondition()
-                        {
-                            Condition = "$foreach.value.name != turn.activity.recipient.name",
-                            Actions = new List<Dialog>()
-                            {
-                                new SendActivity("Hello, I'm the multi-turn prompt bot. Please send a message to get started!")
-                            }
-                        }
-                    }
-                }
-            };
-
-        }
-
-        private static List<Dialog> OnBeginDialogSteps()
-        {
-            return new List<Dialog>()
-            {
-                // Ask for user's age and set it in user.userProfile scope.
-                new TextInput()
-                {
-                    Prompt = new ActivityTemplate("${ModeOfTransportPrompt()}"),
-                    // Set the output of the text input to this property in memory.
-                    Property = "user.userProfile.Transport"
-                },
-                new TextInput()
-                {
-                    Prompt = new ActivityTemplate("${AskForName()}"),
-                    Property = "user.userProfile.Name"
-                },
-                // SendActivity supports full language generation resolution.
-                // See here to learn more about language generation
-                // https://aka.ms/language-generation
-                new SendActivity("${AckName()}"),
-                new ConfirmInput()
-                {
-                    Prompt = new ActivityTemplate("${AgeConfirmPrompt()}"),
-                    Property = "turn.ageConfirmation"
-                },
-                new IfCondition()
-                {
-                    // All conditions are expressed using adaptive expressions.
-                    // See https://aka.ms/adaptive-expressions to learn more
-                    Condition = "turn.ageConfirmation == true",
-                    Actions = new List<Dialog>()
-                    {
-                         new NumberInput()
-                         {
-                             Prompt = new ActivityTemplate("${AskForAge()}"),
-                             Property = "user.userProfile.Age",
-                             // Add validations
-                             Validations = new List<BoolExpression>()
-                             {
-                                 // Age must be greater than or equal 1
-                                 "int(this.value) >= 1",
-                                 // Age must be less than 150
-                                 "int(this.value) < 150"
-                             },
-                             InvalidPrompt = new ActivityTemplate("${AskForAge.invalid()}"),
-                             UnrecognizedPrompt = new ActivityTemplate("${AskForAge.unRecognized()}")
-                         },
-                         new SendActivity("${UserAgeReadBack()}")
-                    },
-                    ElseActions = new List<Dialog>()
-                    {
-                        new SendActivity("${NoName()}")
-                    }
-                },
-                new ConfirmInput()
-                {
-                    Prompt = new ActivityTemplate("${ConfirmPrompt()}"),
-                    Property = "turn.finalConfirmation"
-                },
-                // Use LG template to come back with the final read out.
-                // This LG template is a great example of what logic can be wrapped up in LG sub-system.
-                new SendActivity("${FinalUserProfileReadOut()}"), // examines turn.finalConfirmation
-                new EndDialog()
-            };
-        }
     }
 }

--- a/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/Dialogs/RootDialog.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/Dialogs/RootDialog.cs
@@ -1,0 +1,135 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using AdaptiveExpressions.Properties;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Adaptive;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Actions;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Generators;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Input;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Templates;
+using Microsoft.Bot.Builder.LanguageGeneration;
+
+namespace MultiTurnPromptBot.Dialogs
+{
+    public class RootDialog : AdaptiveDialog
+    {
+        public RootDialog() : base(nameof(RootDialog))
+        {
+            string[] paths = { ".", "Dialogs", $"RootDialog.lg" };
+            string fullPath = Path.Combine(paths);
+
+            // These steps are executed when this Adaptive Dialog begins
+            Triggers = new List<OnCondition>()
+                {
+                    // Add a rule to welcome user
+                    new OnConversationUpdateActivity()
+                    {
+                        Actions = WelcomeUserSteps()
+                    },
+
+                    // Respond to user on message activity
+                    new OnUnknownIntent()
+                    {
+                        Actions = OnBeginDialogSteps()
+                    },
+                };
+            Generator = new TemplateEngineLanguageGenerator(Templates.ParseFile(fullPath));
+        }
+
+        private static List<Dialog> WelcomeUserSteps()
+        {
+            return new List<Dialog>()
+            {
+                // Iterate through membersAdded list and greet user added to the conversation.
+                new Foreach()
+                {
+                    ItemsProperty = "turn.activity.membersAdded",
+                    Actions = new List<Dialog>()
+                    {
+                        // Note: Some channels send two conversation update events - one for the Bot added to the conversation and another for user.
+                        // Filter cases where the bot itself is the recipient of the message. 
+                        new IfCondition()
+                        {
+                            Condition = "$foreach.value.name != turn.activity.recipient.name",
+                            Actions = new List<Dialog>()
+                            {
+                                new SendActivity("Hello, I'm the multi-turn prompt bot. Please send a message to get started!")
+                            }
+                        }
+                    }
+                }
+            };
+
+        }
+
+        private static List<Dialog> OnBeginDialogSteps()
+        {
+            return new List<Dialog>()
+            {
+                // Ask for user's age and set it in user.userProfile scope.
+                new TextInput()
+                {
+                    Prompt = new ActivityTemplate("${ModeOfTransportPrompt()}"),
+                    // Set the output of the text input to this property in memory.
+                    Property = "user.userProfile.Transport"
+                },
+                new TextInput()
+                {
+                    Prompt = new ActivityTemplate("${AskForName()}"),
+                    Property = "user.userProfile.Name"
+                },
+                // SendActivity supports full language generation resolution.
+                // See here to learn more about language generation
+                // https://aka.ms/language-generation
+                new SendActivity("${AckName()}"),
+                new ConfirmInput()
+                {
+                    Prompt = new ActivityTemplate("${AgeConfirmPrompt()}"),
+                    Property = "turn.ageConfirmation"
+                },
+                new IfCondition()
+                {
+                    // All conditions are expressed using adaptive expressions.
+                    // See https://aka.ms/adaptive-expressions to learn more
+                    Condition = "turn.ageConfirmation == true",
+                    Actions = new List<Dialog>()
+                    {
+                         new NumberInput()
+                         {
+                             Prompt = new ActivityTemplate("${AskForAge()}"),
+                             Property = "user.userProfile.Age",
+                             // Add validations
+                             Validations = new List<BoolExpression>()
+                             {
+                                 // Age must be greater than or equal 1
+                                 "int(this.value) >= 1",
+                                 // Age must be less than 150
+                                 "int(this.value) < 150"
+                             },
+                             InvalidPrompt = new ActivityTemplate("${AskForAge.invalid()}"),
+                             UnrecognizedPrompt = new ActivityTemplate("${AskForAge.unRecognized()}")
+                         },
+                         new SendActivity("${UserAgeReadBack()}")
+                    },
+                    ElseActions = new List<Dialog>()
+                    {
+                        new SendActivity("${NoName()}")
+                    }
+                },
+                new ConfirmInput()
+                {
+                    Prompt = new ActivityTemplate("${ConfirmPrompt()}"),
+                    Property = "turn.finalConfirmation"
+                },
+                // Use LG template to come back with the final read out.
+                // This LG template is a great example of what logic can be wrapped up in LG sub-system.
+                new SendActivity("${FinalUserProfileReadOut()}"), // examines turn.finalConfirmation
+                new DeleteProperty() {
+                    Property = "user.userProfile"
+                },
+                new EndDialog(),
+            };
+        }
+    }
+}

--- a/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/Dialogs/RootDialog.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/Dialogs/RootDialog.cs
@@ -31,7 +31,7 @@ namespace MultiTurnPromptBot.Dialogs
                     // Respond to user on message activity
                     new OnUnknownIntent()
                     {
-                        Actions = OnBeginDialogSteps()
+                        Actions = GatheUserInformation()
                     },
                 };
             Generator = new TemplateEngineLanguageGenerator(Templates.ParseFile(fullPath));
@@ -63,7 +63,7 @@ namespace MultiTurnPromptBot.Dialogs
 
         }
 
-        private static List<Dialog> OnBeginDialogSteps()
+        private static List<Dialog> GatheUserInformation()
         {
             return new List<Dialog>()
             {

--- a/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/Dialogs/RootDialog.lg
+++ b/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/Dialogs/RootDialog.lg
@@ -36,7 +36,7 @@
 # ConfirmPrompt
 - Is this ok?
 
-> This template uses inline expressions. Expressions are defined using adaptive expressions. 
+> This template uses in-line expressions. Expressions are defined using adaptive expressions. 
 > See https://aka.ms/adaptive-expressions to learn more.
 # FinalUserProfileReadOut
 - IF: ${turn.finalConfirmation == true}
@@ -44,7 +44,7 @@
 - ELSE:
     - Thanks. Your profile will not be kept.
 
-> Structured template defintion.
+> Structured template definition.
 # ModeOfTransportPrompt
 [Activity
     Text = ${ModeOfTransportPrompt.Text()}
@@ -52,5 +52,5 @@
 ]
 
 # ModeOfTransportPrompt.Text
-- What is your favoriate mode of transportion?
+- What is your favorite mode of transportation?
 - Please enter your mode of transport.

--- a/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/Startup.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/Startup.cs
@@ -1,18 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.IO;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using MultiTurnPromptBot.Dialogs;
 
 namespace Microsoft.BotBuilderSamples
 {
@@ -47,8 +45,11 @@ namespace Microsoft.BotBuilderSamples
             // Create the Conversation state. (Used by the Dialog system itself.)
             services.AddSingleton<ConversationState>();
 
+            // The adaptive dialog that will be run by the bot.
+            services.AddSingleton<RootDialog>();
+
             // Create the bot. the ASP Controller is expecting an IBot.
-            services.AddSingleton<IBot, DialogBot>();
+            services.AddSingleton<IBot, DialogBot<RootDialog>>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/wwwroot/default.htm
+++ b/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/wwwroot/default.htm
@@ -392,7 +392,7 @@
     <header class="header">
         <div class="header-inner-container">
             <div class="header-icon" style="display: inline-block"></div>
-            <div class="header-text" style="display: inline-block">Core Bot Sample</div>
+            <div class="header-text" style="display: inline-block">Multi-turn prompt sample</div>
         </div>
     </header>
     <div class="row">


### PR DESCRIPTION
Fixes BotBuilder-Samples/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/

## Proposed Changes
This fixes two issues
  - Inappropriate code copied over from the original non-adaptive dialog sample.
  - Updates the _proof-of-concept_ merged earlier to be more clean and better reflect the code style of the rest of the samples.

Since the dialog loops after finishing, I added logic to clear the user profile before exiting and restarting the trigger.

## Testing
Other than the aforementioned change, the bot acts the same in the Emulator as before in anecdotal testing of various code paths.

## Additional information
If this is accepted, the other adaptive dialog samples should get similar fixes, as should the JS experimental samples.