### PR TITLE
Ensure pack builds lib directory.

### DIFF
--- a/experimental/generation/generator/packages/cli/README.md
+++ b/experimental/generation/generator/packages/cli/README.md
@@ -17,11 +17,9 @@ Generate Bot Framework Adaptive Dialogs from JSON schema.
 # Commands
 
 <!-- commands -->
-- [Relevant docs](#relevant-docs)
-- [Commands](#commands)
-  - [`bf dialog:generate SCHEMA`](#bf-dialoggenerate-schema)
-  - [`bf dialog:generate:swagger PATH`](#bf-dialoggenerateswagger-path)
-  - [`bf dialog:generate:test TRANSCRIPT DIALOG`](#bf-dialoggeneratetest-transcript-dialog)
+* [`bf dialog:generate SCHEMA`](#bf-dialoggenerate-schema)
+* [`bf dialog:generate:swagger PATH`](#bf-dialoggenerateswagger-path)
+* [`bf dialog:generate:test TRANSCRIPT DIALOG`](#bf-dialoggeneratetest-transcript-dialog)
 
 ## `bf dialog:generate SCHEMA`
 

--- a/experimental/generation/generator/packages/cli/package.json
+++ b/experimental/generation/generator/packages/cli/package.json
@@ -55,7 +55,7 @@
     "build": "tsc -b",
     "postpack": "rimraf oclif.manifest.json",
     "posttest": "tslint -p test -t stylish",
-    "prepack": "rimraf lib && del *.tsbuildinfo && tsc -b",
+    "prepack": "rimraf lib tsconfig.tsbuildinfo && tsc -b",
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\"",
     "doc": "npm run build && npm run doc:readme && rimraf oclif.manifest.json",
     "doc:readme": "oclif-dev manifest && oclif-dev readme",

--- a/experimental/generation/generator/packages/cli/package.json
+++ b/experimental/generation/generator/packages/cli/package.json
@@ -55,7 +55,7 @@
     "build": "tsc -b",
     "postpack": "rimraf oclif.manifest.json",
     "posttest": "tslint -p test -t stylish",
-    "prepack": "rimraf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
+    "prepack": "rimraf lib && del *.tsbuildinfo && tsc -b",
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\"",
     "doc": "npm run build && npm run doc:readme && rimraf oclif.manifest.json",
     "doc:readme": "oclif-dev manifest && oclif-dev readme",

--- a/experimental/generation/generator/packages/library/package.json
+++ b/experimental/generation/generator/packages/library/package.json
@@ -53,7 +53,7 @@
   "scripts": {
     "build": "tsc -b",
     "posttest": "tslint -p test -t stylish",
-    "prepack": "rimraf lib && tsc -b",
+    "prepack": "rimraf lib && del *.tsbuildinfo && tsc -b",
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   }
 }

--- a/experimental/generation/generator/packages/library/package.json
+++ b/experimental/generation/generator/packages/library/package.json
@@ -53,7 +53,7 @@
   "scripts": {
     "build": "tsc -b",
     "posttest": "tslint -p test -t stylish",
-    "prepack": "rimraf lib && del *.tsbuildinfo && tsc -b",
+    "prepack": "rimraf lib tsconfig.tsbuildinfo && tsc -b",
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   }
 }


### PR DESCRIPTION
bf-generate and bf-generate-library packages were broken because of using tsc -b which would not regenerate the lib directory.