### PR TITLE
[57.teams-conversation-bots]: Adding multiple Bots events in existing sample

### DIFF
--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/Bots/TeamsConversationBot.cs
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/Bots/TeamsConversationBot.cs
@@ -241,5 +241,67 @@ namespace Microsoft.BotBuilderSamples.Bots
 
             await turnContext.SendActivityAsync(replyActivity, cancellationToken);
         }
+
+
+        //-----Subscribe to Conversation Events in Bot integration
+        protected override async Task OnTeamsChannelCreatedAsync(ChannelInfo channelInfo, TeamInfo teamInfo, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            var heroCard = new HeroCard(text: $"{channelInfo.Name} is the Channel created");
+            await turnContext.SendActivityAsync(MessageFactory.Attachment(heroCard.ToAttachment()), cancellationToken);
+        }
+
+        protected override async Task OnTeamsChannelRenamedAsync(ChannelInfo channelInfo, TeamInfo teamInfo, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            var heroCard = new HeroCard(text: $"{channelInfo.Name} is the new Channel name");
+            await turnContext.SendActivityAsync(MessageFactory.Attachment(heroCard.ToAttachment()), cancellationToken);
+        }
+
+        protected override async Task OnTeamsChannelDeletedAsync(ChannelInfo channelInfo, TeamInfo teamInfo, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            var heroCard = new HeroCard(text: $"{channelInfo.Name} is the Channel deleted");
+            await turnContext.SendActivityAsync(MessageFactory.Attachment(heroCard.ToAttachment()), cancellationToken);
+        }
+
+        protected override async Task OnTeamsMembersRemovedAsync(IList<TeamsChannelAccount> membersRemoved, TeamInfo teamInfo, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            foreach (TeamsChannelAccount member in membersRemoved)
+            {
+                if (member.Id == turnContext.Activity.Recipient.Id)
+                {
+                    // The bot was removed
+                    // You should clear any cached data you have for this team
+                }
+                else
+                {
+                    var heroCard = new HeroCard(text: $"{member.Name} was removed from {teamInfo.Name}");
+                    await turnContext.SendActivityAsync(MessageFactory.Attachment(heroCard.ToAttachment()), cancellationToken);
+                }
+            }
+        }
+
+        protected override async Task OnTeamsTeamRenamedAsync(TeamInfo teamInfo, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            var heroCard = new HeroCard(text: $"{teamInfo.Name} is the new Team name");
+            await turnContext.SendActivityAsync(MessageFactory.Attachment(heroCard.ToAttachment()), cancellationToken);
+        }
+        protected override async Task OnReactionsAddedAsync(IList<MessageReaction> messageReactions, ITurnContext<IMessageReactionActivity> turnContext, CancellationToken cancellationToken)
+        {
+            foreach (var reaction in messageReactions)
+            {
+                var newReaction = $"You reacted with '{reaction.Type}' to the following message: '{turnContext.Activity.ReplyToId}'";
+                var replyActivity = MessageFactory.Text(newReaction);
+                await turnContext.SendActivityAsync(replyActivity, cancellationToken);
+            }
+        }
+
+        protected override async Task OnReactionsRemovedAsync(IList<MessageReaction> messageReactions, ITurnContext<IMessageReactionActivity> turnContext, CancellationToken cancellationToken)
+        {
+            foreach (var reaction in messageReactions)
+            {
+                var newReaction = $"You removed the reaction '{reaction.Type}' from the following message: '{turnContext.Activity.ReplyToId}'";
+                var replyActivity = MessageFactory.Text(newReaction);
+                await turnContext.SendActivityAsync(replyActivity, cancellationToken);
+            }
+        }
     }
 }


### PR DESCRIPTION
**Descritpion**: Enhancing the sample by adding following Bot events to which user can subscribe



## Events Added to the sample



1. `OnTeamsChannelCreatedAsync`
2. `OnTeamsChannelRenamedAsync`
3. `OnTeamsChannelDeletedAsync`
4. `OnTeamsMembersRemovedAsync`
5. `OnTeamsTeamRenamedAsync`
6. `OnReactionsAddedAsync`
7. `OnReactionsRemovedAsync`



## Testing
**OnTeamsChannelCreatedAsync();** Send a Hero card with channel Name when new channel created
![image](https://user-images.githubusercontent.com/50989436/103742396-c3422680-5020-11eb-9aa1-1cbabc7cca63.png)



**OnTeamsChannelRenamedAsync()**:
![image](https://user-images.githubusercontent.com/50989436/103742544-02707780-5021-11eb-8764-32cc8dea893b.png)



**OnTeamsChannelDeletedAsync()**:
![image](https://user-images.githubusercontent.com/50989436/103742608-1caa5580-5021-11eb-8ac9-e24449bbbcd7.png)



**OnTeamsTeamRenamedAsync**
![image](https://user-images.githubusercontent.com/50989436/103742740-52e7d500-5021-11eb-8492-9068670000c7.png)



**OnReactionsAddedAsync**:
![image](https://user-images.githubusercontent.com/50989436/103742876-7dd22900-5021-11eb-9c36-42e71a971e11.png)



**OnReactionsRemovedAsync**:
![image](https://user-images.githubusercontent.com/50989436/103742963-96424380-5021-11eb-91f1-c73577b80672.png)