### PR TITLE
VSCode Adaptive Tools Extension remove -preview label from version

### DIFF
--- a/experimental/adaptive-tool/package.json
+++ b/experimental/adaptive-tool/package.json
@@ -5,7 +5,7 @@
     "description": "Bot Framework Adaptive Tools",
     "version": "0.1.0",
     "license": "MIT",
-    "publisher": "Microsoft",
+    "publisher": "BotBuilder",
     "repository": {
         "type": "git",
         "url": "https://github.com/microsoft/BotBuilder-Samples.git"

--- a/experimental/adaptive-tool/package.json
+++ b/experimental/adaptive-tool/package.json
@@ -3,7 +3,7 @@
     "author": "Microsoft Corp.",
     "displayName": "Bot Framework Adaptive Tools",
     "description": "Bot Framework Adaptive Tools",
-    "version": "0.1.0-preview",
+    "version": "0.1.0",
     "license": "MIT",
     "publisher": "Microsoft",
     "repository": {


### PR DESCRIPTION
VS Marketplace does not allow non-numerical characters in the version number. Removing the -preview tag to be able to publish.