### PR TITLE
[53.teams-messaging-extensions-action-preview]: Sample enhancement for adding user attribution for bot messages

### DIFF
--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/AdaptiveCardHelper.cs
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/AdaptiveCardHelper.cs
@@ -13,11 +13,13 @@ namespace Microsoft.BotBuilderSamples
         {
             string userText = (adaptiveCard.Body[1] as AdaptiveTextBlock).Text;
             var choiceSet = adaptiveCard.Body[3] as AdaptiveChoiceSetInput;
+            var attributionFlag = (adaptiveCard.Body[4] as AdaptiveTextBlock).Text.Split(":")[1];
 
             return new ExampleData
             {
                 Question = userText,
                 MultiSelect = choiceSet.IsMultiSelect ? "true" : "false",
+                UserAttributionSelect=attributionFlag,
                 Option1 = choiceSet.Choices[0].Title,
                 Option2 = choiceSet.Choices[1].Title,
                 Option3 = choiceSet.Choices[2].Title,
@@ -55,6 +57,19 @@ namespace Microsoft.BotBuilderSamples
                     new AdaptiveTextInput() { Id = "Option1", Placeholder = "Option 1 here", Value = cardData.Option1 },
                     new AdaptiveTextInput() { Id = "Option2", Placeholder = "Option 2 here", Value = cardData.Option2 },
                     new AdaptiveTextInput() { Id = "Option3", Placeholder = "Option 3 here", Value = cardData.Option3 },
+
+                    new AdaptiveTextBlock("Do you want to send this card on behalf of User?"),
+                    new AdaptiveChoiceSetInput
+                    {
+                        Type = AdaptiveChoiceSetInput.TypeName,
+                        Id = "UserAttributionSelect",
+                        Value = cardData.UserAttributionSelect,
+                        Choices = new List<AdaptiveChoice>
+                        {
+                            new AdaptiveChoice() { Title = "True", Value = "true" },
+                            new AdaptiveChoice() { Title = "False", Value = "false" },
+                        },
+                    },
                 },
                 Actions = new List<AdaptiveAction>
                 {
@@ -89,6 +104,9 @@ namespace Microsoft.BotBuilderSamples
                             new AdaptiveChoice() { Title = data.Option3, Value = data.Option3 },
                         },
                     },
+                  new AdaptiveTextBlock("Sending card on behalf of user is set to:"+$"{data.UserAttributionSelect}") {
+                      Id = "AttributionChoice"
+                  },
                 },
                 Actions = new List<AdaptiveAction>
                 {

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/Bots/TeamsMessagingExtensionsActionPreviewBot.cs
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/Bots/TeamsMessagingExtensionsActionPreviewBot.cs
@@ -143,7 +143,6 @@ namespace Microsoft.BotBuilderSamples.Bots
             var activityPreview = action.BotActivityPreview[0];
             var attachmentContent = activityPreview.Attachments[0].Content;
             var previewedCard = JsonConvert.DeserializeObject<AdaptiveCard>(attachmentContent.ToString(), new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
-            previewedCard.Version = "1.0";
             var exampleData = AdaptiveCardHelper.CreateExampleData(previewedCard);
 
             // This is a send so we are done and we will create the adaptive card editor.

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/Bots/TeamsMessagingExtensionsActionPreviewBot.cs
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/Bots/TeamsMessagingExtensionsActionPreviewBot.cs
@@ -151,10 +151,12 @@ namespace Microsoft.BotBuilderSamples.Bots
             var message = MessageFactory.Attachment(new Attachment { ContentType = AdaptiveCard.ContentType, Content = adaptiveCard });
 
             //User Attribution for Bot messages
-            message.ChannelData = new
+            if (exampleData.UserAttributionSelect=="true")
             {
-                OnBehalfOf = new[]
-               {
+                message.ChannelData = new
+                {
+                    OnBehalfOf = new[]
+                   {
                     new
                        {
                          ItemId = 0,
@@ -163,7 +165,8 @@ namespace Microsoft.BotBuilderSamples.Bots
                          DisplayName = turnContext.Activity.From.Name
                     }
                 }
-            };
+                };
+            }
 
             // THIS WILL WORK IF THE BOT IS INSTALLED. (SendActivityAsync will throw if the bot is not installed.)
             await turnContext.SendActivityAsync(message, cancellationToken);

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/Bots/TeamsMessagingExtensionsActionPreviewBot.cs
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/Bots/TeamsMessagingExtensionsActionPreviewBot.cs
@@ -143,7 +143,7 @@ namespace Microsoft.BotBuilderSamples.Bots
             var activityPreview = action.BotActivityPreview[0];
             var attachmentContent = activityPreview.Attachments[0].Content;
             var previewedCard = JsonConvert.DeserializeObject<AdaptiveCard>(attachmentContent.ToString(), new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
-
+            previewedCard.Version = "1.0";
             var exampleData = AdaptiveCardHelper.CreateExampleData(previewedCard);
 
             // This is a send so we are done and we will create the adaptive card editor.
@@ -151,9 +151,24 @@ namespace Microsoft.BotBuilderSamples.Bots
 
             var message = MessageFactory.Attachment(new Attachment { ContentType = AdaptiveCard.ContentType, Content = adaptiveCard });
 
+            //User Attribution for Bot messages
+            message.ChannelData = new
+            {
+                OnBehalfOf = new[]
+               {
+                    new
+                       {
+                         ItemId = 0,
+                         MentionType = "person",
+                         Mri = turnContext.Activity.From.Id,
+                         DisplayName = turnContext.Activity.From.Name
+                    }
+                }
+            };
+
             // THIS WILL WORK IF THE BOT IS INSTALLED. (SendActivityAsync will throw if the bot is not installed.)
             await turnContext.SendActivityAsync(message, cancellationToken);
-            
+
             return null;
         }
 

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/ExampleData.cs
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/ExampleData.cs
@@ -8,6 +8,7 @@ namespace Microsoft.BotBuilderSamples
         public ExampleData()
         {
             MultiSelect = "true";
+            UserAttributionSelect = "true";
         }
 
         public string SubmitLocation { get; set; }
@@ -21,5 +22,7 @@ namespace Microsoft.BotBuilderSamples
         public string Option2 { get; set; }
 
         public string Option3 { get; set; }
+
+        public string UserAttributionSelect { get; set; }
     }
 }

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/README.md
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/README.md
@@ -2,7 +2,7 @@
 
 Bot Framework v4 Teams Messaging Extension Action Preview sample.
 
-This Messaging Extension has been created using [Bot Framework](https://dev.botframework.com). It shows how to create a simple card based on parameters entered by the user from a Task Module.
+This Messaging Extension has been created using [Bot Framework](https://dev.botframework.com). It shows how to create a simple card based on parameters entered by the user from a Task Module.it also display the scenairo where a Bot sends messages on behalf of a User, attributing the message to that user can help with engagement and showcase a more natural interaction flow.
 
 ## Prerequisites
 

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/README.md
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/README.md
@@ -2,7 +2,7 @@
 
 Bot Framework v4 Teams Messaging Extension Action Preview sample.
 
-This Messaging Extension has been created using [Bot Framework](https://dev.botframework.com). It shows how to create a simple card based on parameters entered by the user from a Task Module.it also display the scenairo where a Bot sends messages on behalf of a User, attributing the message to that user can help with engagement and showcase a more natural interaction flow.
+This Messaging Extension has been created using [Bot Framework](https://dev.botframework.com). It shows how to create a simple card based on parameters entered by the user from a Task Module.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Description:
In scenarios where a bot sends messages on behalf of a user, attributing the message to that user can help with engagement and showcase a more natural interaction flow. This feature allows you to attribute a message from your bot to a user on whose behalf it was sent.

## Proposed Changes
  -  Added code snippet in the existing sample for user attribution C#
  - Updated ReadMe file

## Testing

1. Click on Create card command
2. Fill the task module adaptive card
3. set Send Card on behalf of user choice to true or false for optional use

4. Send card on behalf is user is set to true:
`Adaptive Card`
![image](https://user-images.githubusercontent.com/50989436/106430457-d31f2000-6491-11eb-87a8-e783680b50c9.png)

`Preview Card`
![image](https://user-images.githubusercontent.com/50989436/106430843-67898280-6492-11eb-9025-229dcfe60988.png)

`Card in channel:`
![image](https://user-images.githubusercontent.com/50989436/106430770-47f25a00-6492-11eb-8eec-621bf29674e7.png)


When on behalf of user choice is set to false
`Adaptive Card `
![image](https://user-images.githubusercontent.com/50989436/106430270-918e7500-6491-11eb-9f84-cefc37af0264.png)


`Card in channel`
![image](https://user-images.githubusercontent.com/50989436/106430328-a7039f00-6491-11eb-8b6d-8bc8d7fa9d25.png)



