### PR TITLE
Fix markdown in proactive Typescript README.md

### DIFF
--- a/samples/typescript_nodejs/16.proactive-messages/README.md
+++ b/samples/typescript_nodejs/16.proactive-messages/README.md
@@ -22,6 +22,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
     ```bash
     npm install
     ```
+
 - Start the bot
 
     ```bash
@@ -56,10 +57,10 @@ Use a tool like Postman or CURL to send notifcations to your bot using a Post re
 
 ### Publishing Changes to Azure Bot Service
 
-    ```bash
-    # build the TypeScript bot before you publish
-    npm run build
-    ```
+```bash
+# build the TypeScript bot before you publish
+npm run build
+```
 
 To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.
 


### PR DESCRIPTION
Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Proposed Changes

- Surround fenced code block with blank lines (per markdown guidelines)
- Unindent indented fenced code block outside of a list (fixes broken markdown rendering)

What it currently looks like:

    ```bash
    # build the TypeScript bot before you publish
    npm run build
    ```

What it's supposed to look like:

```bash
# build the TypeScript bot before you publish
npm run build
```