### PR TITLE
Ensure trigger intent is always handled.

### DIFF
--- a/experimental/generation/generator/packages/library/templates/standard/form-NotUnderstood.dialog.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/form-NotUnderstood.dialog.lg
@@ -9,7 +9,6 @@
     "$schema": "${appSchema}",
     "$kind": "Microsoft.OnIntent",
     "intent": "None",
-    "condition": "count(turn.recognizedentities) == 0",
     "actions": [
         {
             "$kind": "Microsoft.SendActivity",

--- a/experimental/generation/generator/packages/library/templates/standard/form-triggerIntent.dialog.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/form-triggerIntent.dialog.lg
@@ -9,11 +9,17 @@
     "$schema": "${appSchema}",
     "$kind": "Microsoft.OnIntent",
     "intent": "${triggerIntent}",
-    "condition": "count(turn.recognizedentities) == 0",
     "actions": [
-        {
-            "$kind": "Microsoft.SendActivity",
-            "activity": "\${notUnderstood()}"           
+       {
+          "$kind": "Microsoft.IfCondition",
+          "condition": "count(turn.recognizedEntities) == 0",
+          "actions": [
+            {
+              "$kind": "Microsoft.SendActivity",
+              "activity": "\${notUnderstood()}"
+            }
+          ],
+          "elseActions": []
         }
     ]
     ${designerIntent(triggerIntent)}


### PR DESCRIPTION
The trigger intent was not being handled if an entity was recognized.  This would cause interruption to run and ask the parent dialog even though the form intent was being recognized.