### PR TITLE
Fix the incompatibility caused by version upgrade 

### DIFF
--- a/experimental/adaptive-tool/client/package.json
+++ b/experimental/adaptive-tool/client/package.json
@@ -14,7 +14,7 @@
 	},
 	"dependencies": {
 		"dotenv": "^8.2.0",
-		"vscode-languageclient": "^6.1.3"
+		"vscode-languageclient": "6.1.4"
 	},
 	"devDependencies": {
 		"@types/vscode": "1.43.0",

--- a/experimental/adaptive-tool/server/package.json
+++ b/experimental/adaptive-tool/server/package.json
@@ -14,9 +14,10 @@
 	"dependencies": {
 		"@microsoft/bf-lu": "4.11.1",
 		"botbuilder-lg": "~4.11.0",
-		"vscode-languageserver": "^6.1.1",
-		"vscode-languageserver-textdocument": "^1.0.1",
-		"vscode-uri": "^2.1.2"
+		"vscode-languageserver": "6.1.1",
+		"vscode-languageserver-protocol": "3.15.3",
+		"vscode-languageserver-textdocument": "1.0.1",
+		"vscode-uri": "2.1.2"
 	},
 	"scripts": {}
 }


### PR DESCRIPTION
## Description
Package `vscode-languageserver` `6.1.1` and package `vscode-languageclient` `6.1.3` depends on package `"vscode-languageserver-protocol": "^3.15.3"`. It works fine when `vscode-languageserver-protocol` keeps the latest version `3.15.3`.

But a month ago, `vscode-languageserver-protocol` release its `3.16.0` which does not compatible with  `vscode-languageserver` `6.1.1` and `vscode-languageclient` `6.1.3`.

## Proposed Changes
- Fix `vscode-languageserver` to `6.1.1`, and upgrade `vscode-languageclient` to `6.1.4` which would fix the `vscode-languageserver-protocol` to `3.15.3`
- Add `vscode-languageserver-protocol` `3.15.3` explicitly
- Fix the version of vscode-language related packages to avoid encountering similar problems 

## Related references
https://github.com/microsoft/vscode-languageserver-node/issues/710