### PR TITLE
[57.teams-conversation-bots]: Adding multiple Bots events in existing sample

### DIFF
--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/README.md
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/README.md
@@ -18,6 +18,12 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 - [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
+## Description
+
+- Teams Messaging Extension Auth Configuration [AAD Authentication] for search, action and link unfurling combined in the sample. 
+-[Add Authentication to your Bot] (https://docs.microsoft.com/en-us/microsoftteams/platform/bots/how-to/authentication/add-authentication?tabs=dotnet%2Cdotnet-sample#create-the-bot-channels-registration)
+
+
 ## To try this sample
 
 > Note these instructions are for running the sample on your local machine, the tunnelling solution is required because

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/README.md
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/README.md
@@ -21,7 +21,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 ## Description
 
 - Teams Messaging Extension Auth Configuration [AAD Authentication] for search, action and link unfurling combined in the sample. 
--[Add Authentication to your Bot] (https://docs.microsoft.com/en-us/microsoftteams/platform/bots/how-to/authentication/add-authentication?tabs=dotnet%2Cdotnet-sample#create-the-bot-channels-registration)
+-[Add Authentication to your Bot](https://docs.microsoft.com/en-us/microsoftteams/platform/bots/how-to/authentication/add-authentication?tabs=dotnet%2Cdotnet-sample#create-the-bot-channels-registration)
 
 
 ## To try this sample

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/SimpleGraphClient.cs
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/SimpleGraphClient.cs
@@ -34,7 +34,14 @@ namespace Microsoft.BotBuilderSamples
             var messages = await graphClient.Me.MailFolders.Inbox.Messages.Request(new List<Option>() { searchQuery }).GetAsync();
             return messages.Take(10).ToArray();
         }
-        
+
+        //Fetching user's profile 
+        public async Task<User> GetMyProfile()
+        {
+            var graphClient = GetAuthenticatedClient();
+            return await graphClient.Me.Request().GetAsync();
+        }
+
         // Get an Authenticated Microsoft Graph client using the token issued to the user.
         private GraphServiceClient GetAuthenticatedClient()
         {

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/TeamsAppManifest/manifest.json
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/TeamsAppManifest/manifest.json
@@ -15,12 +15,12 @@
     "outline": "icon-outline.png"
   },
   "name": {
-    "short": "Config Auth Search",
-    "full": "Config Auth Search"
+    "short": "Messaging Extension Auth",
+    "full": "ME Auth for Search, Action and link unfurling"
   },
   "description": {
-    "short": "Config Auth Search",
-    "full": "Config Auth Search"
+    "short": "ME Authentication for Search, Action and Link unfurling",
+    "full": "ME Authentication sample code for all authentication merged"
   },
   "accentColor": "#FFFFFF",
   "composeExtensions": [
@@ -37,7 +37,8 @@
           "fetchTask": false,
           "context": [
             "commandBox",
-            "compose"
+            "compose",
+            "message"
           ],
           "parameters": [
             {
@@ -45,6 +46,26 @@
               "title": "Search",
               "description": "Your search query",
               "inputType": "text"
+            }
+          ]
+        },
+        {
+          "id": "SHOWPROFILE",
+          "type": "action",
+          "title": "Compose",
+          "description": "Compose and send email",
+          "initialRun": false,
+          "fetchTask": true,
+          "context": [
+            "commandBox",
+            "compose",
+            "message"
+          ],
+          "parameters": [
+            {
+              "name": "param",
+              "title": "param",
+              "description": ""
             }
           ]
         },
@@ -66,6 +87,16 @@
               "description": ""
             }
           ]
+        }
+      ],
+      "messageHandlers": [
+        {
+          "type": "link",
+          "value": {
+            "domains": [
+              "*.botframework.com"
+            ]
+          }
         }
       ]
     }

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/TeamsMessagingExtensionsSearchAuthConfig.csproj
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/TeamsMessagingExtensionsSearchAuthConfig.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AdaptiveCards" Version="2.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.11.1" />
     <PackageReference Include="Microsoft.Graph" Version="1.21.0" />

--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/Bots/TeamsConversationBot.cs
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/Bots/TeamsConversationBot.cs
@@ -241,5 +241,67 @@ namespace Microsoft.BotBuilderSamples.Bots
 
             await turnContext.SendActivityAsync(replyActivity, cancellationToken);
         }
+
+        //-----Subscribe to Conversation Events in Bot integration
+
+        protected override async Task OnTeamsChannelCreatedAsync(ChannelInfo channelInfo, TeamInfo teamInfo, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            var heroCard = new HeroCard(text: $"{channelInfo.Name} is the Channel created");
+            await turnContext.SendActivityAsync(MessageFactory.Attachment(heroCard.ToAttachment()), cancellationToken);
+        }
+
+        protected override async Task OnTeamsChannelRenamedAsync(ChannelInfo channelInfo, TeamInfo teamInfo, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            var heroCard = new HeroCard(text: $"{channelInfo.Name} is the new Channel name");
+            await turnContext.SendActivityAsync(MessageFactory.Attachment(heroCard.ToAttachment()), cancellationToken);
+        }
+
+        protected override async Task OnTeamsChannelDeletedAsync(ChannelInfo channelInfo, TeamInfo teamInfo, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            var heroCard = new HeroCard(text: $"{channelInfo.Name} is the Channel deleted");
+            await turnContext.SendActivityAsync(MessageFactory.Attachment(heroCard.ToAttachment()), cancellationToken);
+        }
+
+        protected override async Task OnTeamsMembersRemovedAsync(IList<TeamsChannelAccount> membersRemoved, TeamInfo teamInfo, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            foreach (TeamsChannelAccount member in membersRemoved)
+            {
+                if (member.Id == turnContext.Activity.Recipient.Id)
+                {
+                    // The bot was removed
+                    // You should clear any cached data you have for this team
+                }
+                else
+                {
+                    var heroCard = new HeroCard(text: $"{member.Name} was removed from {teamInfo.Name}");
+                    await turnContext.SendActivityAsync(MessageFactory.Attachment(heroCard.ToAttachment()), cancellationToken);
+                }
+            }
+        }
+
+        protected override async Task OnTeamsTeamRenamedAsync(TeamInfo teamInfo, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            var heroCard = new HeroCard(text: $"{teamInfo.Name} is the new Team name");
+            await turnContext.SendActivityAsync(MessageFactory.Attachment(heroCard.ToAttachment()), cancellationToken);
+        }
+        protected override async Task OnReactionsAddedAsync(IList<MessageReaction> messageReactions, ITurnContext<IMessageReactionActivity> turnContext, CancellationToken cancellationToken)
+        {
+            foreach (var reaction in messageReactions)
+            {
+                var newReaction = $"You reacted with '{reaction.Type}' to the following message: '{turnContext.Activity.ReplyToId}'";
+                var replyActivity = MessageFactory.Text(newReaction);
+                await turnContext.SendActivityAsync(replyActivity, cancellationToken);
+            }
+        }
+
+        protected override async Task OnReactionsRemovedAsync(IList<MessageReaction> messageReactions, ITurnContext<IMessageReactionActivity> turnContext, CancellationToken cancellationToken)
+        {
+            foreach (var reaction in messageReactions)
+            {
+                var newReaction = $"You removed the reaction '{reaction.Type}' from the following message: '{turnContext.Activity.ReplyToId}'";
+                var replyActivity = MessageFactory.Text(newReaction);
+                await turnContext.SendActivityAsync(replyActivity, cancellationToken);
+            }
+        }
     }
 }


### PR DESCRIPTION
**Descritpion**:  Enhancing the sample by adding following Bot events to which user can subscribe

## Events Added to the sample

1. `OnTeamsChannelCreatedAsync`
2. `OnTeamsChannelRenamedAsync`
3. `OnTeamsChannelDeletedAsync`
4. `OnTeamsMembersRemovedAsync`
5. `OnTeamsTeamRenamedAsync`
6. `OnReactionsAddedAsync`
7. `OnReactionsRemovedAsync`

## Testing
**OnTeamsChannelCreatedAsync();** Send a Hero card with channel Name when new channel created
![image](https://user-images.githubusercontent.com/50989436/103742396-c3422680-5020-11eb-9aa1-1cbabc7cca63.png)

**OnTeamsChannelRenamedAsync()**:
![image](https://user-images.githubusercontent.com/50989436/103742544-02707780-5021-11eb-8764-32cc8dea893b.png)

**OnTeamsChannelDeletedAsync()**:
![image](https://user-images.githubusercontent.com/50989436/103742608-1caa5580-5021-11eb-8ac9-e24449bbbcd7.png)

**OnTeamsTeamRenamedAsync**
![image](https://user-images.githubusercontent.com/50989436/103742740-52e7d500-5021-11eb-8492-9068670000c7.png)

**OnReactionsAddedAsync**:
![image](https://user-images.githubusercontent.com/50989436/103742876-7dd22900-5021-11eb-9c36-42e71a971e11.png)

**OnReactionsRemovedAsync**:
![image](https://user-images.githubusercontent.com/50989436/103742963-96424380-5021-11eb-91f1-c73577b80672.png)



