### PR TITLE
Bump js botbuilder refs to 4.13.0

### DIFF
--- a/generators/generator-botbuilder/generators/app/templates/core/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/package.json.js
@@ -17,9 +17,9 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.12.0",
-        "botbuilder-ai": "~4.12.0",
-        "botbuilder-dialogs": "~4.12.0",
+        "botbuilder": "~4.13.0",
+        "botbuilder-ai": "~4.13.0",
+        "botbuilder-dialogs": "~4.13.0",
         "dotenv": "~8.2.0",
         "restify": "~8.5.1"
     },

--- a/generators/generator-botbuilder/generators/app/templates/core/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/package.json.ts
@@ -19,9 +19,9 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.12.0",
-        "botbuilder-ai": "~4.12.0",
-        "botbuilder-dialogs": "~4.12.0",
+        "botbuilder": "~4.13.0",
+        "botbuilder-ai": "~4.13.0",
+        "botbuilder-dialogs": "~4.13.0",
         "dotenv": "~8.2.0",
         "replace": "~1.2.0",
         "restify": "~8.5.1"

--- a/generators/generator-botbuilder/generators/app/templates/echo/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/echo/package.json.js
@@ -16,7 +16,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.12.0",
+        "botbuilder": "~4.13.0",
         "dotenv": "~8.2.0",
         "restify": "~8.5.1"
     },

--- a/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
@@ -18,7 +18,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.12.0",
+        "botbuilder": "~4.13.0",
         "dotenv": "~8.2.0",
         "replace": "~1.2.0",
         "restify": "~8.5.1"

--- a/generators/generator-botbuilder/generators/app/templates/empty/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/empty/package.json.js
@@ -16,7 +16,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.12.0",
+        "botbuilder": "~4.13.0",
         "restify": "~8.5.1"
     },
     "devDependencies": {

--- a/generators/generator-botbuilder/generators/app/templates/empty/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/empty/package.json.ts
@@ -18,7 +18,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.12.0",
+        "botbuilder": "~4.13.0",
         "replace": "~1.2.0",
         "restify": "~8.5.1"
     },


### PR DESCRIPTION
Update generator to emit projects that refer to `botbuilder*` version `~4.13.0`.