### PR TITLE
Added Just In Time installation flow in messaging extension action sample

### DIFF
--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Bots/TeamsMessagingExtensionsActionBot.cs
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Bots/TeamsMessagingExtensionsActionBot.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Teams;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Schema.Teams;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.BotBuilderSamples.Bots
@@ -26,7 +28,8 @@ namespace Microsoft.BotBuilderSamples.Bots
                 case "shareMessage":
                     return ShareMessageCommand(turnContext, action);
                 default:
-                    throw new NotImplementedException($"Invalid CommandId: {action.CommandId}");
+                    return await Task.FromResult(new MessagingExtensionActionResponse());
+                    //  throw new NotImplementedException($"Invalid CommandId: {action.CommandId}");
             }
         }
 
@@ -34,7 +37,7 @@ namespace Microsoft.BotBuilderSamples.Bots
         {
             // The user has chosen to create a card by choosing the 'Create Card' context menu command.
             var createCardData = ((JObject)action.Data).ToObject<CreateCardData>();
-            
+
             var card = new HeroCard
             {
                 Title = createCardData.Title,
@@ -49,7 +52,7 @@ namespace Microsoft.BotBuilderSamples.Bots
                 ContentType = HeroCard.ContentType,
                 Preview = card.ToAttachment(),
             });
-            
+
             return new MessagingExtensionActionResponse
             {
                 ComposeExtension = new MessagingExtensionResult
@@ -76,7 +79,7 @@ namespace Microsoft.BotBuilderSamples.Bots
                 // exercise for the user.
                 heroCard.Subtitle = $"({action.MessagePayload.Attachments.Count} Attachments not included)";
             }
-            
+
             // This Messaging Extension example allows the user to check a box to include an image with the
             // shared message.  This demonstrates sending custom parameters along with the message payload.
             var includeImage = ((JObject)action.Data)["includeImage"]?.ToString();
@@ -114,6 +117,69 @@ namespace Microsoft.BotBuilderSamples.Bots
             public string Subtitle { get; set; }
 
             public string Text { get; set; }
+        }
+
+        protected override async Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionFetchTaskAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
+        {
+            // we are handling two cases within try/catch block 
+            //if the bot is installed it will create adaptive card attachment and show card with input fields
+            string memberName;
+            try
+            {
+                // Check if your app is installed by fetching member information.
+                var member = await TeamsInfo.GetMemberAsync(turnContext, turnContext.Activity.From.Id, cancellationToken);
+                memberName = member.Name;
+            }
+            catch (ErrorResponseException ex)
+            {
+                if (ex.Body.Error.Code == "BotNotInConversationRoster")
+                {
+                    return new MessagingExtensionActionResponse
+                    {
+                        Task = new TaskModuleContinueResponse
+                        {
+                            Value = new TaskModuleTaskInfo
+                            {
+                                Card = GetAdaptiveCardAttachmentFromFile("justintimeinstallation.json"),
+                                Height = 200,
+                                Width = 400,
+                                Title = "Adaptive Card - App Installation",
+                            },
+                        },
+                    };
+                }
+                throw; // It's a different error.
+            }
+
+            return new MessagingExtensionActionResponse
+            {
+                Task = new TaskModuleContinueResponse
+                {
+                    Value = new TaskModuleTaskInfo
+                    {
+                        Card = GetAdaptiveCardAttachmentFromFile("adaptiveCard.json"),
+                        Height = 200,
+                        Width = 400,
+                        Title = $"Welcome {memberName}",
+                    },
+                },
+            };
+        }
+
+
+        /// Returns adaptive card attachment which allows Just In Time installation of app. 
+        private static Attachment GetAdaptiveCardAttachmentFromFile(string fileName)
+        {
+            //Read the card json and create attachment.
+            string[] paths = { ".", "Resources", fileName };
+            var adaptiveCardJson = File.ReadAllText(Path.Combine(paths));
+
+            var adaptiveCardAttachment = new Attachment()
+            {
+                ContentType = "application/vnd.microsoft.card.adaptive",
+                Content = JsonConvert.DeserializeObject(adaptiveCardJson),
+            };
+            return adaptiveCardAttachment;
         }
     }
 }

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Bots/TeamsMessagingExtensionsActionBot.cs
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Bots/TeamsMessagingExtensionsActionBot.cs
@@ -29,7 +29,6 @@ namespace Microsoft.BotBuilderSamples.Bots
                     return ShareMessageCommand(turnContext, action);
                 default:
                     return await Task.FromResult(new MessagingExtensionActionResponse());
-                    //  throw new NotImplementedException($"Invalid CommandId: {action.CommandId}");
             }
         }
 

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/README.md
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/README.md
@@ -58,6 +58,10 @@ or
 
 2) Selecting the **Share Message** command from the Message command list.
 
+or
+
+3) Selecting the **Fetch Roster** command from the Compose Box command list. You will presented with prompt for Just In Time installation if app is not already added to current team/chat.
+
 ## Deploy the bot to Azure
 
 To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Resources/adaptiveCard.json
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Resources/adaptiveCard.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.0",
+  "type": "AdaptiveCard",
+  "body": [
+    {
+      "type": "TextBlock",
+      "text": "This app is installed in this conversation. You can now use it to do some great stuff!!",
+      "isSubtle": false,
+      "wrap": true
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.Submit",
+      "title": "Close"
+    }
+  ]
+}

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Resources/justintimeinstallation.json
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Resources/justintimeinstallation.json
@@ -1,0 +1,22 @@
+{
+  "type": "AdaptiveCard",
+  "body": [
+    {
+      "type": "TextBlock",
+      "text": "Looks like you haven't used Action Messaging Extension app in this team/chat. Please click **Continue** to add this app.",
+      "wrap": true
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.Submit",
+      "title": "Continue",
+      "data": {
+        "msteams": {
+          "justInTimeInstall": true
+        }
+      }
+    }
+  ],
+  "version": "1.0"
+}

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/TeamsAppManifest/manifest.json
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/TeamsAppManifest/manifest.json
@@ -23,6 +23,18 @@
     "color": "icon-color.png"
   },
   "accentColor": "#FFFFFF",
+  "bots": [
+    {
+      "botId": "<<YOUR-MICROSOFT-APP-ID>>",
+      "needsChannelSelector": false,
+      "isNotificationOnly": false,
+      "scopes": [
+        "team",
+        "personal",
+        "groupchat"
+      ]
+    }
+  ],
   "composeExtensions": [
     {
       "botId": "<<YOUR-MICROSOFT-APP-ID>>",
@@ -68,6 +80,14 @@
               "inputType": "toggle"
             }
           ]
+        },
+        {
+          "id": "FetchRoster",
+          "description": "Fetch the conversation roster",
+          "title": "FetchRoster",
+          "type": "action",
+          "fetchTask": true,
+          "context": [ "compose" ]
         }
       ]
     }


### PR DESCRIPTION
## Proposed Changes
Current sample does not show how Messaging Extension action can trigger [Just In Time installation](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/messaging-extension-v3/create-extensions?tabs=typescript#request-to-install-your-conversational-bot). Raising this PR as discussed here: https://github.com/microsoft/BotBuilder-Samples/pull/2990#issuecomment-747637947

Screenshot of Working Sample:
1. Invoke FetchRoster action from command list
![image](https://user-images.githubusercontent.com/31851992/103929717-b5d18d00-5143-11eb-807d-9162dde056ec.png)

1. Display Just In Time installation card
![image](https://user-images.githubusercontent.com/31851992/103929743-c124b880-5143-11eb-8a23-052ab9fee495.png)
