### PR TITLE
[Samples][Java] Fix disparities of 40.timex-resolution sample

### DIFF
--- a/samples/java_springboot/40.timex-resolution/README.md
+++ b/samples/java_springboot/40.timex-resolution/README.md
@@ -344,7 +344,6 @@ The TIMEX expression library is contained in the same GitHub repo as the recogni
 
 ## Further reading
 
-- [Bot Framework Documentation](https://docs.botframework.com)
 - [Bot Basics](https://docs.microsoft.com/azure/bot-service/bot-builder-basics?view=azure-bot-service-4.0)
 - [TIMEX](https://en.wikipedia.org/wiki/TimeML#TIMEX3)
 - [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)


### PR DESCRIPTION
Related to microsoft/botbuilder-java#1165

## Proposed Changes
We compared the documentation/code migration/behavior of the `40.timex-resolution` sample between [Java](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/java_springboot/40.timex-resolution) and [C#](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/csharp_dotnetcore/40.timex-resolution) and we found disparities and fixes that this PR includes.

- Remove redundant link of README ([Azure Bot Service Documentation](https://docs.microsoft.com/en-us/azure/bot-service/?view=azure-bot-service-4.0) contains the same link)

## Testing
_Timex  resolution sample working as expected_
![image](https://user-images.githubusercontent.com/11904023/116890529-1c534d00-ac04-11eb-9607-27a35cfac85d.png)