### PR TITLE
Zerryth/dotenv before bot

### DIFF
--- a/samples/javascript_nodejs/03.welcome-users/index.js
+++ b/samples/javascript_nodejs/03.welcome-users/index.js
@@ -3,6 +3,11 @@
 
 // Import required packages
 const path = require('path');
+
+// Read botFilePath and botFileSecret from .env file
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -10,10 +15,6 @@ const restify = require('restify');
 const { BotFrameworkAdapter, UserState, MemoryStorage } = require('botbuilder');
 
 const { WelcomeBot } = require('./bots/welcomeBot');
-
-// Read botFilePath and botFileSecret from .env file
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create bot adapter.
 // See https://aka.ms/about-bot-adapter to learn more about bot adapter.

--- a/samples/javascript_nodejs/05.multi-turn-prompt/index.js
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/index.js
@@ -4,6 +4,10 @@
 const restify = require('restify');
 const path = require('path');
 
+// Read environment variables from .env file
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
 const { BotFrameworkAdapter, ConversationState, MemoryStorage, UserState } = require('botbuilder');
@@ -11,10 +15,6 @@ const { BotFrameworkAdapter, ConversationState, MemoryStorage, UserState } = req
 // Import our custom bot class that provides a turn handling function.
 const { DialogBot } = require('./bots/dialogBot');
 const { UserProfileDialog } = require('./dialogs/userProfileDialog');
-
-// Read environment variables from .env file
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create the adapter. See https://aka.ms/about-bot-adapter to learn more about using information from
 // the .bot file when configuring your adapter.

--- a/samples/javascript_nodejs/06.using-cards/index.js
+++ b/samples/javascript_nodejs/06.using-cards/index.js
@@ -5,6 +5,9 @@
 
 // Import required packages
 const path = require('path');
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -14,9 +17,6 @@ const { BotFrameworkAdapter, MemoryStorage, ConversationState, UserState } = req
 // This bot's main dialog.
 const { RichCardsBot } = require('./bots/richCardsBot');
 const { MainDialog } = require('./dialogs/mainDialog');
-
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter. See https://aka.ms/about-bot-adapter to learn more about adapters.
 const adapter = new BotFrameworkAdapter({

--- a/samples/javascript_nodejs/07.using-adaptive-cards/index.js
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/index.js
@@ -2,6 +2,11 @@
 // Licensed under the MIT License.
 
 const path = require('path');
+
+// Read botFilePath and botFileSecret from .env file.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -9,10 +14,6 @@ const restify = require('restify');
 const { BotFrameworkAdapter } = require('botbuilder');
 
 const { AdaptiveCardsBot } = require('./bots/adaptiveCardsBot');
-
-// Read botFilePath and botFileSecret from .env file.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter. See https://aka.ms/about-bot-adapter to learn more about adapters.
 const adapter = new BotFrameworkAdapter({

--- a/samples/javascript_nodejs/08.suggested-actions/index.js
+++ b/samples/javascript_nodejs/08.suggested-actions/index.js
@@ -2,6 +2,11 @@
 // Licensed under the MIT License.
 
 const path = require('path');
+
+// Read botFilePath and botFileSecret from .env file.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -9,10 +14,6 @@ const restify = require('restify');
 const { BotFrameworkAdapter } = require('botbuilder');
 
 const { SuggestedActionsBot } = require('./bots/suggestedActionsBot');
-
-// Read botFilePath and botFileSecret from .env file.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter. See https://aka.ms/about-bot-adapter to learn more about adapters.
 const adapter = new BotFrameworkAdapter({

--- a/samples/javascript_nodejs/11.qnamaker/index.js
+++ b/samples/javascript_nodejs/11.qnamaker/index.js
@@ -5,6 +5,11 @@
 
 // Import required packages
 const path = require('path');
+
+// Note: Ensure you have a .env file and include QnAMakerKnowledgeBaseId, QnAMakerEndpointKey and QnAMakerHost.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -14,10 +19,6 @@ const { ActivityTypes } = require('botbuilder-core');
 
 // The bot.
 const { QnABot } = require('./bots/QnABot');
-
-// Note: Ensure you have a .env file and include QnAMakerKnowledgeBaseId, QnAMakerEndpointKey and QnAMakerHost.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.

--- a/samples/javascript_nodejs/14.nlp-with-dispatch/index.js
+++ b/samples/javascript_nodejs/14.nlp-with-dispatch/index.js
@@ -5,6 +5,11 @@
 
 // Import required packages
 const path = require('path');
+
+// Note: Ensure you have a .env file and include all necessary credentials to access services like LUIS and QnAMaker.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -12,10 +17,6 @@ const restify = require('restify');
 const { BotFrameworkAdapter } = require('botbuilder');
 
 const { DispatchBot } = require('./bots/dispatchBot');
-
-// Note: Ensure you have a .env file and include all necessary credentials to access services like LUIS and QnAMaker.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more.

--- a/samples/javascript_nodejs/15.handling-attachments/index.js
+++ b/samples/javascript_nodejs/15.handling-attachments/index.js
@@ -2,6 +2,11 @@
 // Licensed under the MIT License.
 
 const path = require('path');
+
+// Read botFilePath and botFileSecret from .env file.
+const ENV_FILE = path.join(__dirname, './.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -9,10 +14,6 @@ const restify = require('restify');
 const { BotFrameworkAdapter } = require('botbuilder');
 
 const { AttachmentsBot } = require('./bots/attachmentsBot');
-
-// Read botFilePath and botFileSecret from .env file.
-const ENV_FILE = path.join(__dirname, './.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter. See https://aka.ms/about-bot-adapter to learn more about adapters.
 const adapter = new BotFrameworkAdapter({

--- a/samples/javascript_nodejs/16.proactive-messages/index.js
+++ b/samples/javascript_nodejs/16.proactive-messages/index.js
@@ -5,6 +5,11 @@
 
 // Import required packages
 const path = require('path');
+
+// Note: Ensure you have a .env file and include the MicrosoftAppId and MicrosoftAppPassword.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -13,10 +18,6 @@ const { BotFrameworkAdapter } = require('botbuilder');
 
 // This bot's main dialog.
 const { ProactiveBot } = require('./bots/proactiveBot');
-
-// Note: Ensure you have a .env file and include the MicrosoftAppId and MicrosoftAppPassword.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.

--- a/samples/javascript_nodejs/17.multilingual-bot/index.js
+++ b/samples/javascript_nodejs/17.multilingual-bot/index.js
@@ -5,6 +5,11 @@
 
 // Import required packages.
 const path = require('path');
+
+// Note: Ensure you have a .env file and include translatorKey.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 const { MicrosoftTranslator } = require('./translation/microsoftTranslator');
 const { TranslatorMiddleware } = require('./translation/translatorMiddleware');
@@ -15,10 +20,6 @@ const { BotFrameworkAdapter, MemoryStorage, UserState, ActivityTypes, TurnContex
 
 // This bot's main dialog.
 const { MultilingualBot } = require('./bots/multilingualBot');
-
-// Note: Ensure you have a .env file and include translatorKey.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Used to create the BotStatePropertyAccessor for storing the user's language preference.
 const LANGUAGE_PREFERENCE = 'language_preference';

--- a/samples/javascript_nodejs/18.bot-authentication/index.js
+++ b/samples/javascript_nodejs/18.bot-authentication/index.js
@@ -5,6 +5,11 @@
 
 // Import required pckages
 const path = require('path');
+
+// Read botFilePath and botFileSecret from .env file.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -13,10 +18,6 @@ const { BotFrameworkAdapter, ConversationState, MemoryStorage, UserState } = req
 
 const { AuthBot } = require('./bots/authBot');
 const { MainDialog } = require('./dialogs/mainDialog');
-
-// Read botFilePath and botFileSecret from .env file.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.

--- a/samples/javascript_nodejs/19.custom-dialogs/index.js
+++ b/samples/javascript_nodejs/19.custom-dialogs/index.js
@@ -4,16 +4,16 @@
 const restify = require('restify');
 const path = require('path');
 
+// Read botFilePath and botFileSecret from .env file.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
 const { BotFrameworkAdapter, ConversationState, MemoryStorage, UserState } = require('botbuilder');
 
 const { DialogBot } = require('./bots/dialogBot');
 const { RootDialog } = require('./dialogs/rootDialog');
-
-// Read botFilePath and botFileSecret from .env file.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create HTTP server.
 const server = restify.createServer();

--- a/samples/javascript_nodejs/21.corebot-app-insights/index.js
+++ b/samples/javascript_nodejs/21.corebot-app-insights/index.js
@@ -5,6 +5,11 @@
 
 // Import required packages
 const path = require('path');
+
+// Note: Ensure you have a .env file and include LuisAppId, LuisAPIKey and LuisAPIHostName.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required services for bot telemetry
@@ -22,10 +27,6 @@ const { MainDialog } = require('./dialogs/mainDialog');
 // the bot's booking dialog
 const { BookingDialog } = require('./dialogs/bookingDialog');
 const BOOKING_DIALOG = 'bookingDialog';
-
-// Note: Ensure you have a .env file and include LuisAppId, LuisAPIKey and LuisAPIHostName.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.

--- a/samples/javascript_nodejs/23.facebook-events/index.js
+++ b/samples/javascript_nodejs/23.facebook-events/index.js
@@ -5,6 +5,11 @@
 
 // Import required packages
 const path = require('path');
+
+// Note: Ensure that you have a MicrosoftAppId and MicrosoftAppPassword added to the .env file.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -12,10 +17,6 @@ const restify = require('restify');
 const { BotFrameworkAdapter } = require('botbuilder');
 
 const { FacebookBot } = require('./bots/facebookBot');
-
-// Note: Ensure that you have a MicrosoftAppId and MicrosoftAppPassword added to the .env file.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/index.js
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/index.js
@@ -2,6 +2,12 @@
 // Licensed under the MIT License.
 
 const restify = require('restify');
+
+// Note: Ensure you have a .env file and include MicrosoftAppId and MicrosoftAppPassword.
+// This MicrosoftApp should have OAuth enabled.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const path = require('path');
 
 // Import required bot services.
@@ -10,11 +16,6 @@ const { BotFrameworkAdapter, ConversationState, MemoryStorage, UserState } = req
 
 const { AuthBot } = require('./bots/authBot');
 const { MainDialog } = require('./dialogs/mainDialog');
-
-// Note: Ensure you have a .env file and include MicrosoftAppId and MicrosoftAppPassword.
-// This MicrosoftApp should have OAuth enabled.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create the adapter. See https://aka.ms/about-bot-adapter to learn more adapters.
 const adapter = new BotFrameworkAdapter({

--- a/samples/javascript_nodejs/25.message-reaction/index.js
+++ b/samples/javascript_nodejs/25.message-reaction/index.js
@@ -5,6 +5,11 @@
 
 // Import required pckages
 const path = require('path');
+
+// Read botFilePath and botFileSecret from .env file.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -13,10 +18,6 @@ const { BotFrameworkAdapter, MemoryStorage } = require('botbuilder');
 
 const { ActivityLog } = require('./activityLog');
 const { MessageReactionBot } = require('./bots/messageReactionBot');
-
-// Read botFilePath and botFileSecret from .env file.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.

--- a/samples/javascript_nodejs/43.complex-dialog/index.js
+++ b/samples/javascript_nodejs/43.complex-dialog/index.js
@@ -2,6 +2,11 @@
 // Licensed under the MIT License.
 
 const path = require('path');
+
+// Read environment variables from .env file
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -10,10 +15,6 @@ const { BotFrameworkAdapter, MemoryStorage, UserState, ConversationState } = req
 
 const { DialogAndWelcomeBot } = require('./bots/dialogAndWelcomeBot');
 const { MainDialog } = require('./dialogs/mainDialog');
-
-// Read environment variables from .env file
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create HTTP server
 const server = restify.createServer();

--- a/samples/javascript_nodejs/44.prompt-for-user-input/index.js
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/index.js
@@ -2,6 +2,11 @@
 // Licensed under the MIT License.
 
 const path = require('path');
+
+// Read environment variables from .env file
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -10,10 +15,6 @@ const { BotFrameworkAdapter, MemoryStorage, ConversationState, UserState } = req
 
 // This bot's main dialog.
 const { CustomPromptBot } = require('./bots/customPromptBot');
-
-// Read environment variables from .env file
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create HTTP server
 const server = restify.createServer();

--- a/samples/javascript_nodejs/45.state-management/index.js
+++ b/samples/javascript_nodejs/45.state-management/index.js
@@ -2,6 +2,11 @@
 // Licensed under the MIT License.
 
 const path = require('path');
+
+// Read environment variables from .env file
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -10,10 +15,6 @@ const { BotFrameworkAdapter, MemoryStorage, ConversationState, UserState } = req
 
 // This bot's main dialog.
 const { StateManagementBot } = require('./bots/stateManagementBot');
-
-// Read environment variables from .env file
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create HTTP server
 const server = restify.createServer();

--- a/samples/javascript_nodejs/46.teams-auth/index.js
+++ b/samples/javascript_nodejs/46.teams-auth/index.js
@@ -5,6 +5,11 @@
 
 // Import required pckages
 const path = require('path');
+
+// Read botFilePath and botFileSecret from .env file.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -13,10 +18,6 @@ const { BotFrameworkAdapter, ConversationState, MemoryStorage, UserState } = req
 
 const { TeamsBot } = require('./bots/teamsBot');
 const { MainDialog } = require('./dialogs/mainDialog');
-
-// Read botFilePath and botFileSecret from .env file.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.

--- a/samples/javascript_nodejs/47.inspection/index.js
+++ b/samples/javascript_nodejs/47.inspection/index.js
@@ -3,6 +3,11 @@
 
 const dotenv = require('dotenv');
 const path = require('path');
+
+// Import required bot configuration.
+const ENV_FILE = path.join(__dirname, '.env');
+dotenv.config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -13,10 +18,6 @@ const { MicrosoftAppCredentials } = require('botframework-connector');
 
 // This bot's main dialog.
 const { IntersectionBot } = require('./bot');
-
-// Import required bot configuration.
-const ENV_FILE = path.join(__dirname, '.env');
-dotenv.config({ path: ENV_FILE });
 
 // Create HTTP server
 const server = restify.createServer();

--- a/samples/javascript_nodejs/49.qnamaker-all-features/index.js
+++ b/samples/javascript_nodejs/49.qnamaker-all-features/index.js
@@ -5,6 +5,11 @@
 
 // Import required packages
 const path = require('path');
+
+// Note: Ensure you have a .env file and include QnAMakerKnowledgeBaseId, QnAMakerEndpointKey and QnAMakerHost.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services. See https://aka.ms/bot-services to learn more about the different parts of a bot.
@@ -12,10 +17,6 @@ const { BotFrameworkAdapter, ConversationState, MemoryStorage, UserState } = req
 
 const { QnABot } = require('./bots/QnABot');
 const { RootDialog } = require('./dialogs/rootDialog');
-
-// Note: Ensure you have a .env file and include QnAMakerKnowledgeBaseId, QnAMakerEndpointKey and QnAMakerHost.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create HTTP server.
 const server = restify.createServer();

--- a/samples/javascript_nodejs/50.teams-messaging-extensions-search/index.js
+++ b/samples/javascript_nodejs/50.teams-messaging-extensions-search/index.js
@@ -5,6 +5,11 @@
 
 // Import required pckages
 const path = require('path');
+
+// Read botFilePath and botFileSecret from .env file.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -12,10 +17,6 @@ const restify = require('restify');
 const { BotFrameworkAdapter } = require('botbuilder');
 
 const { TeamsMessagingExtensionsSearchBot } = require('./bots/teamsMessagingExtensionsSearchBot');
-
-// Read botFilePath and botFileSecret from .env file.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.

--- a/samples/javascript_nodejs/51.teams-messaging-extensions-action/index.js
+++ b/samples/javascript_nodejs/51.teams-messaging-extensions-action/index.js
@@ -5,16 +5,17 @@
 
 // Import required pckages
 const path = require('path');
+
+// Read botFilePath and botFileSecret from .env file.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
 const { BotFrameworkAdapter } = require('botbuilder');
 const { TeamsMessagingExtensionsActionBot } = require('./bots/teamsMessagingExtensionsActionBot');
-
-// Read botFilePath and botFileSecret from .env file.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.

--- a/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/index.js
+++ b/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/index.js
@@ -5,16 +5,17 @@
 
 // Import required pckages
 const path = require('path');
+
+// Read botFilePath and botFileSecret from .env file.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
 const { BotFrameworkAdapter, UserState, MemoryStorage } = require('botbuilder');
 const { TeamsMessagingExtensionsSearchAuthConfigBot } = require('./bots/teamsMessagingExtensionsSearchAuthConfigBot');
-
-// Read botFilePath and botFileSecret from .env file.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.

--- a/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/index.js
+++ b/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/index.js
@@ -5,16 +5,17 @@
 
 // Import required pckages
 const path = require('path');
+
+// Read botFilePath and botFileSecret from .env file.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
 const { BotFrameworkAdapter } = require('botbuilder');
 const { TeamsMessagingExtensionsActionPreviewBot } = require('./bots/teamsMessagingExtensionsActionPreviewBot');
-
-// Read botFilePath and botFileSecret from .env file.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.

--- a/samples/javascript_nodejs/54.teams-task-module/index.js
+++ b/samples/javascript_nodejs/54.teams-task-module/index.js
@@ -5,16 +5,17 @@
 
 // Import required pckages
 const path = require('path');
+
+// Read botFilePath and botFileSecret from .env file.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
 const { BotFrameworkAdapter } = require('botbuilder');
 const { TeamsTaskModuleBot } = require('./bots/teamsTaskModuleBot');
-
-// Read botFilePath and botFileSecret from .env file.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.

--- a/samples/javascript_nodejs/55.teams-link-unfurling/index.js
+++ b/samples/javascript_nodejs/55.teams-link-unfurling/index.js
@@ -5,6 +5,11 @@
 
 // Import required pckages
 const path = require('path');
+
+// Read botFilePath and botFileSecret from .env file.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -12,10 +17,6 @@ const restify = require('restify');
 const { BotFrameworkAdapter } = require('botbuilder');
 
 const { TeamsLinkUnfurlingBot } = require('./bots/teamsLinkUnfurlingBot');
-
-// Read botFilePath and botFileSecret from .env file.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.

--- a/samples/javascript_nodejs/56.teams-file-upload/index.js
+++ b/samples/javascript_nodejs/56.teams-file-upload/index.js
@@ -5,6 +5,11 @@
 
 // Import required pckages
 const path = require('path');
+
+// Read botFilePath and botFileSecret from .env file.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -12,10 +17,6 @@ const restify = require('restify');
 const { BotFrameworkAdapter } = require('botbuilder');
 
 const { TeamsFileUploadBot } = require('./bots/teamsFileUploadBot');
-
-// Read botFilePath and botFileSecret from .env file.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.

--- a/samples/javascript_nodejs/57.teams-conversation-bot/index.js
+++ b/samples/javascript_nodejs/57.teams-conversation-bot/index.js
@@ -5,6 +5,11 @@
 
 // Import required pckages
 const path = require('path');
+
+// Read botFilePath and botFileSecret from .env file.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -12,10 +17,6 @@ const restify = require('restify');
 const { BotFrameworkAdapter } = require('botbuilder');
 
 const { TeamsConversationBot } = require('./bots/teamsConversationBot');
-
-// Read botFilePath and botFileSecret from .env file.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.

--- a/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/index.js
+++ b/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/index.js
@@ -5,6 +5,11 @@
 
 // Import required pckages
 const path = require('path');
+
+// Read botFilePath and botFileSecret from .env file.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -12,10 +17,6 @@ const restify = require('restify');
 const { BotFrameworkAdapter } = require('botbuilder');
 
 const { TeamsStartNewThreadInChannel } = require('./bots/TeamsStartNewThreadInChannel');
-
-// Read botFilePath and botFileSecret from .env file.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/index.js
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/index.js
@@ -12,13 +12,13 @@ const restify = require('restify');
 const { ActivityTypes, BotFrameworkAdapter, ChannelServiceRoutes, ConversationState, InputHints, MemoryStorage, SkillHandler, SkillHttpClient, TurnContext } = require('botbuilder');
 const { AuthenticationConfiguration, SimpleCredentialProvider } = require('botframework-connector');
 
-// This bot's main dialog.
-const { RootBot } = require('./bots/rootBot');
-const { MainDialog } = require('./dialogs/mainDialog');
-
 // Note: Ensure you have a .env file and include LuisAppId, LuisAPIKey and LuisAPIHostName.
 const ENV_FILE = path.join(__dirname, '.env');
 require('dotenv').config({ path: ENV_FILE });
+
+// This bot's main dialog.
+const { RootBot } = require('./bots/rootBot');
+const { MainDialog } = require('./dialogs/mainDialog');
 
 // Import Skills modules.
 const { allowedSkillsClaimsValidator } = require('./authentication/allowedSkillsClaimsValidator');

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/index.js
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/index.js
@@ -5,6 +5,11 @@
 
 // Import required packages.
 const path = require('path');
+
+// Note: Ensure you have a .env file and include LuisAppId, LuisAPIKey and LuisAPIHostName.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 
 // Import required bot services.
@@ -16,10 +21,6 @@ const { AuthenticationConfiguration } = require('botframework-connector');
 const { SkillBot } = require('./bots/skillBot');
 const { ActivityRouterDialog } = require('./dialogs/activityRouterDialog');
 const { FlightBookingRecognizer } = require('./dialogs/flightBookingRecognizer');
-
-// Note: Ensure you have a .env file and include LuisAppId, LuisAPIKey and LuisAPIHostName.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Import Skills modules.
 const { allowedSkillsClaimsValidator: allowedCallersClaimsValidator } = require('./authentication/allowedCallersClaimsValidator');

--- a/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/index.js
+++ b/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/index.js
@@ -3,6 +3,11 @@
 
 const restify = require('restify');
 const path = require('path');
+
+// Read environment variables from .env file
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const { Templates, MultiLanguageLG } = require('botbuilder-lg');
 
 // Import required bot services.
@@ -12,10 +17,6 @@ const { BotFrameworkAdapter, ConversationState, MemoryStorage, UserState, Activi
 // Import our custom bot class that provides a turn handling function.
 const { DialogBot } = require('./bots/dialogBot');
 const { UserProfileDialog } = require('./dialogs/userProfileDialog');
-
-// Read environment variables from .env file
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create the adapter. See https://aka.ms/about-bot-adapter to learn more about using information from
 // the .bot file when configuring your adapter.

--- a/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/index.js
+++ b/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/index.js
@@ -3,6 +3,11 @@
 
 const restify = require('restify');
 const path = require('path');
+
+// Read environment variables from .env file
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const { Templates } = require('botbuilder-lg');
 
 // Import required bot services.
@@ -12,10 +17,6 @@ const { BotFrameworkAdapter, ConversationState, MemoryStorage, UserState } = req
 // Import our custom bot class that provides a turn handling function.
 const { DialogBot } = require('./bots/dialogBot');
 const { UserProfileDialog } = require('./dialogs/userProfileDialog');
-
-// Read environment variables from .env file
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create the adapter. See https://aka.ms/about-bot-adapter to learn more about using information from
 // the .bot file when configuring your adapter.

--- a/samples/javascript_nodejs/language-generation/06.using-cards/index.js
+++ b/samples/javascript_nodejs/language-generation/06.using-cards/index.js
@@ -5,6 +5,9 @@
 
 // Import required packages
 const path = require('path');
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 const { Templates } = require('botbuilder-lg');
 
@@ -15,9 +18,6 @@ const { BotFrameworkAdapter, MemoryStorage, ConversationState, UserState } = req
 // This bot's main dialog.
 const { RichCardsBot } = require('./bots/richCardsBot');
 const { MainDialog } = require('./dialogs/mainDialog');
-
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter. See https://aka.ms/about-bot-adapter to learn more about adapters.
 const adapter = new BotFrameworkAdapter({

--- a/samples/javascript_nodejs/language-generation/13.core-bot/index.js
+++ b/samples/javascript_nodejs/language-generation/13.core-bot/index.js
@@ -5,6 +5,11 @@
 
 // Import required packages
 const path = require('path');
+
+// Note: Ensure you have a .env file and include LuisAppId, LuisAPIKey and LuisAPIHostName.
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
 const restify = require('restify');
 const { Templates } = require('botbuilder-lg');
 
@@ -21,10 +26,6 @@ const { MainDialog } = require('./dialogs/mainDialog');
 // the bot's booking dialog
 const { BookingDialog } = require('./dialogs/bookingDialog');
 const BOOKING_DIALOG = 'bookingDialog';
-
-// Note: Ensure you have a .env file and include LuisAppId, LuisAPIKey and LuisAPIHostName.
-const ENV_FILE = path.join(__dirname, '.env');
-require('dotenv').config({ path: ENV_FILE });
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.

--- a/samples/javascript_nodejs/language-generation/20.custom-functions/index.js
+++ b/samples/javascript_nodejs/language-generation/20.custom-functions/index.js
@@ -3,6 +3,11 @@
 
 const dotenv = require('dotenv');
 const path = require('path');
+
+// Import required bot configuration.
+const ENV_FILE = path.join(__dirname, '.env');
+dotenv.config({ path: ENV_FILE });
+
 const restify = require('restify');
 const { Templates } = require('botbuilder-lg');
 
@@ -12,10 +17,6 @@ const { BotFrameworkAdapter } = require('botbuilder');
 
 // This bot's main dialog.
 const { EchoBot } = require('./bot');
-
-// Import required bot configuration.
-const ENV_FILE = path.join(__dirname, '.env');
-dotenv.config({ path: ENV_FILE });
 
 // Create HTTP server
 const server = restify.createServer();


### PR DESCRIPTION
Fixes #2405 

## Proposed Changes
- Moved loading dotenv before loading bot, because in certain scenarios, bot can break when trying to access environment variables that haven't been loaded yet.
- Original issue: #2374 
- In R9, these changes were already carried into echo and core bots. R10 we are proliferating these changes across the rest of the Node samples to realign them