### PR TITLE
Update qnamakerBaseDialog.js

### DIFF
--- a/samples/javascript_nodejs/49.qnamaker-all-features/dialogs/qnamakerBaseDialog.js
+++ b/samples/javascript_nodejs/49.qnamaker-all-features/dialogs/qnamakerBaseDialog.js
@@ -28,7 +28,7 @@ class QnAMakerBaseDialog extends QnAMakerDialog {
      * @param {QnAMaker} qnaService A QnAMaker service object.
      */
     constructor(knowledgebaseId, authkey, host) {
-        var noAnswer = ActivityFactory.DefaultNoAnswer;
+        var noAnswer = ActivityFactory.fromObject(DefaultNoAnswer);
         var filters = [];
         super(knowledgebaseId, authkey, host, noAnswer, DefaultThreshold, DefaultCardTitle, DefaultCardNoMatchText,
             DefaultTopN, ActivityFactory.cardNoMatchResponse, filters, QNAMAKER_BASE_DIALOG);


### PR DESCRIPTION
Fixes #2588

## Proposed Changes
This is to fix sample so that DefaultNoAnswer constant is actually used by bot.

# How it works -
Editing the bot code via App-Service-Editor

Change Line 15 - 
`const DefaultNoAnswer = 'No QnAMaker answers found.';`
to 
`const DefaultNoAnswer = 'Bot does not know the answer to your question.';`
Below has been the result. The change did not reflect.

![image](https://user-images.githubusercontent.com/53164851/90617685-9dacb000-e22c-11ea-8655-dd40429d53c2.png)

After the change in this PR, change in const value is reflected in bot response.

![image](https://user-images.githubusercontent.com/53164851/90617847-cfbe1200-e22c-11ea-823c-271b15d3dd57.png)

## Testing
Not a new sample or new feature 