### PR TITLE
Remove debugger statement

### DIFF
--- a/experimental/generation/generator/packages/library/src/dialogGenerator.ts
+++ b/experimental/generation/generator/packages/library/src/dialogGenerator.ts
@@ -771,7 +771,6 @@ export async function generate(
         let startDirs = await templateDirectories(templateDirs)
         
         // Find generator.lg for schema expansion
-        debugger
         for (let dir of startDirs) {
             let loc = ppath.join(dir, '../generator.lg')
             if (await fs.pathExists(loc)) {

--- a/experimental/generation/generator/packages/library/test/generate.test.ts
+++ b/experimental/generation/generator/packages/library/test/generate.test.ts
@@ -133,7 +133,7 @@ describe('dialog:generate library', async () => {
     it('Generation with override', async () => {
         try {
             console.log('\n\nGeneration with override')
-            await gen.generate(schemaPath, undefined, output, undefined, ['en-us'], [override, 'standard'], false, false, undefined, feedback)
+            await gen.generate(schemaPath, undefined, output, undefined, ['en-us'], [override, 'template:standard'], false, false, undefined, feedback)
             let lg = await fs.readFile(ppath.join(output, 'en-us/bread', 'sandwich-Bread.en-us.lg'))
             assert.ok(lg.toString().includes('What kind of bread?'), 'Did not override locale generated file')
             let dialog = await fs.readFile(ppath.join(output, 'bread/sandwich-Bread-missing.dialog'))


### PR DESCRIPTION
A debugger statement was left in the code and the tests were not passing.