### PR TITLE
Add moment-timezone dependency

### DIFF
--- a/samples/javascript_nodejs/13.core-bot/package.json
+++ b/samples/javascript_nodejs/13.core-bot/package.json
@@ -22,7 +22,8 @@
         "botbuilder-dialogs": "~4.11.0",
         "botbuilder-testing": "~4.11.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.5.1"
+        "restify": "~8.5.1",
+        "moment-timezone": "~0.5.33"
     },
     "devDependencies": {
         "eslint": "^7.0.0",


### PR DESCRIPTION
Fixes #3080

Node CoreBot was missing the `moment-timezone` dependency in `package.json`, despite it being required [here](https://github.com/microsoft/BotBuilder-Samples/blob/main/samples/javascript_nodejs/13.core-bot/dialogs/mainDialog.js#L8). For some reason, this doesn't seem to be an issue with Node v12, but was in Node v10.14, which our pipeline runs. This should fix it.

![image](https://user-images.githubusercontent.com/40401643/108259245-b7647c80-7115-11eb-9a33-ef5bd3b5679c.png)
