### PR TITLE
Delete obsolete AzureBlobStorage instead of Microsoft.Bot.Builder.Azure.Blobs

### DIFF
--- a/samples/csharp_dotnetcore/45.state-management/Startup.cs
+++ b/samples/csharp_dotnetcore/45.state-management/Startup.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Azure.Blobs;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -27,7 +28,7 @@ namespace Microsoft.BotBuilderSamples
 
             /* AZURE BLOB STORAGE - Uncomment the code in this section to use Azure blob storage */
                            
-            // var storage = new AzureBlobStorage("<blob-storage-connection-string>", "bot-state");
+            //var storage = new BlobsStorage("<blob-storage-connection-string>", "bot-state");
 
             /* END AZURE BLOB STORAGE */
 

--- a/samples/csharp_dotnetcore/45.state-management/Startup.cs
+++ b/samples/csharp_dotnetcore/45.state-management/Startup.cs
@@ -28,7 +28,7 @@ namespace Microsoft.BotBuilderSamples
 
             /* AZURE BLOB STORAGE - Uncomment the code in this section to use Azure blob storage */
                            
-            //var storage = new BlobsStorage("<blob-storage-connection-string>", "bot-state");
+            // var storage = new BlobsStorage("<blob-storage-connection-string>", "bot-state");
 
             /* END AZURE BLOB STORAGE */
 

--- a/samples/csharp_dotnetcore/45.state-management/StateMangementBot.csproj
+++ b/samples/csharp_dotnetcore/45.state-management/StateMangementBot.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.11.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure.Blobs" Version="4.11.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.11.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Proposed Changes
  - Delete obsolete AzureBlobStorage instead of Microsoft.Bot.Builder.Azure.Blobs


## Testing
