### PR TITLE
Adding inline-image download node js

### DIFF
--- a/samples/javascript_nodejs/56.teams-file-upload/README.md
+++ b/samples/javascript_nodejs/56.teams-file-upload/README.md
@@ -2,8 +2,9 @@
 
 Bot Framework v4 file upload bot sample for Teams.
 
-This bot has been created using [Bot Framework](https://dev.botframework.com), it shows how to
-upload files to Teams from a bot and how to receive a file sent to a bot as an attachment.
+This bot has been created using [Bot Framework](https://dev.botframework.com), it shows how to -
+-   Upload files to Teams from a bot and how to receive a file sent to a bot as an attachment.
+-   How to automatically fetch and save an inline image sent to a bot as a message.
 
 ## Prerequisites
 
@@ -58,9 +59,15 @@ the Teams service needs to call into the bot.
 
 > Note this `manifest.json` specified that the bot will be installed in "personal" scope which is why you immediately entered a one on one chat conversation with the bot. Please refer to Teams documentation for more details.
 
-Sending a message to the bot will cause it to respond with a card that will prompt you to upload a file. The file that's being uploaded is the `teams-logo.png` in the `Files` directory in this sample. The `Accept` and `Decline` events illustrated in this sample are specific to Teams. You can message the bot again to receive another prompt.
+1. Sending a message to the bot will cause it to respond with a card that will prompt you to upload a file. The file that's being uploaded is the `teams-logo.png` in the `Files` directory in this sample. The `Accept` and `Decline` events illustrated in this sample are specific to Teams. You can message the bot again to receive another prompt.
 
-You can also send a file to the bot as an attachment in the message compose section in Teams. This will be delivered to the bot as a Message Activity and the code in this sample fetches and saves the file.
+![image](https://user-images.githubusercontent.com/85108465/120271113-53cb1d00-c2c8-11eb-9465-b8b0122fdb0b.png)
+
+2. Sending an inline image from the message compose section to bot will cause the image to be downloaded in the `Files` directory and bot will send an prompt with the image details and image in a card. This will be present in the attachments of the Activity and requires the Bot's access token to fetch the image.
+
+![image](https://user-images.githubusercontent.com/85108465/120273432-1bc5d900-c2cc-11eb-9182-a1167c76228f.png)
+
+3. You can also send a file to the bot as an attachment in the message compose section in Teams. This will be delivered to the bot as a Message Activity and the code in this sample fetches and saves the file.
 
 ## Deploy the bot to Azure
 

--- a/samples/javascript_nodejs/56.teams-file-upload/bots/teamsFileUploadBot.js
+++ b/samples/javascript_nodejs/56.teams-file-upload/bots/teamsFileUploadBot.js
@@ -116,7 +116,7 @@ class TeamsFileUploadBot extends TeamsActivityHandler {
         const filePath = path.join(FILES_DIR, fileName);
         await writeFile(file.contentUrl, config, filePath);
         const fileSize = await getFileSize(filePath);
-        var reply = MessageFactory.text(`Image <b>${ fileName }</b> of size <b>${ fileSize }</b> bytes received and saved.`);
+        const reply = MessageFactory.text(`Image <b>${ fileName }</b> of size <b>${ fileSize }</b> bytes received and saved.`);
         const inlineAttachment = this.getInlineAttachment(fileName);
         reply.attachments = [inlineAttachment];
         await context.sendActivity(reply);

--- a/samples/javascript_nodejs/56.teams-file-upload/services/fileService.js
+++ b/samples/javascript_nodejs/56.teams-file-upload/services/fileService.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const util = require('util');
+const axios = require('axios');
+const readdir = util.promisify(fs.readdir);
+
+// Generates File Name with Sequence
+const GeneFileName = async (FileDir)=>{
+    let filenameConst = `UserAttachment`
+    let files = await readdir(FileDir)
+    let filteredFiles  = files.filter(f => f.includes(filenameConst)).map(f => parseInt(f.split(filenameConst)[1].split('.')[0]))
+    let maxSeq = 0
+    if(filteredFiles.length > 0){
+        maxSeq = Math.max.apply(Math, filteredFiles);
+    }else{
+        maxSeq = 0
+    }
+    let filename = `${filenameConst}${maxSeq + 1}.png`
+    return filename;
+}
+
+// Download and Save Streams into File
+const WriteFile = async (contentUrl, config, filePath) =>{
+    return new Promise(async (resolve)=>{
+        const response = await axios.get(contentUrl, config);
+        let stream = response.data.pipe(fs.createWriteStream(filePath));
+        stream.on('finish', () =>{
+            resolve();
+        });
+    })
+}
+
+// Returns File Size
+const GetFileSize = async (FilePath) =>{
+    stats = fs.statSync(FilePath)
+    return stats.size;
+}
+
+module.exports = {
+    GeneFileName,
+    GetFileSize,
+    WriteFile
+}

--- a/samples/javascript_nodejs/56.teams-file-upload/services/fileService.js
+++ b/samples/javascript_nodejs/56.teams-file-upload/services/fileService.js
@@ -14,10 +14,9 @@ const geneFileName = async (fileDir) => {
 };
 
 // Download and Save Streams into File
-const writeFile = async (contentUrl, filePath) => {
+const writeFile = async (contentUrl, config, filePath) => {
     const response = await axios({ method: 'GET', url: contentUrl, responseType: 'stream' });
-    return await new Promise((resolve, reject) => response.pipe(fs.createWriteStream(filePath)).once('finish', resolve).once('error', reject));
-    
+    return await new Promise((resolve, reject) => response.pipe(fs.createWriteStream(filePath)).once('finish', resolve).once('error', reject));    
 };
 
 // Returns File Size

--- a/samples/javascript_nodejs/56.teams-file-upload/services/fileService.js
+++ b/samples/javascript_nodejs/56.teams-file-upload/services/fileService.js
@@ -4,7 +4,7 @@ const axios = require('axios');
 const readdir = util.promisify(fs.readdir);
 
 // Generates File Name with Sequence
-const GeneFileName = async (fileDir) => {
+const geneFileName = async (fileDir) => {
     const filenameConst = 'UserAttachment';
     const files = await readdir(fileDir);
     const filteredFiles = files.filter(f => f.includes(filenameConst)).map(f => parseInt(f.split(filenameConst)[1].split('.')[0]));
@@ -19,7 +19,7 @@ const GeneFileName = async (fileDir) => {
 };
 
 // Download and Save Streams into File
-const WriteFile = async (contentUrl, config, filePath) => {
+const writeFile = async (contentUrl, config, filePath) => {
     return new Promise((resolve) => {
         axios.get(contentUrl, config).then(response => {
             const stream = response.data.pipe(fs.createWriteStream(filePath));
@@ -29,24 +29,15 @@ const WriteFile = async (contentUrl, config, filePath) => {
         });
     });
 };
-// const WriteFile = async (contentUrl, config, filePath) => {
-//     return new Promise(async (resolve) => {
-//         const response = await axios.get(contentUrl, config);
-//         const stream = response.data.pipe(fs.createWriteStream(filePath));
-//         stream.on('finish', () => {
-//             resolve();
-//         });
-//     });
-// };
 
 // Returns File Size
-const GetFileSize = async (FilePath) => {
+const getFileSize = async (FilePath) => {
     const stats = fs.statSync(FilePath);
     return stats.size;
 };
 
 module.exports = {
-    GeneFileName,
-    GetFileSize,
-    WriteFile
+    geneFileName,
+    getFileSize,
+    writeFile
 };

--- a/samples/javascript_nodejs/56.teams-file-upload/services/fileService.js
+++ b/samples/javascript_nodejs/56.teams-file-upload/services/fileService.js
@@ -8,27 +8,14 @@ const geneFileName = async (fileDir) => {
     const filenameConst = 'UserAttachment';
     const files = await readdir(fileDir);
     const filteredFiles = files.filter(f => f.includes(filenameConst)).map(f => parseInt(f.split(filenameConst)[1].split('.')[0]));
-    let maxSeq = 0;
-    if (filteredFiles.length > 0) {
-        maxSeq = Math.max.apply(Math, filteredFiles);
-    } else {
-        maxSeq = 0;
-    }
+    const maxSeq = Math.max(0, filteredFiles);
     const filename = `${ filenameConst }${ maxSeq + 1 }.png`;
     return filename;
 };
 
 // Download and Save Streams into File
-const writeFile = async (contentUrl, config, filePath) => {
-    return new Promise((resolve) => {
-        axios.get(contentUrl, config).then(response => {
-            const stream = response.data.pipe(fs.createWriteStream(filePath));
-            stream.on('finish', () => {
-                resolve();
-            });
-        });
-    });
-};
+const response = await axios({ method: 'GET', url: contentUrl, responseType: 'stream' });
+await new Promise((resolve, reject) => response.pipe(fs.createWriteStream(filePath)).once('finish', resolve).once('error', reject));
 
 // Returns File Size
 const getFileSize = async (FilePath) => {

--- a/samples/javascript_nodejs/56.teams-file-upload/services/fileService.js
+++ b/samples/javascript_nodejs/56.teams-file-upload/services/fileService.js
@@ -4,39 +4,49 @@ const axios = require('axios');
 const readdir = util.promisify(fs.readdir);
 
 // Generates File Name with Sequence
-const GeneFileName = async (FileDir)=>{
-    let filenameConst = `UserAttachment`
-    let files = await readdir(FileDir)
-    let filteredFiles  = files.filter(f => f.includes(filenameConst)).map(f => parseInt(f.split(filenameConst)[1].split('.')[0]))
-    let maxSeq = 0
-    if(filteredFiles.length > 0){
+const GeneFileName = async (fileDir) => {
+    const filenameConst = 'UserAttachment';
+    const files = await readdir(fileDir);
+    const filteredFiles = files.filter(f => f.includes(filenameConst)).map(f => parseInt(f.split(filenameConst)[1].split('.')[0]));
+    let maxSeq = 0;
+    if (filteredFiles.length > 0) {
         maxSeq = Math.max.apply(Math, filteredFiles);
-    }else{
-        maxSeq = 0
+    } else {
+        maxSeq = 0;
     }
-    let filename = `${filenameConst}${maxSeq + 1}.png`
+    const filename = `${ filenameConst }${ maxSeq + 1 }.png`;
     return filename;
-}
+};
 
 // Download and Save Streams into File
-const WriteFile = async (contentUrl, config, filePath) =>{
-    return new Promise(async (resolve)=>{
-        const response = await axios.get(contentUrl, config);
-        let stream = response.data.pipe(fs.createWriteStream(filePath));
-        stream.on('finish', () =>{
-            resolve();
+const WriteFile = async (contentUrl, config, filePath) => {
+    return new Promise((resolve) => {
+        axios.get(contentUrl, config).then(response => {
+            const stream = response.data.pipe(fs.createWriteStream(filePath));
+            stream.on('finish', () => {
+                resolve();
+            });
         });
-    })
-}
+    });
+};
+// const WriteFile = async (contentUrl, config, filePath) => {
+//     return new Promise(async (resolve) => {
+//         const response = await axios.get(contentUrl, config);
+//         const stream = response.data.pipe(fs.createWriteStream(filePath));
+//         stream.on('finish', () => {
+//             resolve();
+//         });
+//     });
+// };
 
 // Returns File Size
-const GetFileSize = async (FilePath) =>{
-    stats = fs.statSync(FilePath)
+const GetFileSize = async (FilePath) => {
+    const stats = fs.statSync(FilePath);
     return stats.size;
-}
+};
 
 module.exports = {
     GeneFileName,
     GetFileSize,
     WriteFile
-}
+};

--- a/samples/javascript_nodejs/56.teams-file-upload/services/fileService.js
+++ b/samples/javascript_nodejs/56.teams-file-upload/services/fileService.js
@@ -14,8 +14,11 @@ const geneFileName = async (fileDir) => {
 };
 
 // Download and Save Streams into File
-const response = await axios({ method: 'GET', url: contentUrl, responseType: 'stream' });
-await new Promise((resolve, reject) => response.pipe(fs.createWriteStream(filePath)).once('finish', resolve).once('error', reject));
+const writeFile = async (contentUrl, filePath) => {
+    const response = await axios({ method: 'GET', url: contentUrl, responseType: 'stream' });
+    return await new Promise((resolve, reject) => response.pipe(fs.createWriteStream(filePath)).once('finish', resolve).once('error', reject));
+    
+};
 
 // Returns File Size
 const getFileSize = async (FilePath) => {


### PR DESCRIPTION
##Description

Adding processing inline-image in current sample `56.teams-file-upload` bot. 

Language used: node js

## Proposed Changes
1. Adding inline image download in current sample

##Testing

1. Sending a message to the bot will cause it to respond with a card that will prompt you to upload a file. The file that's being uploaded is the `teams-logo.png` in the `Files` directory in this sample. The `Accept` and `Decline` events illustrated in this sample are specific to Teams. You can message the bot again to receive another prompt.

![image](https://user-images.githubusercontent.com/85108465/120271113-53cb1d00-c2c8-11eb-9465-b8b0122fdb0b.png)

2. Sending an inline image from the message compose section to bot will cause the image to be downloaded in the `Files` directory and bot will send an prompt with the image details and image in a card. This will be present in the attachments of the Activity and requires the Bot's access token to fetch the image.

![image](https://user-images.githubusercontent.com/85108465/120273432-1bc5d900-c2cc-11eb-9182-a1167c76228f.png)

