### PR TITLE
fix: revert to tilde for generated js deps

### DIFF
--- a/generators/generator-botbuilder/generators/app/templates/core/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/package.json.js
@@ -20,8 +20,8 @@
         "botbuilder": "~4.12.0",
         "botbuilder-ai": "~4.12.0",
         "botbuilder-dialogs": "~4.12.0",
-        "dotenv": "^8.2.0",
-        "restify": "^8.5.1"
+        "dotenv": "~8.2.0",
+        "restify": "~8.5.1"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/generators/generator-botbuilder/generators/app/templates/core/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/package.json.ts
@@ -19,12 +19,12 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "^4.12.0",
-        "botbuilder-ai": "^4.12.0",
-        "botbuilder-dialogs": "^4.12.0",
-        "dotenv": "^8.2.0",
-        "replace": "^1.2.0",
-        "restify": "^8.5.1"
+        "botbuilder": "~4.12.0",
+        "botbuilder-ai": "~4.12.0",
+        "botbuilder-dialogs": "~4.12.0",
+        "dotenv": "~8.2.0",
+        "replace": "~1.2.0",
+        "restify": "~8.5.1"
     },
     "devDependencies": {
         "@types/mocha": "^7.0.2",

--- a/generators/generator-botbuilder/generators/app/templates/echo/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/echo/package.json.js
@@ -16,8 +16,8 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.11.0",
-        "dotenv": "^8.2.0",
+        "botbuilder": "~4.12.0",
+        "dotenv": "~8.2.0",
         "restify": "~8.5.1"
     },
     "devDependencies": {
@@ -27,6 +27,6 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^4.2.1",
         "eslint-plugin-standard": "^4.0.1",
-        "nodemon": "~2.0.4"
+        "nodemon": "^2.0.4"
     }
 }

--- a/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
@@ -18,15 +18,15 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.11.0",
-        "dotenv": "^8.2.0",
+        "botbuilder": "~4.12.0",
+        "dotenv": "~8.2.0",
         "replace": "~1.2.0",
         "restify": "~8.5.1"
     },
     "devDependencies": {
         "@types/restify": "8.4.2",
-        "nodemon": "~2.0.4",
-        "tslint": "~6.1.2",
-        "typescript": "~3.9.2"
+        "nodemon": "^2.0.4",
+        "tslint": "^6.1.2",
+        "typescript": "^3.9.2"
     }
 }

--- a/generators/generator-botbuilder/generators/app/templates/empty/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/empty/package.json.js
@@ -26,6 +26,6 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^4.2.1",
         "eslint-plugin-standard": "^4.0.1",
-        "nodemon": "~2.0.4"
+        "nodemon": "^2.0.4"
     }
 }

--- a/generators/generator-botbuilder/generators/app/templates/empty/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/empty/package.json.ts
@@ -24,8 +24,8 @@
     },
     "devDependencies": {
         "@types/restify": "8.4.2",
-        "nodemon": "~2.0.4",
-        "tslint": "~6.1.2",
-        "typescript": "~3.9.2"
+        "nodemon": "^2.0.4",
+        "tslint": "^6.1.2",
+        "typescript": "^3.9.2"
     }
 }


### PR DESCRIPTION
Use `~` to ensure we pick up patch updates rather than minor and patch updates.

cc @sgellock 