### PR TITLE
Add "luis_schema_version" to Weather.json in both C# and JS samples of 14.nlp-with-dispatch

### DIFF
--- a/samples/csharp_dotnetcore/14.nlp-with-dispatch/CognitiveModels/Weather.json
+++ b/samples/csharp_dotnetcore/14.nlp-with-dispatch/CognitiveModels/Weather.json
@@ -1,4 +1,5 @@
 {
+  "luis_schema_version": "3.2.0",
   "name": "Weather",
   "versionId": "0.1",
   "desc": "Weather LUIS application - Bot Builder Samples",

--- a/samples/javascript_nodejs/14.nlp-with-dispatch/cognitiveModels/Weather.json
+++ b/samples/javascript_nodejs/14.nlp-with-dispatch/cognitiveModels/Weather.json
@@ -1,4 +1,5 @@
 {
+  "luis_schema_version": "3.2.0",
   "name": "Weather",
   "versionId": "0.1",
   "desc": "Weather LUIS application - Bot Builder Samples",


### PR DESCRIPTION
Fixes #2649 
Added  luis_schema_version to Weather.json for both C# and JS samples 

## Proposed Changes
The Weather.json file in the CognitiveModels folder does not contain the luis_schema_version and hence is throwing up this error "BadArgument: Invalid luis schema version. Failed to parse application json." when you try to import Weather.json.


