### PR TITLE
bundling LG extension code to reduce the package size

### DIFF
--- a/experimental/adaptive-tool/.vscodeignore
+++ b/experimental/adaptive-tool/.vscodeignore
@@ -1,0 +1,16 @@
+.vscode/**
+.github/**
+**/*.ts
+**/*.map
+.gitignore
+**/tsconfig.json
+**/tsconfig.base.json
+**/tslint.json
+contributing.md
+.azure-pipelines.yml
+shared.webpack.config.js
+client/**
+!client/out/extension.js
+server/**
+!server/out/eslintServer.js
+playgrounds/**

--- a/experimental/adaptive-tool/.vscodeignore
+++ b/experimental/adaptive-tool/.vscodeignore
@@ -6,11 +6,9 @@
 **/tsconfig.json
 **/tsconfig.base.json
 **/tslint.json
-contributing.md
-.azure-pipelines.yml
 shared.webpack.config.js
 client/**
 !client/out/extension.js
 server/**
-!server/out/eslintServer.js
-playgrounds/**
+!server/out/server.js
+node_modules

--- a/experimental/adaptive-tool/.vscodeignore
+++ b/experimental/adaptive-tool/.vscodeignore
@@ -9,6 +9,6 @@
 shared.webpack.config.js
 client/**
 !client/out/extension.js
-server/**
+server/lg/**
 !server/out/server.js
 node_modules

--- a/experimental/adaptive-tool/client/src/extension.ts
+++ b/experimental/adaptive-tool/client/src/extension.ts
@@ -22,7 +22,7 @@ export function activate(context: ExtensionContext) {
 function startLgClient(context: ExtensionContext) {
 	// The server is implemented in node
 	const serverModule = context.asAbsolutePath(
-		path.join('server', 'out', 'lg', 'src', 'server.js')
+		path.join('server', 'out', 'server.js')
 	);
 	// The debug options for the server
 	// --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging

--- a/experimental/adaptive-tool/client/webpack.config.js
+++ b/experimental/adaptive-tool/client/webpack.config.js
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//@ts-check
+
+'use strict';
+
+const withDefaults = require('../shared.webpack.config');
+const path = require('path');
+
+module.exports = withDefaults({
+	context: path.join(__dirname),
+	entry: {
+		extension: './src/extension.ts',
+	},
+	output: {
+		filename: 'extension.js',
+		path: path.join(__dirname, 'out')
+	}
+});

--- a/experimental/adaptive-tool/package.json
+++ b/experimental/adaptive-tool/package.json
@@ -212,9 +212,14 @@
     ],
     "main": "./client/out/src/extension",
     "scripts": {
-        "vscode:prepublish": "npm run compile",
+        "vscode:prepublish": "npm run webpack",
+        "webpack": "npm run clean && webpack --mode production --config ./client/webpack.config.js && webpack --mode production --config ./server/webpack.config.js",
+        "webpack:dev": "npm run clean && webpack --mode none --config ./client/webpack.config.js && webpack --mode none --config ./server/webpack.config.js",
         "compile": "tsc -b",
+        "compile:client": "tsc -b ./client/tsconfig.json",
+        "compile:server": "tsc -b ./server/tsconfig.json",
         "watch": "tsc -b -w",
+        "clean": "rimraf client/out && rimraf server/out",
         "postinstall": "cd client && npm install && cd ../server && npm install && cd ..",
         "test": "sh ./scripts/e2e.sh"
     },
@@ -226,7 +231,12 @@
         "@typescript-eslint/parser": "^3.4.0",
         "eslint": "^7.3.1",
         "typescript": "^3.9.4",
-        "vscode-test": "^1.3.0"
+        "vscode-test": "^1.3.0",
+        "webpack": "^4.43.0",
+        "webpack-cli": "^3.3.11",
+        "ts-loader": "^6.2.1",
+        "merge-options": "^2.0.0",
+        "rimraf": "^3.0.2"
     },
     "dependencies": {
         "botbuilder-lg": "4.9.0",

--- a/experimental/adaptive-tool/package.json
+++ b/experimental/adaptive-tool/package.json
@@ -230,16 +230,12 @@
         "@typescript-eslint/eslint-plugin": "^3.4.0",
         "@typescript-eslint/parser": "^3.4.0",
         "eslint": "^7.3.1",
+        "merge-options": "^2.0.0",
+        "rimraf": "^3.0.2",
+        "ts-loader": "^6.2.1",
         "typescript": "^3.9.4",
         "vscode-test": "^1.3.0",
         "webpack": "^4.43.0",
-        "webpack-cli": "^3.3.11",
-        "ts-loader": "^6.2.1",
-        "merge-options": "^2.0.0",
-        "rimraf": "^3.0.2"
-    },
-    "dependencies": {
-        "botbuilder-lg": "4.9.0",
-        "@microsoft/bf-lu": "4.9.0"
+        "webpack-cli": "^3.3.11"
     }
 }

--- a/experimental/adaptive-tool/package.json
+++ b/experimental/adaptive-tool/package.json
@@ -224,7 +224,6 @@
         "test": "sh ./scripts/e2e.sh"
     },
     "devDependencies": {
-        "@types/mocha": "^7.0.2",
         "@types/node": "^13.9.3",
         "@types/vscode": "^1.38.0",
         "@typescript-eslint/eslint-plugin": "^3.4.0",

--- a/experimental/adaptive-tool/server/lg/src/providers/definition.ts
+++ b/experimental/adaptive-tool/server/lg/src/providers/definition.ts
@@ -6,12 +6,12 @@ import {
 	TextDocuments, Location, DefinitionParams
 } from 'vscode-languageserver';
 
-import { TemplatesStatus, TemplatesEntity } from '../templatesStatus';
+import { TemplatesStatus } from '../templatesStatus';
 import * as util from '../util';
 import * as path from 'path';
 
 import {
-	TextDocument, Position, Range, DocumentUri
+	TextDocument, Position, DocumentUri
 } from 'vscode-languageserver-textdocument';
 import { Templates, Template } from 'botbuilder-lg';
 

--- a/experimental/adaptive-tool/server/lg/src/providers/hover.ts
+++ b/experimental/adaptive-tool/server/lg/src/providers/hover.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /**
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
@@ -40,4 +42,6 @@ export function provideHover(params: HoverParams, documents: TextDocuments<TextD
 		
 		return {contents, wordRange};
 	}
+	
+	return undefined;
 }

--- a/experimental/adaptive-tool/server/lg/src/server.ts
+++ b/experimental/adaptive-tool/server/lg/src/server.ts
@@ -14,7 +14,6 @@ import {
 	ProposedFeatures,
 	InitializeParams,
 	DidChangeConfigurationNotification,
-	CompletionItem,
 	TextDocumentPositionParams,
 	TextDocumentSyncKind,
 	InitializeResult,
@@ -50,7 +49,6 @@ let workspaceFolders: WorkspaceFolder[] | null | undefined;
 
 let hasConfigurationCapability = false;
 let hasWorkspaceFolderCapability = false;
-let hasDiagnosticRelatedInformationCapability = false;
 let hasDidChangeWatchedFilesCapability = false;
 
 
@@ -66,11 +64,6 @@ connection.onInitialize((params: InitializeParams) => {
 	);
 	hasWorkspaceFolderCapability = !!(
 		capabilities.workspace && !!capabilities.workspace.workspaceFolders
-	);
-	hasDiagnosticRelatedInformationCapability = !!(
-		capabilities.textDocument &&
-		capabilities.textDocument.publishDiagnostics &&
-		capabilities.textDocument.publishDiagnostics.relatedInformation
 	);
 	hasDidChangeWatchedFilesCapability = !!(
 		capabilities.workspace && !! capabilities.workspace.didChangeWatchedFiles?.dynamicRegistration
@@ -135,24 +128,14 @@ interface LgSettings {
 	maxNumberOfProblems: number;
 }
 
-// The global settings, used when the `workspace/configuration` request is not supported by the client.
-// Please note that this is not the case when using this server with the client provided in this example
-// but could happen with other clients.
-const defaultSettings: LgSettings = { maxNumberOfProblems: 1000 };
-let globalSettings: LgSettings = defaultSettings;
-
 // Cache the settings of all open documents
 const documentSettings: Map<string, Thenable<LgSettings>> = new Map();
 
 
-connection.onDidChangeConfiguration(change => {
+connection.onDidChangeConfiguration(() => {
 	if (hasConfigurationCapability) {
 		// Reset all cached document settings
 		documentSettings.clear();
-	} else {
-		globalSettings = <LgSettings>(
-			(change.settings.languageServerExample || defaultSettings)
-		);
 	}
 
 	// To update templatestatus with only open text documents

--- a/experimental/adaptive-tool/server/tsconfig.json
+++ b/experimental/adaptive-tool/server/tsconfig.json
@@ -1,15 +1,18 @@
 {
+	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
-		"target": "es6",
-		"lib": ["es2015", "dom"],
+		"target": "es2017",
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"sourceMap": true,
-		"strict": true,
 		"outDir": "out",
-		"rootDir": "./",
-		"composite": true
+		"rootDir": "src",
+		"lib": [ "es2017" ]
 	},
-	"include": ["./lg/src"],
-	"exclude": ["node_modules", ".vscode-test"]
+	"include": [
+		"src"
+	],
+	"exclude": [
+		"node_modules"
+	]
 }

--- a/experimental/adaptive-tool/server/tsconfig.json
+++ b/experimental/adaptive-tool/server/tsconfig.json
@@ -6,11 +6,11 @@
 		"moduleResolution": "node",
 		"sourceMap": true,
 		"outDir": "out",
-		"rootDir": "src",
+		"rootDir": "lg/src",
 		"lib": [ "es2017" ]
 	},
 	"include": [
-		"src"
+		"lg/src"
 	],
 	"exclude": [
 		"node_modules"

--- a/experimental/adaptive-tool/server/webpack.config.js
+++ b/experimental/adaptive-tool/server/webpack.config.js
@@ -1,0 +1,23 @@
+  
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//@ts-check
+
+'use strict';
+
+const withDefaults = require('../shared.webpack.config');
+const path = require('path');
+
+module.exports = withDefaults({
+	context: path.join(__dirname),
+	entry: {
+		extension: './lg/src/server.ts',
+	},
+	output: {
+		filename: 'server.js',
+		path: path.join(__dirname, 'out')
+	}
+});

--- a/experimental/adaptive-tool/shared.webpack.config.js
+++ b/experimental/adaptive-tool/shared.webpack.config.js
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//@ts-check
+/** @typedef {import('webpack').Configuration} WebpackConfig **/
+
+'use strict';
+
+const path = require('path');
+const merge = require('merge-options');
+
+module.exports = function withDefaults(/**@type WebpackConfig*/extConfig) {
+
+	/** @type WebpackConfig */
+	let defaultConfig = {
+		mode: 'none', // this leaves the source code as close as possible to the original (when packaging we set this to 'production')
+		target: 'node', // extensions run in a node context
+		node: {
+			__dirname: false // leave the __dirname-behaviour intact
+		},
+		resolve: {
+			mainFields: ['module', 'main'],
+			extensions: ['.ts', '.js'] // support ts-files and js-files
+		},
+		module: {
+			rules: [{
+				test: /\.ts$/,
+				exclude: /node_modules/,
+				use: [{
+					// configure TypeScript loader:
+					// * enable sources maps for end-to-end source maps
+					loader: 'ts-loader',
+					options: {
+						compilerOptions: {
+							"sourceMap": true,
+						}
+					}
+				}]
+			}]
+		},
+		externals: {
+			'vscode': 'commonjs vscode', // ignored because it doesn't exist
+		},
+		output: {
+			// all output goes into `dist`.
+			// packaging depends on that and this must always be like it
+			filename: '[name].js',
+			path: path.join(extConfig.context, 'out'),
+			libraryTarget: "commonjs",
+		},
+		// yes, really source maps
+		devtool: 'source-map'
+	};
+
+	return merge(defaultConfig, extConfig);
+};

--- a/experimental/adaptive-tool/tsconfig.base.json
+++ b/experimental/adaptive-tool/tsconfig.base.json
@@ -1,0 +1,9 @@
+{
+	"compilerOptions": {
+		"noImplicitAny": true,
+		"noImplicitReturns": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"strict": true
+	}
+}

--- a/experimental/adaptive-tool/tsconfig.json
+++ b/experimental/adaptive-tool/tsconfig.json
@@ -1,15 +1,18 @@
 {
+	"extends": "./tsconfig.base.json",
 	"compilerOptions": {
 		"module": "commonjs",
 		"target": "es6",
-		"lib": ["es2015", "dom"]
+		"outDir": "out",
+		"rootDir": "src",
+		"lib": [ "es6" ],
+		"sourceMap": true
 	},
 	"include": [
 		"src"
 	],
 	"exclude": [
-		"node_modules",
-		".vscode-test"
+		"node_modules"
 	],
 	"references": [
 		{ "path": "./client" },


### PR DESCRIPTION
Fixes #2589
1. Use webpack to bundling the LG extension code, to shrink the size of the package

2. Use `.vscodeignore` file to ignore the other files except for the bundling dist file and other resource files.

> After step 1, and 2, the package size dropped from 7.2M to 2.1M

3. Replace the relative path of images in README with absolute url path, to make sure they can be poped normally in any case.

![Capture](https://user-images.githubusercontent.com/7289268/87379077-f8b20e00-c5c1-11ea-9758-ad105d68a550.PNG)
