### PR TITLE
Fix MicrosoftAppID typo

### DIFF
--- a/samples/javascript_nodejs/07.using-adaptive-cards/index.js
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/index.js
@@ -17,7 +17,7 @@ const { AdaptiveCardsBot } = require('./bots/adaptiveCardsBot');
 
 // Create adapter. See https://aka.ms/about-bot-adapter to learn more about adapters.
 const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppID,
+    appId: process.env.MicrosoftAppId,
     appPassword: process.env.MicrosoftAppPassword
 });
 

--- a/samples/javascript_nodejs/15.handling-attachments/index.js
+++ b/samples/javascript_nodejs/15.handling-attachments/index.js
@@ -17,7 +17,7 @@ const { AttachmentsBot } = require('./bots/attachmentsBot');
 
 // Create adapter. See https://aka.ms/about-bot-adapter to learn more about adapters.
 const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppID,
+    appId: process.env.MicrosoftAppId,
     appPassword: process.env.MicrosoftAppPassword
 });
 

--- a/samples/typescript_nodejs/00.empty-bot/src/index.ts
+++ b/samples/typescript_nodejs/00.empty-bot/src/index.ts
@@ -19,7 +19,7 @@ server.listen(process.env.port || process.env.PORT || 3978, () => {
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.
 const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppID,
+    appId: process.env.MicrosoftAppId,
     appPassword: process.env.MicrosoftAppPassword
 });
 

--- a/samples/typescript_nodejs/03.welcome-users/src/index.ts
+++ b/samples/typescript_nodejs/03.welcome-users/src/index.ts
@@ -19,7 +19,7 @@ server.listen(process.env.port || process.env.PORT || 3978, () => {
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.
 const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppID,
+    appId: process.env.MicrosoftAppId,
     appPassword: process.env.MicrosoftAppPassword
 });
 

--- a/samples/typescript_nodejs/13.core-bot/src/index.ts
+++ b/samples/typescript_nodejs/13.core-bot/src/index.ts
@@ -29,7 +29,7 @@ import { FlightBookingRecognizer } from './dialogs/flightBookingRecognizer';
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.
 const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppID,
+    appId: process.env.MicrosoftAppId,
     appPassword: process.env.MicrosoftAppPassword
 });
 


### PR DESCRIPTION
Fixes #3316

## Proposed Changes

  - Change `MicrosoftAppID` to `MicrosoftAppId` in 2 JavaScript files and 3 TypeScript files
