### PR TITLE
Fix the issue that IncludeImage doesn't work in Microsoft Teams messa…

### DIFF
--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Bots/TeamsMessagingExtensionsActionBot.cs
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Bots/TeamsMessagingExtensionsActionBot.cs
@@ -80,7 +80,7 @@ namespace Microsoft.BotBuilderSamples.Bots
             // This Messaging Extension example allows the user to check a box to include an image with the
             // shared message.  This demonstrates sending custom parameters along with the message payload.
             var includeImage = ((JObject)action.Data)["includeImage"]?.ToString();
-            if (!string.IsNullOrEmpty(includeImage) && bool.TrueString == includeImage)
+            if (string.Equals(includeImage, bool.TrueString, StringComparison.OrdinalIgnoreCase))
             {
                 heroCard.Images = new List<CardImage>
                 {


### PR DESCRIPTION
…ge extension action sample.

Fixes #2621

## Proposed Changes
Compare two strings by ignoring case.

## Testing
After this fix, the image is included in the returned HeroCard.
![3](https://user-images.githubusercontent.com/11691919/88477173-522a1d80-cf70-11ea-984a-8adeecd59321.png)
