### PR TITLE
remove trustServiceUrl docs and comments

### DIFF
--- a/samples/csharp_dotnetcore/16.proactive-messages/README.md
+++ b/samples/csharp_dotnetcore/16.proactive-messages/README.md
@@ -85,10 +85,6 @@ In order to send a proactive message using Bot Framework, the bot must first cap
 
 To send proactive messages, acquire a conversation reference, then use `adapter.continueConversation()` to create a TurnContext object that will allow the bot to deliver the new outgoing message.
 
-### Avoiding Permission-Related Errors
-
-You may encounter permission-related errors when sending a proactive message. This can often be mitigated by using `MicrosoftAppCredentials.TrustServiceUrl()`. See [the documentation](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-proactive-message?view=azure-bot-service-4.0&tabs=csharp#avoiding-401-unauthorized-errors) for more information.
-
 ## Deploy this bot to Azure
 
 To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.

--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/Bots/TeamsConversationBot.cs
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/Bots/TeamsConversationBot.cs
@@ -126,8 +126,6 @@ namespace Microsoft.BotBuilderSamples.Bots
             await turnContext.DeleteActivityAsync(turnContext.Activity.ReplyToId, cancellationToken);
         }
 
-        // If you encounter permission-related errors when sending this message, see
-        // https://aka.ms/BotTrustServiceUrl
         private async Task MessageAllMembersAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
             var teamsChannelId = turnContext.Activity.TeamsGetChannelId();

--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/README.md
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/README.md
@@ -65,10 +65,6 @@ You can interact with this bot by sending it a message, or selecting a command f
 
 You can select an option from the command list by typing ```@TeamsConversationBot``` into the compose message area and ```What can I do?``` text above the compose area.
 
-### Avoiding Permission-Related Errors
-
-You may encounter permission-related errors when sending a proactive message. This can often be mitigated by using `MicrosoftAppCredentials.TrustServiceUrl()`. See [the documentation](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-proactive-message?view=azure-bot-service-4.0&tabs=csharp#avoiding-401-unauthorized-errors) for more information.
-
 ## Deploy the bot to Azure
 
 To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.

--- a/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/README.md
+++ b/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/README.md
@@ -52,10 +52,6 @@ the Teams service needs to call into the bot.
 
 You can interact with this bot by sending it a message. The bot will respond by creating a new thread in the channel and replying to that new thread.
 
-### Avoiding Permission-Related Errors
-
-You may encounter permission-related errors when sending a proactive message. This can often be mitigated by using `MicrosoftAppCredentials.TrustServiceUrl()`. See [the documentation](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-proactive-message?view=azure-bot-service-4.0&tabs=csharp#avoiding-401-unauthorized-errors) for more information.
-
 ## Deploy the bot to Azure
 
 To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.

--- a/samples/javascript_nodejs/16.proactive-messages/README.md
+++ b/samples/javascript_nodejs/16.proactive-messages/README.md
@@ -86,10 +86,6 @@ In order to send a proactive message using Bot Framework, the bot must first cap
 
 To send proactive messages, acquire a conversation reference, then use `adapter.continueConversation()` to create a TurnContext object that will allow the bot to deliver the new outgoing message.
 
-### Avoiding Permission-Related Errors
-
-You may encounter permission-related errors when sending a proactive message. This can often be mitigated by using `MicrosoftAppCredentials.trustServiceUrl()`. See [the documentation](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-proactive-message?view=azure-bot-service-4.0&tabs=javascript#avoiding-401-unauthorized-errors) for more information.
-
 ## Deploy this bot to Azure
 
 To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.

--- a/samples/javascript_nodejs/16.proactive-messages/index.js
+++ b/samples/javascript_nodejs/16.proactive-messages/index.js
@@ -71,8 +71,6 @@ server.post('/api/messages', (req, res) => {
 server.get('/api/notify', async (req, res) => {
     for (const conversationReference of Object.values(conversationReferences)) {
         await adapter.continueConversation(conversationReference, async turnContext => {
-            // If you encounter permission-related errors when sending this message, see
-            // https://aka.ms/BotTrustServiceUrl
             await turnContext.sendActivity('proactive hello');
         });
     }

--- a/samples/javascript_nodejs/57.teams-conversation-bot/README.md
+++ b/samples/javascript_nodejs/57.teams-conversation-bot/README.md
@@ -71,10 +71,6 @@ You can interact with this bot by sending it a message, or selecting a command f
 
 You can select an option from the command list by typing ```@TeamsConversationBot``` into the compose message area and ```What can I do?``` text above the compose area.
 
-### Avoiding Permission-Related Errors
-
-You may encounter permission-related errors when sending a proactive message. This can often be mitigated by using `MicrosoftAppCredentials.trustServiceUrl()`. See [the documentation](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-proactive-message?view=azure-bot-service-4.0&tabs=javascript#avoiding-401-unauthorized-errors) for more information.
-
 ## Deploy the bot to Azure
 
 To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.

--- a/samples/javascript_nodejs/57.teams-conversation-bot/bots/teamsConversationBot.js
+++ b/samples/javascript_nodejs/57.teams-conversation-bot/bots/teamsConversationBot.js
@@ -175,8 +175,6 @@ class TeamsConversationBot extends TeamsActivityHandler {
         await context.deleteActivity(context.activity.replyToId);
     }
 
-    // If you encounter permission-related errors when sending this message, see
-    // https://aka.ms/BotTrustServiceUrl
     async messageAllMembersAsync(context) {
         const members = await this.getPagedMembers(context);
 

--- a/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/README.md
+++ b/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/README.md
@@ -59,10 +59,6 @@ the Teams service needs to call into the bot.
 
 You can interact with this bot by sending it a message. The bot will respond by sending a reply to the channel, and then responding to that reply.
 
-### Avoiding Permission-Related Errors
-
-You may encounter permission-related errors when sending a proactive message. This can often be mitigated by using `MicrosoftAppCredentials.trustServiceUrl()`. See [the documentation](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-proactive-message?view=azure-bot-service-4.0&tabs=javascript#avoiding-401-unauthorized-errors) for more information.
-
 ## Deploy the bot to Azure
 
 To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.
@@ -70,4 +66,3 @@ To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](htt
 ## Further reading
 
 - [How Microsoft Teams bots work](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-basics-teams?view=azure-bot-service-4.0&tabs=javascript)
-

--- a/samples/python/16.proactive-messages/README.md
+++ b/samples/python/16.proactive-messages/README.md
@@ -62,10 +62,6 @@ In order to send a proactive message using Bot Framework, the bot must first cap
 
 To send proactive messages, acquire a conversation reference, then use `adapter.continueConversation()` to create a TurnContext object that will allow the bot to deliver the new outgoing message.
 
-### Avoiding Permission-Related Errors
-
-You may encounter permission-related errors when sending a proactive message. This can often be mitigated by using `MicrosoftAppCredentials.TrustServiceUrl()`. See [the documentation](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-proactive-message?view=azure-bot-service-4.0&tabs=csharp#avoiding-401-unauthorized-errors) for more information.
-
 ## Deploy this bot to Azure
 
 To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.

--- a/samples/typescript_nodejs/16.proactive-messages/src/index.ts
+++ b/samples/typescript_nodejs/16.proactive-messages/src/index.ts
@@ -90,8 +90,6 @@ server.on('upgrade', (req, socket, head) => {
 server.get('/api/notify', async (req, res) => {
     for (const conversationReference of Object.values(conversationReferences)) {
         await adapter.continueConversation(conversationReference, async turnContext => {
-            // If you encounter permission-related errors when sending this message, see
-            // https://aka.ms/BotTrustServiceUrl
             await turnContext.sendActivity('proactive hello');
         });
     }
@@ -107,8 +105,6 @@ server.post('/api/notify', async (req, res) => {
         var msg = req.body[prop];
         for (const conversationReference of Object.values(conversationReferences)) {
             await adapter.continueConversation(conversationReference, async turnContext => {
-                // If you encounter permission-related errors when sending this message, see
-                // https://aka.ms/BotTrustServiceUrl
                 await turnContext.sendActivity(msg);
             });
         }

--- a/samples/typescript_nodejs/57.teams-conversation-bot/README.md
+++ b/samples/typescript_nodejs/57.teams-conversation-bot/README.md
@@ -71,10 +71,6 @@ You can interact with this bot by sending it a message, or selecting a command f
 
 You can select an option from the command list by typing ```@TeamsConversationBot``` into the compose message area and ```What can I do?``` text above the compose area.
 
-### Avoiding Permission-Related Errors
-
-You may encounter permission-related errors when sending a proactive message. This can often be mitigated by using `MicrosoftAppCredentials.trustServiceUrl()`. See [the documentation](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-proactive-message?view=azure-bot-service-4.0&tabs=javascript#avoiding-401-unauthorized-errors) for more information.
-
 ## Deploy the bot to Azure
 
 To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.

--- a/samples/typescript_nodejs/57.teams-conversation-bot/src/teamsConversationBot.ts
+++ b/samples/typescript_nodejs/57.teams-conversation-bot/src/teamsConversationBot.ts
@@ -151,8 +151,6 @@ export class TeamsConversationBot extends TeamsActivityHandler {
         await context.deleteActivity( context.activity.replyToId );
     }
 
-    // If you encounter permission-related errors when sending this message, see
-    // https://aka.ms/BotTrustServiceUrl
     public async messageAllMembersAsync( context: TurnContext ): Promise<void> {
         const members = await this.getPagedMembers( context );
 

--- a/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/README.md
+++ b/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/README.md
@@ -63,10 +63,6 @@ the Teams service needs to call into the bot.
 
 You can interact with this bot by sending it a message. The bot will respond by sending a reply to the channel, and then responding to that reply.
 
-### Avoiding Permission-Related Errors
-
-You may encounter permission-related errors when sending a proactive message. This can often be mitigated by using `MicrosoftAppCredentials.trustServiceUrl()`. See [the documentation](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-proactive-message?view=azure-bot-service-4.0&tabs=javascript#avoiding-401-unauthorized-errors) for more information.
-
 ## Deploy the bot to Azure
 
 ### Publishing Changes to Azure Bot Service


### PR DESCRIPTION
Fixes https://github.com/microsoft/BotBuilder-Samples/issues/3099

Affected samples (@JonathanFingold) :

* C#
  * 16-proactive (README only)
  * 57-teams conversation bot (README and TeamsConversationBot.cs)
  * 58-teams convo new channel (README only)
* Node
  * 16-proactive (README and index.js)
  * 57-teams conversation bot (README and teamsConversationBot.js)
  * 58-teams convo new channel (README only)
* TypeScript
  * 16-proactive (README and index.ts)
  * 57-teams conversation bot (README and teamsConversationBot.ts)
  * 58-teams convo new channel (README only)
* Python
  * 16-proactive (README only)

Note: There's only one other place in the Samples repo that references `trustServiceUrl` at all, and that's in the code for [the experimental Handoff bot](https://github.com/microsoft/BotBuilder-Samples/blob/main/experimental/handoff-library/csharp_dotnetcore/samples/LivePersonConnector/LivePersonController.cs#L180). Removing that call might break the bot, though, since it's still on 4.8.0.