### PR TITLE
Corrected missing text property on msg object

### DIFF
--- a/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/Dialogs/UserProfileDialog.cs
+++ b/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/Dialogs/UserProfileDialog.cs
@@ -76,7 +76,7 @@ namespace Microsoft.BotBuilderSamples
 
             // We can send messages to the user at any point in the WaterfallStep.
             await stepContext.Context.SendActivityAsync(ActivityFactory.FromObject(_lgGenerator.Generate("AckName", new {
-                Result = stepContext.Result
+                stepContext.Result
             }, stepContext.Context.Activity.Locale)), cancellationToken);
 
             // WaterfallStep always finishes with the end of the Waterfall or with another dialog; here it is a Prompt Dialog.

--- a/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/Dialogs/UserProfileDialog.cs
+++ b/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/Dialogs/UserProfileDialog.cs
@@ -116,7 +116,7 @@ namespace Microsoft.BotBuilderSamples
             }, stepContext.Context.Activity.Locale));
 
             // We can send messages to the user at any point in the WaterfallStep.
-            await stepContext.Context.SendActivityAsync(ActivityFactory.FromObject(msg.ToString()), cancellationToken);
+            await stepContext.Context.SendActivityAsync(ActivityFactory.FromObject(msg.Text.ToString()), cancellationToken);
 
             // WaterfallStep always finishes with the end of the Waterfall or with another dialog, here it is a Prompt Dialog.
             return await stepContext.PromptAsync(nameof(ConfirmPrompt), new PromptOptions {
@@ -137,7 +137,7 @@ namespace Microsoft.BotBuilderSamples
 
                 var msg = ActivityFactory.FromObject(_lgGenerator.Generate("SummaryReadout", userProfile, stepContext.Context.Activity.Locale));
 
-                await stepContext.Context.SendActivityAsync(ActivityFactory.FromObject(msg.ToString()), cancellationToken);
+                await stepContext.Context.SendActivityAsync(ActivityFactory.FromObject(msg.Text.ToString()), cancellationToken);
             }
             else
             {

--- a/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/Dialogs/UserProfileDialog.cs
+++ b/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/Dialogs/UserProfileDialog.cs
@@ -116,7 +116,7 @@ namespace Microsoft.BotBuilderSamples
             }, stepContext.Context.Activity.Locale));
 
             // We can send messages to the user at any point in the WaterfallStep.
-            await stepContext.Context.SendActivityAsync(ActivityFactory.FromObject(msg.Text.ToString()), cancellationToken);
+            await stepContext.Context.SendActivityAsync(msg, cancellationToken);
 
             // WaterfallStep always finishes with the end of the Waterfall or with another dialog, here it is a Prompt Dialog.
             return await stepContext.PromptAsync(nameof(ConfirmPrompt), new PromptOptions {
@@ -137,7 +137,7 @@ namespace Microsoft.BotBuilderSamples
 
                 var msg = ActivityFactory.FromObject(_lgGenerator.Generate("SummaryReadout", userProfile, stepContext.Context.Activity.Locale));
 
-                await stepContext.Context.SendActivityAsync(ActivityFactory.FromObject(msg.Text.ToString()), cancellationToken);
+                await stepContext.Context.SendActivityAsync(msg, cancellationToken);
             }
             else
             {

--- a/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/Resources/UserProfileDialog.fr-fr.lg
+++ b/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/Resources/UserProfileDialog.fr-fr.lg
@@ -28,7 +28,7 @@
 > See https://aka.ms/adaptive-expressions to learn more.
 
 # AgeReadBack (userAge)
-- IF: ${userAge == null}
+- IF: ${userAge == -1}
    - Et, pas d'âge donné.
 - ELSE: 
    - Et, j'ai votre âge comme ${userAge}.

--- a/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/Resources/UserProfileDialog.lg
+++ b/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/Resources/UserProfileDialog.lg
@@ -28,7 +28,7 @@
 > See https://aka.ms/adaptive-expressions to learn more.
 
 # AgeReadBack (userAge)
-- IF: ${userAge == null}
+- IF: ${userAge == -1}
    - And, No age given.
 - ELSE: 
    - And, I have your age as ${userAge}.


### PR DESCRIPTION
## Proposed Changes
On lines 119 and 140 of UserProfileDialog.cs, the sample incorrectly passes the message object, `msg.ToString()`, as a response to a disclosed/non-disclosed age. Instead, it should pass the message's text value, `msg.Text.ToString()`.

Line 31 of UserProfileDialog.lg and UserProfileDialog.fr-fr.lg incorrectly checks for a `null` value when the user selects "No" as a response. It should check for a `-1` which is the value that is actually returned.