### PR TITLE
fix bug in teams-sso experimental sample

### DIFF
--- a/experimental/teams-sso/csharp_dotnetcore/TokenExchangeHelper.cs
+++ b/experimental/teams-sso/csharp_dotnetcore/TokenExchangeHelper.cs
@@ -41,7 +41,7 @@ namespace Microsoft.BotBuilderSamples
         /// <returns>True if the bot should continue processing this TokenExchange request.</returns>
         public async Task<bool> ShouldProcessTokenExchange(ITurnContext turnContext, CancellationToken cancellationToken)
         {
-            if (turnContext.Activity.Name == SignInConstants.TokenExchangeOperationName)
+            if (turnContext.Activity.Name != SignInConstants.TokenExchangeOperationName)
             {
                 throw new InvalidOperationException("Only 'signin/tokenExchange' invoke activities can be procssed by TokenExchangeHelper.");
             }


### PR DESCRIPTION


Fixes 

line 44 in `TokenExchangeHelper.cs` should throw if the type is not equal to `SignInConstants.TokenExchangeOperationName` instead of equal to.


## Proposed Changes
Change to not equals instead of equals.  have verified with @EricDahlvang 
