### PR TITLE
Handle activityProcessed and improve prompts

### DIFF
--- a/experimental/generation/generator/packages/library/src/dialogGenerator.ts
+++ b/experimental/generation/generator/packages/library/src/dialogGenerator.ts
@@ -521,14 +521,14 @@ function verifyEnumAndGetExamples(schema: any, property: string, locale: string,
     let usedLocale = true
     let global = false
     if (!examples) {
-        usedLocale = false
-        global = false
-        examples = propertySchema.$examples?.['']?.[entity]
-    }
-    if (!examples) {
         usedLocale = true
         global = true
         examples = schema.$examples?.[locale]?.[entity]
+    }
+    if (!examples) {
+        usedLocale = false
+        global = false
+        examples = propertySchema.$examples?.['']?.[entity]
     }
     if (!examples) {
         usedLocale = false

--- a/experimental/generation/generator/packages/library/templates/generator.lg
+++ b/experimental/generation/generator/packages/library/templates/generator.lg
@@ -531,7 +531,7 @@ ${defineOperation('Help', entity)}
     - @ ml dummyProperty
 
 > Add examples for operations on the '${property}' property to the intent '${triggerIntent}'.
-${'#'} ${triggerIntent}
+# ${triggerIntent}
 ${substitutions(
     `form-operations.${locale}.data`,
     substitutionScope(utterances, entityValues(values), label),
@@ -692,11 +692,11 @@ ${if(length(entities[entity]) > 1, `    - @ ${entity} ${entity}`, '')}```
 - ```
 >> Prompts
 
-${'#'} ${property}_MissingPrompt()
+# ${property}_MissingPrompt()
 > Prompt when '${property}' property is missing
 - ${missing}
 
-${'#'} ${property}_ChangePrompt()
+# ${property}_ChangePrompt()
 > Prompt when '${property}' property has a value, but is being changed
 - ${change}```
 
@@ -704,30 +704,30 @@ ${'#'} ${property}_ChangePrompt()
 - ```
 >> Confirmation
 
-${'#'} ${property}_ExpectedSetConfirmation(newVal)
+# ${property}_ExpectedSetConfirmation(newVal)
 > Confirmation when adding expected value to empty '${property}' property
 - ${expectedSet}
 
 ${expectedUpdateTemplate(expectedReplace)}
-${'#'} ${property}_UnexpectedSetConfirmation(newVal)
+# ${property}_UnexpectedSetConfirmation(newVal)
 > Confirmation when adding unexpected value to empty '${property}' property
 - ${unexpectedSet}
 
-${'#'} ${property}_UnexpectedUpdateConfirmation(newVal)
+# ${property}_UnexpectedUpdateConfirmation(newVal)
 > Confirmation when replacing unexpected value in '${property}' property
 - ${unexpectedReplace}
 
-${'#'} ${property}_RemoveConfirmation(val)
+# ${property}_RemoveConfirmation(val)
 > Confirmation when value is removed from '${property}' property
 - ${remove}
 
-${'#'} ${property}_ClearConfirmation()
+# ${property}_ClearConfirmation()
 > Confirmation when '${property}' property is cleared
 - ${clear}```
 
 # expectedUpdateTemplate(expectedReplace)
 - IF: ${!isArrayProperty(property)}
-    - ```${'#'} ${property}_ExpectedUpdateConfirmation(newVal)
+    - ```# ${property}_ExpectedUpdateConfirmation(newVal)
 > Confirmation when replacing expected value in '${property}' property
 - ${expectedReplace}
 ```
@@ -738,25 +738,25 @@ ${'#'} ${property}_ClearConfirmation()
 - ```
 >> Help
 
-${'#'} ${property}_RepromptHelp()
+# ${property}_RepromptHelp()
 > Help for '${property}' property reprompt
 - ${reprompt}
 
-${'#'} ${property}_Help()
+# ${property}_Help()
 > Help for '${property}' property
 - ${help}```
 
 # showTemplate(show)
 - ```
 >> Show
-${'#'} ${property}_Show()
+# ${property}_Show()
 > Show value of '${property}' property
 - ${show}```
 
 # incorrectUnitsTemplate()
 - IF: ${units()}
 - ```
-${'#'} ${property}_IncorrectUnits(actual)
+# ${property}_IncorrectUnits(actual)
 > Incorrect units for '${property}' property
 - \${actual} must be '${units()}'```
 - ELSE:

--- a/experimental/generation/generator/packages/library/templates/generator.lg
+++ b/experimental/generation/generator/packages/library/templates/generator.lg
@@ -341,7 +341,8 @@
             "$kind": "Microsoft.SendActivity",
             "activity": "\${${property}_RemoveConfirmation(@${entity})}"
         },  
-        ${deleteOrRemove(entity)}
+        ${deleteOrRemove(entity)},
+        ${actionDeletePropertyToChange()}
     ]```
 
 # checkIfPresent(entity, actions)
@@ -691,11 +692,11 @@ ${if(length(entities[entity]) > 1, `    - @ ${entity} ${entity}`, '')}```
 - ```
 >> Prompts
 
-${'#'} ${property}_MissingPrompt
+${'#'} ${property}_MissingPrompt()
 > Prompt when '${property}' property is missing
 - ${missing}
 
-${'#'} ${property}_ChangePrompt
+${'#'} ${property}_ChangePrompt()
 > Prompt when '${property}' property has a value, but is being changed
 - ${change}```
 
@@ -707,10 +708,7 @@ ${'#'} ${property}_ExpectedSetConfirmation(newVal)
 > Confirmation when adding expected value to empty '${property}' property
 - ${expectedSet}
 
-${'#'} ${property}_ExpectedUpdateConfirmation(newVal)
-> Confirmation when replacing expected value in '${property}' property
-- ${expectedReplace}
-
+${expectedUpdateTemplate(expectedReplace)}
 ${'#'} ${property}_UnexpectedSetConfirmation(newVal)
 > Confirmation when adding unexpected value to empty '${property}' property
 - ${unexpectedSet}
@@ -723,26 +721,35 @@ ${'#'} ${property}_RemoveConfirmation(val)
 > Confirmation when value is removed from '${property}' property
 - ${remove}
 
-${'#'} ${property}_ClearConfirmation
+${'#'} ${property}_ClearConfirmation()
 > Confirmation when '${property}' property is cleared
 - ${clear}```
+
+# expectedUpdateTemplate(expectedReplace)
+- IF: ${!isArrayProperty(property)}
+    - ```${'#'} ${property}_ExpectedUpdateConfirmation(newVal)
+> Confirmation when replacing expected value in '${property}' property
+- ${expectedReplace}
+```
+- ELSE:
+    -
 
 # helpTemplates(reprompt, help)
 - ```
 >> Help
 
-${'#'} ${property}_RepromptHelp
+${'#'} ${property}_RepromptHelp()
 > Help for '${property}' property reprompt
 - ${reprompt}
 
-${'#'} ${property}_Help
+${'#'} ${property}_Help()
 > Help for '${property}' property
 - ${help}```
 
 # showTemplate(show)
 - ```
 >> Show
-${'#'} ${property}_Show
+${'#'} ${property}_Show()
 > Show value of '${property}' property
 - ${show}```
 

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/datetimeProperty.en-us.lg.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/datetimeProperty.en-us.lg.lg
@@ -8,6 +8,6 @@
 
 # validationTemplate
 - ```
-${'#'} ${property}_invalidDate(val)
+# ${property}_invalidDate(val)
 > Invalid value for '${property}' property
 - \${${property}_Value(val)} is not a date```

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/enumEntity.en-us.lg.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/enumEntity.en-us.lg.lg
@@ -22,7 +22,7 @@ ${'#'} ${entity}_chooseEntity()
 -```
 ${'#'} ${entity}_Value(entity) 
 > Display value for '${entity}'
-- \${complexValue(entity.value, '${enumName(entity)}')}```
+- \${choices(entity.value, '${enumName(entity)}', 'and')}```
 
 # propertyEnumValue
 - ${join([namePlusSwitch(), cases(), default()], '')}

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/enumEntity.en-us.lg.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/enumEntity.en-us.lg.lg
@@ -14,13 +14,13 @@ ${chooseEntity()}
 
 # chooseEntity
 -```
-${'#'} ${entity}_chooseEntity()
+# ${entity}_chooseEntity()
 > Choose between '${entity}' values
 - \${chooseEnumEntity()}```
 
 # propertyEntityValue
 -```
-${'#'} ${entity}_Value(entity) 
+# ${entity}_Value(entity) 
 > Display value for '${entity}'
 - \${choices(entity.value, '${enumName(entity)}', 'and')}```
 
@@ -29,7 +29,7 @@ ${'#'} ${entity}_Value(entity)
 
 # namePlusSwitch
 -```
-${'#'} ${enumName(entity)}(value) 
+# ${enumName(entity)}(value) 
 > Display value for '${entity}' enumeration value
 - SWITCH: \${value}```
 

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/enumProperty.en-us.lg.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/enumProperty.en-us.lg.lg
@@ -35,11 +35,11 @@ ${enumValueTemplate()}
 # enumValueTemplate
 - IF: ${isArrayProperty(property)}
     -```
-${'#'} ${property}_Value(val)
+# ${property}_Value(val)
 - \${choices(val, '${enumName(entity)}', 'and')}```
 - ELSE:
     -```
-${'#'} ${property}_Value(val)
-- \${${enumName(entity)}(val)}```
+# ${property}_Value(val)
+- '\${${enumName(entity)}(val)}'```
 
 

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/enumProperty.en-us.lg.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/enumProperty.en-us.lg.lg
@@ -7,7 +7,7 @@
 - ```
 ${formImport('form.en-us.lg')}
 ${importLG(`${entity}`)}
-${promptTemplates(missingEnum(), changeEnum())}
+${promptTemplates(missingDefault(), changeDefault())}
 ${confirmationTemplates(expectedSetDefault(), 
                         expectedUpdateDefault(),
                         unexpectedSetDefault(),
@@ -19,18 +19,6 @@ ${showTemplate(showDefault())}
 ${nameTemplate()}
 ${enumValueTemplate()}
 ```
-
-# missingEnum()
-- IF: ${isArrayProperty(property)}
-    - What values do you want to add for ${propertyName()}?
-- ELSE:
-    - What value do you want for ${propertyName()}?
-
-# changeEnum()
-- IF: ${isArrayProperty(property)}
-    - How do you want to change ${propertyName()} of ${propertyCurrentValue()}?
-- ELSE:
-    - What value should replace ${propertyCurrentValue()} in ${propertyName()}?
 
 # repromptEnum()
 - IF: ${isArrayProperty(property)}
@@ -48,7 +36,7 @@ ${enumValueTemplate()}
 - IF: ${isArrayProperty(property)}
     -```
 ${'#'} ${property}_Value(val)
-- \${complexValue(val, '${property}Enum_Value')}```
+- \${choices(val, '${enumName(entity)}', 'and')}```
 - ELSE:
     -```
 ${'#'} ${property}_Value(val)

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/form-Choose.en-us.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/form-Choose.en-us.lg
@@ -5,11 +5,7 @@
 
 # chooseEnumEntity()
 > Choose between enum entity values
-- Please choose a value for ${chooseEntityPropertyName()} from ${chooseEntityValues()} to ${chooseEntityOperation()}
-
-# chooseEnumArrayEntity(property)
-> Choose between a list of enum entity values
-- Please choose a value for ${chooseEntityPropertyName()} from ${chooseEntityValues()} to ${chooseEntityOperation()}
+- Did you mean ${choices(turn.dialogEvent.value.value.value, enumName(turn.dialogEvent.value.value.type), 'or')} for ${chooseEntityPropertyName()}?
 
 # chooseEntityProperty
 > Property from the current event entity
@@ -23,15 +19,16 @@
 > Operation name from the current event entity
 - ${operationName(turn.dialogEvent.value.operation)}
 
-# chooseEntityValues()
-- ${entityValue(turn.dialogEvent.value.value)}
+# enumName(type)
+> Return the name of the template for enum values of entity
+- ${substring(type, 0, indexOf(type, 'Value'))}Enum_Value
 
 >> OnChooseProperty
 
 # chooseProperties
 > Choose between different properties
-- Did you mean ${join(foreach(turn.dialogevent.value, choice, chooseProperty(choice)), " or ")}?
+- Did you mean ${choices(turn.dialogEvent.value, 'chooseProperty', 'or')}?
 
 # chooseProperty(property)
 > Display a possible property assignment
-- ${displayOperation(property.operation, property.property, property.entity)}
+- ${displayOperation(property.operation, property.property, property.value)}

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/form-Choose.en-us.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/form-Choose.en-us.lg
@@ -17,7 +17,7 @@
 
 # chooseEntityOperation()
 > Operation name from the current event entity
-- ${operationName(turn.dialogEvent.value.operation, turn.dialogEvent.value.property)}
+- ${operationName(turn.dialogEvent.value.operation)}
 
 # enumName(type)
 > Return the name of the template for enum values of entity

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/form-Choose.en-us.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/form-Choose.en-us.lg
@@ -17,7 +17,7 @@
 
 # chooseEntityOperation()
 > Operation name from the current event entity
-- ${operationName(turn.dialogEvent.value.operation)}
+- ${operationName(turn.dialogEvent.value.operation, turn.dialogEvent.value.property)}
 
 # enumName(type)
 > Return the name of the template for enum values of entity

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/form-DisplayOperation.en-us.lg.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/form-DisplayOperation.en-us.lg.lg
@@ -9,17 +9,23 @@
 ${'#'} displayOperation(op, property, entity)
 > Display value for a combination of operation, property and entity
 - IF: \${op && property && entity.value} 
-        - \${operationName(op)} \${entity.text} to \${propertyName(property)}
+        - \${operationName(op, property)} \${entity.text} to \${propertyName(property)}
 - ELSEIF: \${op && property}
-        - \${operationName(op)} \${propertyName(property)}
+        - \${operationName(op, property)} \${propertyName(property)}
 - ELSE:
-        - \${operationName(op)}
+        - \${operationName(op, property)}
 
 ${join(flatten([namePlusSwitch(), cases(), default()]), EOL())}
+
+${'#'} addOrSetOp(property)
+- IF: \${isArrayProperty(property)}
+- add
+- ELSE:
+- set
 ```
 
 # namePlusSwitch
--```${'#'} operationName(op) 
+-```${'#'} operationName(op, property) 
 > Display value for an operation
 - SWITCH: \${op}```
 
@@ -27,6 +33,11 @@ ${join(flatten([namePlusSwitch(), cases(), default()]), EOL())}
 - ${foreach(operations, op, case(op))}
 
 # case(op)
+- SWITCH: ${op}
+- CASE: ${'Add()'}
+-```    - CASE: \${'${op}'}
+        - \${addOrSetOp(property)}```
+- DEFAULT:
 -```    - CASE: \${'${op}'}
         - ${phrase(substring(op, 0, indexOf(op, '(')))}```
 

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/form-DisplayOperation.en-us.lg.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/form-DisplayOperation.en-us.lg.lg
@@ -6,26 +6,48 @@
 # template
 -```${formImport('form.en-us.lg')}
 
-${'#'} displayOperation(op, property, entity)
-> Display value for a combination of operation, property and entity
-- IF: \${op && property && entity.value} 
-        - \${operationName(op, property)} \${entity.text} to \${propertyName(property)}
-- ELSEIF: \${op && property}
-        - \${operationName(op, property)} \${propertyName(property)}
+# displayOperation(op, property, value)
+> Display value for a combination of operation, property and value
+- SWITCH: \${op}
+- CASE: \${'Add()'}
+        - \${displayAddOperation(op, property, value)}
+- CASE: \${'Remove()'}
+        - \${displayRemoveOperation(op, property, value)}
+- DEFAULT:
+        - \${displayDefaultOperation(op, property, value)}
+
+# displayAddOperation(op, property, value)
+> Display value for an Add() operation
+- IF: \${property && value && isArrayProperty(property)}
+    - Add "\${value.text}" to \${propertyName(property)}
+- ELSEIF: \${property && value}
+    - Set \${propertyName(property)} to "\${value.text}"
 - ELSE:
-        - \${operationName(op, property)}
+    - \${displayDefaultOperation(op, property, value)}
+
+# displayRemoveOperation(op, property, value)
+> Display value for a Remove() operation
+- IF: \${property && value && isArrayProperty(property)}
+    - Remove "\${value.text}" from \${propertyName(property)}
+- ELSEIF: \${property}
+    - Clear \${propertyName(property)}
+- ELSE:
+    - \${displayDefaultOperation(op, property, value)}
+
+# displayDefaultOperation(op, property, value)
+> Default display value for an operation, property and value
+- IF: \${op && property && value.value} 
+    - \${operationName(op)} \${value.text} to \${propertyName(property)}
+- ELSEIF: \${op && property}
+    - \${operationName(op)} \${propertyName(property)}
+- ELSE:
+    - \${operationName(op)}
 
 ${join(flatten([namePlusSwitch(), cases(), default()]), EOL())}
-
-${'#'} addOrSetOp(property)
-- IF: \${isArrayProperty(property)}
-- add
-- ELSE:
-- set
 ```
 
 # namePlusSwitch
--```${'#'} operationName(op, property) 
+-```# operationName(op) 
 > Display value for an operation
 - SWITCH: \${op}```
 
@@ -33,11 +55,6 @@ ${'#'} addOrSetOp(property)
 - ${foreach(operations, op, case(op))}
 
 # case(op)
-- SWITCH: ${op}
-- CASE: ${'Add()'}
--```    - CASE: \${'${op}'}
-        - \${addOrSetOp(property)}```
-- DEFAULT:
 -```    - CASE: \${'${op}'}
         - ${phrase(substring(op, 0, indexOf(op, '(')))}```
 

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/form-Show.en-us.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/form-Show.en-us.lg
@@ -41,4 +41,4 @@
 
 # getPropertyAsFact(property)
 > Display property value as a card fact
-- {"title": "${propertyName(property)}", "value": "${propertyValue(property, dialog[property])}"}
+- {"title": "${propertyName(property)}", "value": "${replace(propertyValue(property, dialog[property]), '"', '\"')}"}

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/form.en-us.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/form.en-us.lg
@@ -151,7 +151,8 @@ You can also ask for over all help, cancel the whole form or skip a step.```
     - ${concat(join(foreach(subArray(list, 0, count(list) - 1), entry, `"${template(templateName, entry)}"`), ', '), `, ${final} `, `"${template(templateName, last(list))}"`)}
 
 # TODO
-- Update message to add/set depending on array
 - Quote values in correct places
-- Distinguish between Add() and Set() as operations
+- Revisit how choices and PROPERTY_Value interact, right now arrays end up with quotes and values do not which makes other templates variable in a weird way.
+- Add value to property vs. set property to value.  Probably need to update display operation to be smart on add/set.
+
 

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/form.en-us.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/form.en-us.lg
@@ -153,3 +153,5 @@ You can also ask for over all help, cancel the whole form or skip a step.```
 # TODO
 - Update message to add/set depending on array
 - Quote values in correct places
+- Distinguish between Add() and Set() as operations
+

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/form.en-us.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/form.en-us.lg
@@ -13,7 +13,7 @@
 
 # alreadyExistsText(property, entity)
 > Message if a value already exists in an array
-- ${value(entity)} is already in ${propertyName(property)}
+- '${value(entity)}' is already in ${propertyName(property)}
 
 # propertyName(property)
 > Display value for a property
@@ -142,17 +142,10 @@ You can also ask for over all help, cancel the whole form or skip a step.```
 - IF: ${isArray(value)}
     - ${choicesList(value, templateName, final)}
 - ELSE:
-    - ${`"${template(templateName, value)}"`}
+    - ${`'${template(templateName, value)}'`}
 
 # choicesList(list, templateName, final)
 - IF: ${count(list) == 1}
-    - "${template(templateName, list[0])}"
+    - '${template(templateName, list[0])}'
 - ELSE: 
-    - ${concat(join(foreach(subArray(list, 0, count(list) - 1), entry, `"${template(templateName, entry)}"`), ', '), `, ${final} `, `"${template(templateName, last(list))}"`)}
-
-# TODO
-- Quote values in correct places
-- Revisit how choices and PROPERTY_Value interact, right now arrays end up with quotes and values do not which makes other templates variable in a weird way.
-- Add value to property vs. set property to value.  Probably need to update display operation to be smart on add/set.
-
-
+    - ${concat(join(foreach(subArray(list, 0, count(list) - 1), entry, `'${template(templateName, entry)}'`), ', '), `, ${final} `, `'${template(templateName, last(list))}'`)}

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/form.en-us.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/form.en-us.lg
@@ -99,7 +99,7 @@ You can also ask for over all help, cancel the whole form or skip a step.```
 # confirmationText(property, val)
 > Display confirmation text based on whether the property was expected or not
 - IF: ${contains($expectedProperties, property)}
-    - ${template(if(dialog[property], `${property}_ExpectedUpdateConfirmation`, `${property}_ExpectedSetConfirmation`), val)}
+    - ${template(if(dialog[property] && !isArrayProperty(property), `${property}_ExpectedUpdateConfirmation`, `${property}_ExpectedSetConfirmation`), val)}
 - ELSE:
     - ${confirmUpdate(property, val)}
 
@@ -136,3 +136,20 @@ You can also ask for over all help, cancel the whole form or skip a step.```
 # skipExpectedProperties()
 > Create new required properties where expected properties are moved to the end
 - ${union(where($requiredProperties, property, !contains($expectedProperties, property)), where($expectedProperties, property, contains($requiredProperties, property)))}
+
+# choices(value, templateName, final)
+> Apply templateName to simple or list with commas and a final join like and/or.
+- IF: ${isArray(value)}
+    - ${choicesList(value, templateName, final)}
+- ELSE:
+    - ${`"${template(templateName, value)}"`}
+
+# choicesList(list, templateName, final)
+- IF: ${count(list) == 1}
+    - "${template(templateName, list[0])}"
+- ELSE: 
+    - ${concat(join(foreach(subArray(list, 0, count(list) - 1), entry, `"${template(templateName, entry)}"`), ', '), `, ${final} `, `"${template(templateName, last(list))}"`)}
+
+# TODO
+- Update message to add/set depending on array
+- Quote values in correct places

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/standard.en-us.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/standard.en-us.lg
@@ -73,7 +73,7 @@ ${'#'} ${type}Value_Value(entity)
 - IF: ${isArrayProperty(property)}
     - Changes to ${propertyCurrentValue()} in ${propertyName()}?
 - ELSE:
-    - Change ${propertyCurrentValue()} in ${propertyName()} to?
+    - Change "${propertyCurrentValue()}" in ${propertyName()} to?
 
 # repromptDefault(type)
 - ${helpDefault(type)}
@@ -95,16 +95,16 @@ ${'#'} ${type}Value_Value(entity)
 - IF: ${isArrayProperty(property)}
     - Added ${propertyValue('newVal')} to ${propertyName()}
 - ELSE:
-    - Set ${propertyName()} to ${propertyValue('newVal')}
+    - Set ${propertyName()} to "${propertyValue('newVal')}"
 
 # unexpectedUpdateDefault()
 - IF: ${isArrayProperty(property)}
     - ${unexpectedSetDefault()}
 - ELSE:
-    - Changed ${propertyName()} from ${propertyCurrentValue()} to ${propertyValue('newVal')}
+    - Changed ${propertyName()} from "${propertyCurrentValue()}" to "${propertyValue('newVal')}"
 
 # removeDefault()
-- Removed ${propertyValue('val')} from ${propertyName()}
+- Removed "${propertyValue('val')}" from ${propertyName()}
 
 # clearDefault()
 - Cleared ${propertyName()}

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/standard.en-us.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/standard.en-us.lg
@@ -68,13 +68,13 @@ ${'#'} ${type}Value_Value(entity)
 
 # missingDefault(type)
 - IF: ${isArrayProperty(property)}
-    - Enter ${definite(type)} to add to ${propertyName()}
+    - Add to ${propertyName()}?
 - ELSE:
-    - Enter ${definite(type)} for ${propertyName()}
+    - ${sentenceCase(propertyName())}?
 
 # changeDefault(type)
 - IF: ${isArrayProperty(property)}
-    - How do you want to change ${propertyCurrentValue()} in ${propertyName()}
+    - Changes to ${propertyCurrentValue()} in ${propertyName()}?
 - ELSE:
     - Change ${propertyCurrentValue()} in ${propertyName()} to?
 

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/standard.en-us.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/standard.en-us.lg
@@ -67,10 +67,7 @@ ${'#'} ${type}Value_Value(entity)
     - a ${word}
 
 # missingDefault(type)
-- IF: ${isArrayProperty(property)}
-    - Add to ${propertyName()}?
-- ELSE:
-    - ${sentenceCase(propertyName())}?
+- ${sentenceCase(propertyName())}?
 
 # changeDefault(type)
 - IF: ${isArrayProperty(property)}

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/standard.en-us.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/standard.en-us.lg
@@ -71,7 +71,7 @@
 
 # changeDefault(type)
 - IF: ${isArrayProperty(property)}
-    - Changes to ${propertyCurrentValue()} in ${propertyName()}?
+    - Changes to "${propertyCurrentValue()}" in ${propertyName()}?
 - ELSE:
     - Change "${propertyCurrentValue()}" in ${propertyName()} to?
 

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/standard.en-us.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/standard.en-us.lg
@@ -3,23 +3,23 @@
 
 # nameTemplate()
 -```
-${'#'} ${property}_Name
+# ${property}_Name()
 > Name of the '${property}' property
 - ${phrase(property, locale)}```
 
 # valueTemplate()
 -```
-${'#'} ${property}_Value(val)
+# ${property}_Value(val)
 > Display value for '${property}'
  - IF: \${val}
- - \${${if(isArrayProperty(property), 'value(val)', 'val')}}
+ - '\${${if(isArrayProperty(property), 'value(val)', 'val')}}'
  - ELSE:
  - no value
 ```
 
 # complexValueTemplate(type)
 -```
-${'#'} ${property}_Value(val)
+# ${property}_Value(val)
 > Display value for '${property}'
 - \${value(val)}
 ```
@@ -27,13 +27,13 @@ ${'#'} ${property}_Value(val)
 # entityTypeTemplate(type)
 -```${formImport('form.en-us.lg')}
 > Display value for '${type}' entity
-${'#'} ${type}Value_Value(entity)
+# ${type}Value_Value(entity)
 - \${value(entity.value)}
 ```
 
 # entityTextTemplate(type)
 -```
-${'#'} ${type}Value_Value(entity)
+# ${type}Value_Value(entity)
 > Display value for '${type}' entity
 - \${entity.text}
 ```
@@ -95,16 +95,16 @@ ${'#'} ${type}Value_Value(entity)
 - IF: ${isArrayProperty(property)}
     - Added ${propertyValue('newVal')} to ${propertyName()}
 - ELSE:
-    - Set ${propertyName()} to "${propertyValue('newVal')}"
+    - Set ${propertyName()} to ${propertyValue('newVal')}
 
 # unexpectedUpdateDefault()
 - IF: ${isArrayProperty(property)}
     - ${unexpectedSetDefault()}
 - ELSE:
-    - Changed ${propertyName()} from "${propertyCurrentValue()}" to "${propertyValue('newVal')}"
+    - Changed ${propertyName()} from ${propertyCurrentValue()} to ${propertyValue('newVal')}
 
 # removeDefault()
-- Removed "${propertyValue('val')}" from ${propertyName()}
+- Removed ${propertyValue('val')} from ${propertyName()}
 
 # clearDefault()
 - Cleared ${propertyName()}
@@ -140,7 +140,7 @@ ${valueTemplate()}
 
 # stringValidationTemplates()
 - IF: ${propertySchema.pattern}
-    -```${'#'} ${property}_NoPatternMatch(val)
+    -```# ${property}_NoPatternMatch(val)
 - ${propertyValue('val')} does not match ${propertyName()} property pattern \${dialogClass.schema.properties.${property}.pattern}
 ```
 - ELSE:
@@ -211,7 +211,7 @@ ${tooBig()}```
 # tooSmall()
 - IF: ${propertySchema.minimum}
     -```
-${'#'} ${property}_IsTooSmall(val)
+# ${property}_IsTooSmall(val)
 > ${property} property is less than minimum allowed value
 - ${propertyValue('val')} must be at least \${dialogClass.schema.properties.${property}.minimum}${unitsMessage()} for ${propertyName()}```
 - ELSE:
@@ -220,7 +220,7 @@ ${'#'} ${property}_IsTooSmall(val)
 # tooBig()
 - IF: ${propertySchema.maximum}
     -```
-${'#'} ${property}_IsTooBig(val)
+# ${property}_IsTooBig(val)
 > ${property} property is greater than maximum allowed value
 - ${propertyValue('val')} must be no more than \${dialogClass.schema.properties.${property}.maximum}${unitsMessage()} for ${propertyName()}```
 - ELSE:
@@ -239,7 +239,7 @@ ${'#'} ${property}_IsTooBig(val)
 
 # dateFormatValidationMessage()
 - ```
-${'#'} ${property}_invalid${templateName(propertySchema.format)}(val)
+# ${property}_invalid${templateName(propertySchema.format)}(val)
 > Invalid ${propertySchema.format} for '${property}' property
 - \${value(val)} is not a ${propertySchema.format}```
 

--- a/experimental/generation/generator/packages/library/templates/standard/form-BeginDialog.dialog.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/form-BeginDialog.dialog.lg
@@ -8,11 +8,22 @@
 {
     "$schema": "${appSchema}",
     "$kind": "Microsoft.OnBeginDialog",
-    "$comment": "TODO: This is a hack to work around the lack of a way to remit activity or not when invoked.",
     "actions":  [
         {
             "$kind": "Microsoft.SendActivity",
             "activity": "\${welcome()}"           
+        },
+        {
+            "$kind": "Microsoft.IfCondition",
+            "condition": "!turn.activityProcessed",
+            "actions": [
+                {
+                    "$kind": "Microsoft.EmitEvent",
+                    "eventName": "activityReceived",
+                    "eventValue": "=turn.activity",
+                    "bubbleEvent": false
+                }
+            ]
         }
     ]
 }

--- a/experimental/generation/generator/packages/library/templates/standard/form-global.lu.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/form-global.lu.lg
@@ -6,6 +6,6 @@
 # template
 -```
 > Add examples for operations across properties
-${'#'} ${triggerIntent}
+# ${triggerIntent}
 ${substitutions(`${locale}/form-global.${locale}.data`, examples, 6)}
 ```


### PR DESCRIPTION
Change BeginDialog to properly handle if turn.activityProcessed is set to false to pass in trigger phrase.
Update generated prompts to be simpler and more grammatical and to include quotes.
Change $examples lookup to put locale specific first.