### PR TITLE
Resolved multiple values for keyword TypeError

### DIFF
--- a/samples/python/54.teams-task-module/bots/teams_task_module_bot.py
+++ b/samples/python/54.teams-task-module/bots/teams_task_module_bot.py
@@ -55,7 +55,7 @@ class TeamsTaskModuleBot(TeamsActivityHandler):
         task_info = TaskModuleTaskInfo(
             card=card, title="Adaptive Card: Inputs", height=200, width=400
         )
-        continue_response = TaskModuleContinueResponse(type="continue", value=task_info)
+        continue_response = TaskModuleContinueResponse(value=task_info)
         return TaskModuleResponse(task=continue_response)
 
     async def on_teams_task_module_submit(
@@ -67,7 +67,7 @@ class TeamsTaskModuleBot(TeamsActivityHandler):
             )
         )
 
-        message_response = TaskModuleMessageResponse(type="message", value="Thanks!")
+        message_response = TaskModuleMessageResponse(value="Thanks!")
         return TaskModuleResponse(task=message_response)
 
     def _get_task_module_hero_card(self) -> Attachment:


### PR DESCRIPTION
Fixes #2640 in Python sample 54. Task Module
The functions TaskModuleMessageResponse & TaskModuleContinueResponse in teams_task_module_bot.py were giving multiple values for type argument which is already defined in the base/core functions (i.e  TaskModuleMessageResponse & TaskModuleContinueResponse in botbuilder.schema.teams). Due to their error the task-module popup card was showing a TypeError and was unable to be displayed properly.

Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->
<!-- If you are introducing a new sample, make sure that the sample adheres to sample guidelines -->

  - Removed type parameter of **TaskModuleMessageResponse** in teams_task_module_bot.py from `(type="message",value=task_info)` to `(value=task_info)` as the base/core function of TaskModuleMessageResponse already had type="message" as parameter thereby producing a multiple values for keyword 'type'
  - Similarly, removed type parameter of **TaskModuleContinueResponse** which already had `type="continue"` in its base/core function

<img src="https://user-images.githubusercontent.com/60312540/90982095-8a7a4700-e582-11ea-85a8-65fccf7e0e3a.JPG" alt="teams_task_module_error" height=200px>
<img src="https://user-images.githubusercontent.com/60312540/90982097-8fd79180-e582-11ea-81f0-5bc240a5c7e6.JPG" alt="vscode_error" height=100px>
<img src="https://user-images.githubusercontent.com/60312540/90982103-95cd7280-e582-11ea-82fd-f9baa7a040d6.JPG" alt="task_module" height=300px>
<img src="https://user-images.githubusercontent.com/60312540/90982105-97973600-e582-11ea-8d66-fa2bd151790a.JPG" alt="fixed_task_module" height=300px>

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->