### PR TITLE
Updated appsettings.json to have empty appIds and passwords.

### DIFF
--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/README.md
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/README.md
@@ -37,12 +37,14 @@ The solution includes a parent bot (`SimpleRootBot`) and a skill bot (`EchoSkill
     git clone https://github.com/microsoft/botbuilder-samples.git
     ```
 
+- Open the `SimpleBotToBot.sln` solution and configure it to [start debugging with multiple processes](https://docs.microsoft.com/en-us/visualstudio/debugger/debug-multiple-processes?view=vs-2019#start-debugging-with-multiple-processes)
+
+You can also configure the sample to run using a Microsoft AppId and password, to do this:
+
 - Create a bot registration in the azure portal for the `EchoSkillBot` and update [EchoSkillBot/appsettings.json](EchoSkillBot/appsettings.json) with the `MicrosoftAppId` and `MicrosoftAppPassword` of the new bot registration
 - Create a bot registration in the azure portal for the `SimpleRootBot` and update [SimpleRootBot/appsettings.json](SimpleRootBot/appsettings.json) with the `MicrosoftAppId` and `MicrosoftAppPassword` of the new bot registration
 - Update the `BotFrameworkSkills` section in [SimpleRootBot/appsettings.json](SimpleRootBot/appsettings.json) with the app ID for the skill you created in the previous step
 - (Optionally) Add the `SimpleRootBot` `MicrosoftAppId` to the `AllowedCallers` list in [EchoSkillBot/appsettings.json](EchoSkillBot/appsettings.json) 
-- Open the `SimpleBotToBot.sln` solution and configure it to [start debugging with multiple processes](https://docs.microsoft.com/en-us/visualstudio/debugger/debug-multiple-processes?view=vs-2019#start-debugging-with-multiple-processes)
-
 
 ## Testing the bot using Bot Framework Emulator
 

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/Bots/RootBot.cs
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/Bots/RootBot.cs
@@ -37,10 +37,6 @@ namespace Microsoft.BotBuilderSamples.SimpleRootBot.Bots
             }
 
             _botId = configuration.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey)?.Value;
-            if (string.IsNullOrWhiteSpace(_botId))
-            {
-                throw new ArgumentException($"{MicrosoftAppCredentials.MicrosoftAppIdKey} is not set in configuration");
-            }
 
             // We use a single skill in this example.
             var targetSkillId = "EchoSkillBot";

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/appsettings.json
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/appsettings.json
@@ -5,7 +5,7 @@
   "BotFrameworkSkills": [
     {
       "Id": "EchoSkillBot",
-      "AppId": "TODO: Add here the App ID for the skill",
+      "AppId": "",
       "SkillEndpoint": "http://localhost:39783/api/messages"
     }
   ]

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/Dialogs/MainDialog.cs
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/Dialogs/MainDialog.cs
@@ -40,10 +40,6 @@ namespace Microsoft.BotBuilderSamples.DialogRootBot.Dialogs
             : base(nameof(MainDialog))
         {
             var botId = configuration.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey)?.Value;
-            if (string.IsNullOrWhiteSpace(botId))
-            {
-                throw new ArgumentException($"{MicrosoftAppCredentials.MicrosoftAppIdKey} is not in configuration");
-            }
 
             _skillsConfig = skillsConfig ?? throw new ArgumentNullException(nameof(skillsConfig));
 

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/appsettings.json
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/appsettings.json
@@ -1,12 +1,12 @@
 {
-  "MicrosoftAppId": "TODO: Add here the App ID for the bot",
-  "MicrosoftAppPassword": "TODO: Add here the password for the bot",
+  "MicrosoftAppId": "",
+  "MicrosoftAppPassword": "",
 
   "SkillHostEndpoint": "http://localhost:3978/api/skills/",
   "BotFrameworkSkills": [
     {
       "Id": "DialogSkillBot",
-      "AppId": "TODO: Add here the App ID for the skill",
+      "AppId": "",
       "SkillEndpoint": "http://localhost:39783/api/messages"
     }
   ]

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/README.md
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/README.md
@@ -51,11 +51,16 @@ It demonstrates how to post activities from the parent bot to the skill bot and 
   git clone https://github.com/microsoft/botbuilder-samples.git
   ```
 
-- Create a bot registration in the azure portal for the `DialogSkillBot` and update [DialogSkillBot/appsettings.json](DialogSkillBot/appsettings.json) with the AppId and password.
-- Create a bot registration in the azure portal for the DialogRootBot and update [DialogRootBot/appsettings.json](DialogRootBot/appsettings.json) with the AppId and password. 
-- Update the BotFrameworkSkills section in [DialogRootBot/appsettings.json](DialogRootBot/appsettings.json) with the AppId for the skill you created in the previous step.
-- (Optional) Configure the LuisAppId, LuisAPIKey and LuisAPIHostName section in the [DialogSkillBot/appsettings.json](DialogSkillBot/appsettings.json) if you want to run message activities through LUIS.
 - Open the `SkillDialogSample.sln` solution and configure it to [start debugging with multiple processes](https://docs.microsoft.com/en-us/visualstudio/debugger/debug-multiple-processes?view=vs-2019#start-debugging-with-multiple-processes).
+- (Optional) Configure the LuisAppId, LuisAPIKey and LuisAPIHostName section in the [DialogSkillBot/appsettings.json](DialogSkillBot/appsettings.json) if you want to run message activities through LUIS.
+
+You can also configure the sample to run using a Microsoft AppId and password, to do this:
+
+- Create a bot registration in the azure portal for the `DialogSkillBot` and update [DialogSkillBot/appsettings.json](DialogSkillBot/appsettings.json) with the AppId and password.
+- Create a bot registration in the azure portal for the DialogRootBot and update [DialogRootBot/appsettings.json](DialogRootBot/appsettings.json) with the AppId and password.
+- Update the BotFrameworkSkills section in [DialogRootBot/appsettings.json](DialogRootBot/appsettings.json) with the AppId for the skill you created in the previous step.
+- (Optionally) Add the `DialogRootBot` `MicrosoftAppId` to the `AllowedCallers` list in [DialogSkillBot/appsettings.json](DialogSkillBot/appsettings.json) 
+
 
 ## Testing the bot using Bot Framework Emulator
 

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/.env
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/.env
@@ -3,5 +3,5 @@ MicrosoftAppPassword=
 SkillHostEndpoint=http://localhost:3978/api/skills/
 
 SkillId=EchoSkillBot
-SkillAppId=TODO: Add here the App ID for the skill
+SkillAppId=
 SkillEndpoint=http://localhost:39783/api/messages

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/rootBot.js
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/rootBot.js
@@ -13,11 +13,7 @@ class RootBot extends ActivityHandler {
         this.conversationState = conversationState;
         this.skillsConfig = skillsConfig;
         this.skillClient = skillClient;
-
         this.botId = process.env.MicrosoftAppId;
-        if (!this.botId) {
-            throw new Error('[RootBot] MicrosoftAppId is not set in configuration');
-        }
 
         // We use a single skill in this example.
         const targetSkillId = 'EchoSkillBot';

--- a/samples/python/80.skills-simple-bot-to-bot/simple-root-bot/config.py
+++ b/samples/python/80.skills-simple-bot-to-bot/simple-root-bot/config.py
@@ -12,10 +12,10 @@ class DefaultConfig:
 
     PORT = 3978
     APP_ID = os.environ.get(
-        "MicrosoftAppId", "TODO: Add here the App ID for the root bot"
+        "MicrosoftAppId", ""
     )
     APP_PASSWORD = os.environ.get(
-        "MicrosoftAppPassword", "TODO: Add here the App Password for the root bot"
+        "MicrosoftAppPassword", ""
     )
     SKILL_HOST_ENDPOINT = "http://localhost:3978/api/skills"
     SKILLS = [

--- a/samples/python/81.skills-skilldialog/dialog-root-bot/config.py
+++ b/samples/python/81.skills-skilldialog/dialog-root-bot/config.py
@@ -11,15 +11,15 @@ class DefaultConfig:
     """ Bot Configuration """
 
     PORT = 3978
-    APP_ID = os.environ.get("MicrosoftAppId", "TODO: Add here the App ID for the bot")
+    APP_ID = os.environ.get("MicrosoftAppId", "")
     APP_PASSWORD = os.environ.get(
-        "MicrosoftAppPassword", "TODO: Add here the password for the bot"
+        "MicrosoftAppPassword", ""
     )
     SKILL_HOST_ENDPOINT = "http://localhost:3978/api/skills"
     SKILLS = [
         {
             "id": "DialogSkillBot",
-            "app_id": "TODO: Add here the App ID for the skill",
+            "app_id": "",
             "skill_endpoint": "http://localhost:39783/api/messages",
         },
     ]

--- a/samples/python/81.skills-skilldialog/dialog-root-bot/dialogs/main_dialog.py
+++ b/samples/python/81.skills-skilldialog/dialog-root-bot/dialogs/main_dialog.py
@@ -59,8 +59,6 @@ class MainDialog(ComponentDialog):
         )
 
         bot_id = configuration.APP_ID
-        if not bot_id:
-            raise TypeError("App Id is not in configuration")
 
         self._skills_config = skills_config
         if not self._skills_config:


### PR DESCRIPTION
Fixes #2895 

Changes include:

- Updated appsettings.json to have empty appIds and passwords.
- Removed validation for MicrosoftAppId from RootBot and MainDialog (since now this is allowed).
- Updated readme files to note that now appId and passwords are optional.