### PR TITLE
fix: bump typescript version to 4.3.2

### DIFF
--- a/samples/typescript_nodejs/00.empty-bot/package.json
+++ b/samples/typescript_nodejs/00.empty-bot/package.json
@@ -26,6 +26,6 @@
         "@types/restify": "8.4.2",
         "nodemon": "~2.0.4",
         "tslint": "~6.1.2",
-        "typescript": "~3.9.2"
+        "typescript": "~4.3.2"
     }
 }

--- a/samples/typescript_nodejs/01.console-echo/package.json
+++ b/samples/typescript_nodejs/01.console-echo/package.json
@@ -19,6 +19,6 @@
   "devDependencies": {
     "nodemon": "~1.19.4",
     "tslint": "^5.20.0",
-    "typescript": "^3.6.4"
+    "typescript": "~4.3.2"
   }
 }

--- a/samples/typescript_nodejs/02.echo-bot/package.json
+++ b/samples/typescript_nodejs/02.echo-bot/package.json
@@ -28,6 +28,6 @@
         "@types/restify": "8.4.2",
         "nodemon": "~2.0.4",
         "tslint": "~6.1.2",
-        "typescript": "~3.9.2"
+        "typescript": "~4.3.2"
     }
 }

--- a/samples/typescript_nodejs/03.welcome-users/package.json
+++ b/samples/typescript_nodejs/03.welcome-users/package.json
@@ -26,6 +26,6 @@
         "@types/restify": "8.4.2",
         "nodemon": "~1.19.4",
         "tslint": "~5.20.0",
-        "typescript": "~3.6.4"
+        "typescript": "~4.3.2"
     }
 }

--- a/samples/typescript_nodejs/05.multi-turn-prompt/package.json
+++ b/samples/typescript_nodejs/05.multi-turn-prompt/package.json
@@ -28,6 +28,6 @@
         "@types/restify": "8.4.2",
         "nodemon": "~1.19.4",
         "tslint": "~5.20.0",
-        "typescript": "~3.6.4"
+        "typescript": "~4.3.2"
     }
 }

--- a/samples/typescript_nodejs/06.using-cards/package.json
+++ b/samples/typescript_nodejs/06.using-cards/package.json
@@ -28,6 +28,6 @@
         "@types/restify": "8.4.2",
         "nodemon": "~1.19.4",
         "tslint": "~5.20.0",
-        "typescript": "~3.6.4"
+        "typescript": "~4.3.2"
     }
 }

--- a/samples/typescript_nodejs/13.core-bot/package.json
+++ b/samples/typescript_nodejs/13.core-bot/package.json
@@ -55,6 +55,6 @@
         "nyc": "^15.0.1",
         "ts-node": "^8.10.1",
         "tslint": "~6.1.2",
-        "typescript": "~3.9.2"
+        "typescript": "~4.3.2"
     }
 }

--- a/samples/typescript_nodejs/16.proactive-messages/package.json
+++ b/samples/typescript_nodejs/16.proactive-messages/package.json
@@ -28,6 +28,6 @@
         "@types/restify": "8.4.2",
         "nodemon": "~1.19.4",
         "tslint": "~5.20.0",
-        "typescript": "~3.6.4"
+        "typescript": "~4.3.2"
     }
 }

--- a/samples/typescript_nodejs/50.teams-messaging-extensions-search/package.json
+++ b/samples/typescript_nodejs/50.teams-messaging-extensions-search/package.json
@@ -29,6 +29,6 @@
     "@types/restify": "8.4.2",
     "nodemon": "~1.19.4",
     "tslint": "~5.20.0",
-    "typescript": "~3.6.4"
+    "typescript": "~4.3.2"
   }
 }

--- a/samples/typescript_nodejs/51.teams-messaging-extensions-action/package.json
+++ b/samples/typescript_nodejs/51.teams-messaging-extensions-action/package.json
@@ -29,6 +29,6 @@
     "@types/restify": "8.4.2",
     "nodemon": "~1.19.4",
     "tslint": "~5.20.0",
-    "typescript": "~3.6.4"
+    "typescript": "~4.3.2"
   }
 }

--- a/samples/typescript_nodejs/57.teams-conversation-bot/package.json
+++ b/samples/typescript_nodejs/57.teams-conversation-bot/package.json
@@ -28,6 +28,6 @@
         "@types/restify": "8.4.2",
         "nodemon": "~1.19.4",
         "tslint": "~5.20.0",
-        "typescript": "~3.6.4"
+        "typescript": "~4.3.2"
     }
 }

--- a/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/package.json
+++ b/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/package.json
@@ -28,6 +28,6 @@
         "@types/restify": "8.4.2",
         "nodemon": "~1.19.4",
         "tslint": "~5.20.0",
-        "typescript": "~3.6.4"
+        "typescript": "~4.3.2"
     }
 }


### PR DESCRIPTION
#minor

Fixes some [broken pipelines](https://fuselabs.visualstudio.com/SDK_v4/_build/results?buildId=250685&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a&t=c2b66b3d-aa49-589b-dfee-68fd1060458b&l=78)