### PR TITLE
Corrects casing of "TaskModuleUIConstants" filename in require statement

### DIFF
--- a/samples/javascript_nodejs/54.teams-task-module/bots/teamsTaskModuleBot.js
+++ b/samples/javascript_nodejs/54.teams-task-module/bots/teamsTaskModuleBot.js
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 const { TeamsActivityHandler, MessageFactory, CardFactory } = require('botbuilder');
-const { TaskModuleUIConstants } = require('../models/TaskModuleUIConstants');
+const { TaskModuleUIConstants } = require('../models/taskModuleUIConstants');
 const { TaskModuleIds } = require('../models/taskmoduleids');
 const { TaskModuleResponseFactory } = require('../models/taskmoduleresponsefactory');
 


### PR DESCRIPTION
Fixes #3320

## Proposed Changes
  - Changes the casing of the referenced "TaskModuleUIConstants" filename to "taskModuleUIConstants" to match the actual filename.