### PR TITLE
broken link to `bf dialog:generate:test`

### DIFF
--- a/experimental/generation/TestBot/readme.md
+++ b/experimental/generation/TestBot/readme.md
@@ -31,7 +31,7 @@ These parameters are used to find your `luis.settings.<environment>.<region>.jso
 ## Generating Tests from Transcripts
 
 A simple way to test your bot is to generate a test file from a transcript using [`bf
-dialog:generate:test`](../generator/packages/cli/readme.md#bf-dialoggeneratetest-transcript-dialog)
+dialog:generate:test`](../generator/packages/cli#bf-dialoggeneratetest-transcript-dialog)
 To do this:
 1. Test your `bot.main.dialog` in the [Bot Framework Emulator][emulator].
 2. Save the transcript as something like `bot.transcript`.


### PR DESCRIPTION
The link as written will result in a 404 if you select this link while you are reading this readme while in tree view, such as:

> https://github.com/microsoft/BotBuilder-Samples/**tree**/main/experimental/generation/TestBot

With this change, the link will work regardless if it is selected while you are in tree view of file view.

Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->
<!-- If you are introducing a new sample, make sure that the sample adheres to sample guidelines -->

  - 
  -
  -


## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->