### PR TITLE
Bump adaptive-tools version to 0.1.1

### DIFF
--- a/experimental/adaptive-tool/package.json
+++ b/experimental/adaptive-tool/package.json
@@ -3,7 +3,7 @@
     "author": "Microsoft Corp.",
     "displayName": "Bot Framework Adaptive Tools",
     "description": "Bot Framework Adaptive Tools",
-    "version": "0.1.0-preview",
+    "version": "0.1.1-preview",
     "license": "MIT",
     "publisher": "Microsoft",
     "repository": {


### PR DESCRIPTION
With the added support to .qna files and several fixes to README, it's ready to bump the version up. 