### PR TITLE
Remove trusted service url comment

### DIFF
--- a/samples/csharp_dotnetcore/16.proactive-messages/Controllers/NotifyController.cs
+++ b/samples/csharp_dotnetcore/16.proactive-messages/Controllers/NotifyController.cs
@@ -47,8 +47,6 @@ namespace ProactiveBot.Controllers
 
         private async Task BotCallback(ITurnContext turnContext, CancellationToken cancellationToken)
         {
-            // If you encounter permission-related errors when sending this message, see
-            // https://aka.ms/BotTrustServiceUrl
             await turnContext.SendActivityAsync("proactive hello");
         }
     }


### PR DESCRIPTION
Related to [Dotnet Issue # 5158](https://github.com/microsoft/botbuilder-dotnet/issues/5158). Updating code snippet used in documentation.