### PR TITLE
Remove nuget.config from Orchestrator sample, update package references

### DIFF
--- a/experimental/orchestrator/csharp_dotnetcore/01.dispatch-bot/01.dispatch-bot.csproj
+++ b/experimental/orchestrator/csharp_dotnetcore/01.dispatch-bot/01.dispatch-bot.csproj
@@ -13,10 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.11.0-daily*" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Orchestrator" Version="4.11.0-daily*" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.11.0-daily*" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.11.0-daily*" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.11.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Orchestrator" Version="4.11.1-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.11.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.11.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/experimental/orchestrator/csharp_dotnetcore/01.dispatch-bot/Startup.cs
+++ b/experimental/orchestrator/csharp_dotnetcore/01.dispatch-bot/Startup.cs
@@ -65,8 +65,8 @@ namespace Microsoft.BotBuilderSamples
             string snapshotFile = Path.GetFullPath(OrchestratorConfig.SnapshotFile);
             OrchestratorRecognizer orc = new OrchestratorRecognizer()
             {
-                ModelFolder = modelFolder,
-                SnapshotFile = snapshotFile
+                ModelPath = modelFolder,
+                SnapshotPath = snapshotFile
             };
             return orc;
         }

--- a/experimental/orchestrator/csharp_dotnetcore/nuget.config
+++ b/experimental/orchestrator/csharp_dotnetcore/nuget.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="ConversationalAI" value="https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
This is related to #3067.

## Proposed Changes
  - Remove Nuget.config for experimental Orchestrator sample
  - Update references for LUIS/QnA and Orchestrator
  - Roll back updates that refer to (future) version of Orchestrator

