### PR TITLE
Updates NotifyController.cs _appId assignment

### DIFF
--- a/samples/csharp_dotnetcore/16.proactive-messages/Controllers/NotifyController.cs
+++ b/samples/csharp_dotnetcore/16.proactive-messages/Controllers/NotifyController.cs
@@ -26,15 +26,7 @@ namespace ProactiveBot.Controllers
         {
             _adapter = adapter;
             _conversationReferences = conversationReferences;
-            _appId = configuration["MicrosoftAppId"];
-
-            // If the channel is the Emulator, and authentication is not in use,
-            // the AppId will be null.  We generate a random AppId for this case only.
-            // This is not required for production, since the AppId will have a value.
-            if (string.IsNullOrEmpty(_appId))
-            {
-                _appId = Guid.NewGuid().ToString(); //if no AppId, use a random Guid
-            }
+            _appId = configuration["MicrosoftAppId"] ?? string.Empty;
         }
 
         public async Task<IActionResult> Get()


### PR DESCRIPTION
## Proposed Changes
This change brings the sample into parity with recent changes made to the dotnet SDK (#[4891](https://github.com/microsoft/botbuilder-dotnet/pull/4891/files)) by passing either a supplied "MicrosoftAppId" or an empty string if no Id is provided.

#4891 addressed a regression in the SDK that was causing an error to generate if an app Id was not supplied to the adapter.