### PR TITLE
Fixed #2637: Directory separator char no longer hard-coded

### DIFF
--- a/samples/csharp_dotnetcore/15.handling-attachments/Bots/AttachmentsBot.cs
+++ b/samples/csharp_dotnetcore/15.handling-attachments/Bots/AttachmentsBot.cs
@@ -166,7 +166,7 @@ namespace Microsoft.BotBuilderSamples
         // Please consult the channel documentation for specifics.
         private static Attachment GetInlineAttachment()
         {
-            var imagePath = Path.Combine(Environment.CurrentDirectory, @"Resources\architecture-resize.png");
+            var imagePath = Path.Combine(Environment.CurrentDirectory, @"Resources", "architecture-resize.png");
             var imageData = Convert.ToBase64String(File.ReadAllBytes(imagePath));
 
             return new Attachment
@@ -190,7 +190,7 @@ namespace Microsoft.BotBuilderSamples
                 throw new ArgumentNullException(nameof(conversationId));
             }
 
-            var imagePath = Path.Combine(Environment.CurrentDirectory, @"Resources\architecture-resize.png");
+            var imagePath = Path.Combine(Environment.CurrentDirectory, @"Resources", "architecture-resize.png");
 
             var connector = turnContext.TurnState.Get<IConnectorClient>() as ConnectorClient;
             var attachments = new Attachments(connector);


### PR DESCRIPTION
Fixes #2637 

## Proposed Changes
.NET sample no. 15 didn't work on macOS because the backward slash is hard-coded as a directory separator. This pull request fixes the issue on macOS. 

I haven't tried any other samples or systems.