### PR TITLE
Removes appId validation in skill samples

### DIFF
--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/README.md
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/README.md
@@ -58,4 +58,4 @@ The solution includes a parent bot (`SimpleRootBot`) and a skill bot (`EchoSkill
 
 ## Deploy the bots to Azure
 
-To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.
+To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions. 

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/README.md
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/README.md
@@ -37,9 +37,9 @@ The solution includes a parent bot (`SimpleRootBot`) and a skill bot (`EchoSkill
     git clone https://github.com/microsoft/botbuilder-samples.git
     ```
 
-- Create a bot registration in the azure portal for the `EchoSkillBot` and update [EchoSkillBot/appsettings.json](EchoSkillBot/appsettings.json) with the `MicrosoftAppId` and `MicrosoftAppPassword` of the new bot registration
-- Create a bot registration in the azure portal for the `SimpleRootBot` and update [SimpleRootBot/appsettings.json](SimpleRootBot/appsettings.json) with the `MicrosoftAppId` and `MicrosoftAppPassword` of the new bot registration
-- Update the `BotFrameworkSkills` section in [SimpleRootBot/appsettings.json](SimpleRootBot/appsettings.json) with the app ID for the skill you created in the previous step
+- (Optionally) Create a bot registration in the azure portal for the `EchoSkillBot` and update [EchoSkillBot/appsettings.json](EchoSkillBot/appsettings.json) with the `MicrosoftAppId` and `MicrosoftAppPassword` of the new bot registration
+- (Optionally) Create a bot registration in the azure portal for the `SimpleRootBot` and update [SimpleRootBot/appsettings.json](SimpleRootBot/appsettings.json) with the `MicrosoftAppId` and `MicrosoftAppPassword` of the new bot registration
+- (Optionally) Update the `BotFrameworkSkills` section in [SimpleRootBot/appsettings.json](SimpleRootBot/appsettings.json) with the app ID for the skill you created in the previous step
 - (Optionally) Add the `SimpleRootBot` `MicrosoftAppId` to the `AllowedCallers` list in [EchoSkillBot/appsettings.json](EchoSkillBot/appsettings.json) 
 - Open the `SimpleBotToBot.sln` solution and configure it to [start debugging with multiple processes](https://docs.microsoft.com/en-us/visualstudio/debugger/debug-multiple-processes?view=vs-2019#start-debugging-with-multiple-processes)
 

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/Bots/RootBot.cs
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/Bots/RootBot.cs
@@ -40,7 +40,7 @@ namespace Microsoft.BotBuilderSamples.SimpleRootBot.Bots
 
             // We use a single skill in this example.
             var targetSkillId = "EchoSkillBot";
-            _skillsConfig.Skills.TryGetValue(targetSkillId, out _targetSkill)
+            _skillsConfig.Skills.TryGetValue(targetSkillId, out _targetSkill);
 
             // Create state property to track the active skill
             _activeSkillProperty = conversationState.CreateProperty<BotFrameworkSkill>(ActiveSkillPropertyName);

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/Bots/RootBot.cs
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/Bots/RootBot.cs
@@ -37,17 +37,10 @@ namespace Microsoft.BotBuilderSamples.SimpleRootBot.Bots
             }
 
             _botId = configuration.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey)?.Value;
-            if (string.IsNullOrWhiteSpace(_botId))
-            {
-                throw new ArgumentException($"{MicrosoftAppCredentials.MicrosoftAppIdKey} is not set in configuration");
-            }
 
             // We use a single skill in this example.
             var targetSkillId = "EchoSkillBot";
-            if (!_skillsConfig.Skills.TryGetValue(targetSkillId, out _targetSkill))
-            {
-                throw new ArgumentException($"Skill with ID \"{targetSkillId}\" not found in configuration");
-            }
+            _skillsConfig.Skills.TryGetValue(targetSkillId, out _targetSkill)
 
             // Create state property to track the active skill
             _activeSkillProperty = conversationState.CreateProperty<BotFrameworkSkill>(ActiveSkillPropertyName);

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/appsettings.json
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/appsettings.json
@@ -5,7 +5,7 @@
   "BotFrameworkSkills": [
     {
       "Id": "EchoSkillBot",
-      "AppId": "TODO: Add here the App ID for the skill",
+      "AppId": "",
       "SkillEndpoint": "http://localhost:39783/api/messages"
     }
   ]

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/Dialogs/MainDialog.cs
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/Dialogs/MainDialog.cs
@@ -40,10 +40,10 @@ namespace Microsoft.BotBuilderSamples.DialogRootBot.Dialogs
             : base(nameof(MainDialog))
         {
             var botId = configuration.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey)?.Value;
-            if (string.IsNullOrWhiteSpace(botId))
-            {
-                throw new ArgumentException($"{MicrosoftAppCredentials.MicrosoftAppIdKey} is not in configuration");
-            }
+            // if (string.IsNullOrWhiteSpace(botId))
+            // {
+            //     throw new ArgumentException($"{MicrosoftAppCredentials.MicrosoftAppIdKey} is not in configuration");
+            // }
 
             _skillsConfig = skillsConfig ?? throw new ArgumentNullException(nameof(skillsConfig));
 

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/Dialogs/MainDialog.cs
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/Dialogs/MainDialog.cs
@@ -40,10 +40,6 @@ namespace Microsoft.BotBuilderSamples.DialogRootBot.Dialogs
             : base(nameof(MainDialog))
         {
             var botId = configuration.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey)?.Value;
-            // if (string.IsNullOrWhiteSpace(botId))
-            // {
-            //     throw new ArgumentException($"{MicrosoftAppCredentials.MicrosoftAppIdKey} is not in configuration");
-            // }
 
             _skillsConfig = skillsConfig ?? throw new ArgumentNullException(nameof(skillsConfig));
 

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/appsettings.json
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/appsettings.json
@@ -1,12 +1,12 @@
 {
-  "MicrosoftAppId": "TODO: Add here the App ID for the bot",
-  "MicrosoftAppPassword": "TODO: Add here the password for the bot",
+  "MicrosoftAppId": "",
+  "MicrosoftAppPassword": "",
 
   "SkillHostEndpoint": "http://localhost:3978/api/skills/",
   "BotFrameworkSkills": [
     {
       "Id": "DialogSkillBot",
-      "AppId": "TODO: Add here the App ID for the skill",
+      "AppId": "",
       "SkillEndpoint": "http://localhost:39783/api/messages"
     }
   ]

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/README.md
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/README.md
@@ -51,9 +51,9 @@ It demonstrates how to post activities from the parent bot to the skill bot and 
   git clone https://github.com/microsoft/botbuilder-samples.git
   ```
 
-- Create a bot registration in the azure portal for the `DialogSkillBot` and update [DialogSkillBot/appsettings.json](DialogSkillBot/appsettings.json) with the AppId and password.
-- Create a bot registration in the azure portal for the DialogRootBot and update [DialogRootBot/appsettings.json](DialogRootBot/appsettings.json) with the AppId and password. 
-- Update the BotFrameworkSkills section in [DialogRootBot/appsettings.json](DialogRootBot/appsettings.json) with the AppId for the skill you created in the previous step.
+- (Optionally) Create a bot registration in the azure portal for the `DialogSkillBot` and update [DialogSkillBot/appsettings.json](DialogSkillBot/appsettings.json) with the AppId and password.
+- (Optionally) Create a bot registration in the azure portal for the DialogRootBot and update [DialogRootBot/appsettings.json](DialogRootBot/appsettings.json) with the AppId and password. 
+- (Optionally) Update the BotFrameworkSkills section in [DialogRootBot/appsettings.json](DialogRootBot/appsettings.json) with the AppId for the skill you created in the previous step.
 - (Optional) Configure the LuisAppId, LuisAPIKey and LuisAPIHostName section in the [DialogSkillBot/appsettings.json](DialogSkillBot/appsettings.json) if you want to run message activities through LUIS.
 - Open the `SkillDialogSample.sln` solution and configure it to [start debugging with multiple processes](https://docs.microsoft.com/en-us/visualstudio/debugger/debug-multiple-processes?view=vs-2019#start-debugging-with-multiple-processes).
 

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/README.md
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/README.md
@@ -35,9 +35,9 @@ The solution includes a parent bot (`simple-root-bot`) and a skill bot (`echo-sk
     git clone https://github.com/microsoft/botbuilder-samples.git
     ```
 
-- Create a bot registration in the azure portal for the `echo-skill-bot` and update [echo-skill-bot/.env](echo-skill-bot/.env) with the `MicrosoftAppId` and `MicrosoftAppPassword` of the new bot registration
-- Create a bot registration in the azure portal for the `simple-root-bot` and update [simple-root-bot/.env](simple-root-bot/.env) with the `MicrosoftAppId` and `MicrosoftAppPassword` of the new bot registration
-- Update the `SkillAppId` variable in [simple-root-bot/.env](simple-root-bot/.env) with the `AppId` for the skill you created in the previous step
+- (Optionally) Create a bot registration in the azure portal for the `echo-skill-bot` and update [echo-skill-bot/.env](echo-skill-bot/.env) with the `MicrosoftAppId` and `MicrosoftAppPassword` of the new bot registration
+- (Optionally) Create a bot registration in the azure portal for the `simple-root-bot` and update [simple-root-bot/.env](simple-root-bot/.env) with the `MicrosoftAppId` and `MicrosoftAppPassword` of the new bot registration
+- (Optionally) Update the `SkillAppId` variable in [simple-root-bot/.env](simple-root-bot/.env) with the `AppId` for the skill you created in the previous step
 - (Optionally) Add the `simple-root-bot` `MicrosoftAppId` to the `AllowedCallers` comma separated list in [echo-skill-bot/.env](echo-skill-bot/.env)
 - In a terminal, navigate to `samples\javascript_nodejs\80.skills-simple-bot-to-bot\echo-skill-bot`
 

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/.env
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/.env
@@ -3,5 +3,5 @@ MicrosoftAppPassword=
 SkillHostEndpoint=http://localhost:3978/api/skills/
 
 SkillId=EchoSkillBot
-SkillAppId=TODO: Add here the App ID for the skill
+SkillAppId=
 SkillEndpoint=http://localhost:39783/api/messages

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/rootBot.js
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/rootBot.js
@@ -15,16 +15,10 @@ class RootBot extends ActivityHandler {
         this.skillClient = skillClient;
 
         this.botId = process.env.MicrosoftAppId;
-        if (!this.botId) {
-            throw new Error('[RootBot] MicrosoftAppId is not set in configuration');
-        }
 
         // We use a single skill in this example.
         const targetSkillId = 'EchoSkillBot';
         this.targetSkill = skillsConfig.skills[targetSkillId];
-        if (!this.targetSkill) {
-            throw new Error(`[RootBot] Skill with ID "${ targetSkillId }" not found in configuration`);
-        }
 
         // Create state property to track the active skill
         this.activeSkillProperty = this.conversationState.createProperty(RootBot.ActiveSkillPropertyName);

--- a/samples/javascript_nodejs/81.skills-skilldialog/README.md
+++ b/samples/javascript_nodejs/81.skills-skilldialog/README.md
@@ -45,9 +45,9 @@ The solution uses dialogs, within both a parent bot (`DialogRootBot`) and a skil
   git clone https://github.com/microsoft/botbuilder-samples.git
   ```
 
-- Create a bot registration in the azure portal for the `dialogSkillBot` and update [dialogSkillBot/.env](dialogSkillBot/.env) with the AppId and password.
-- Create a bot registration in the azure portal for the `dialogRootBot` and update [dialogRootBot/.env](dialogRootBot/.env) with the AppId and password.
-- Update the BotFrameworkSkills section in [dialogRootBot/.env](dialogRootBot/.env) with the AppId for the skill you created in the previous step.
+- (Optionally) Create a bot registration in the azure portal for the `dialogSkillBot` and update [dialogSkillBot/.env](dialogSkillBot/.env) with the AppId and password.
+- (Optionally) Create a bot registration in the azure portal for the `dialogRootBot` and update [dialogRootBot/.env](dialogRootBot/.env) with the AppId and password.
+- (Optionally) Update the BotFrameworkSkills section in [dialogRootBot/.env](dialogRootBot/.env) with the AppId for the skill you created in the previous step.
 - (Optional) Configure the LuisAppId, LuisAPIKey and LuisAPIHostName section in the [dialogSkillBot/.env](dialogSkillBot/.env) if you want to run message activities through LUIS.
 
 For each bot directory, `dialogSkillBot` and `dialogRootBot` as `<botDirectory>`:

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/dialogs/mainDialog.js
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/dialogs/mainDialog.js
@@ -26,9 +26,6 @@ class MainDialog extends ComponentDialog {
         if (!skillClient) throw new Error('[MainDialog]: Missing parameter \'skillClient\' is required');
         if (!conversationIdFactory) throw new Error('[MainDialog]: Missing parameter \'conversationIdFactory\' is required');
 
-        if (!process.env.MicrosoftAppId) throw new Error('[MainDialog]: Missing parameter \'MicrosoftAppId\' is required');
-        if (!process.env.SkillHostEndpoint) throw new Error('[MainDialog]: Missing parameter \'SkillHostEndpoint\' is required');
-
         this.activeSkillPropertyName = `${ MAIN_DIALOG }.activeSkillProperty`;
         this.activeSkillProperty = conversationState.createProperty(this.activeSkillPropertyName);
         this.skillsConfig = skillsConfig;

--- a/samples/python/80.skills-simple-bot-to-bot/README.md
+++ b/samples/python/80.skills-simple-bot-to-bot/README.md
@@ -34,9 +34,9 @@ The solution includes a parent bot (`simple-root-bot`) and a skill bot (`echo-sk
     git clone https://github.com/microsoft/botbuilder-samples.git
     ```
 
-- Create a bot registration in the azure portal for the `echo-skill-bot` and update [echo-skill-bot/config.py](echo-skill-bot/config.py) with the `MicrosoftAppId` and `MicrosoftAppPassword` of the new bot registration
-- Create a bot registration in the azure portal for the `simple-root-bot` and update [simple-root-bot/config.py](simple-root-bot/config.py) with the `MicrosoftAppId` and `MicrosoftAppPassword` of the new bot registration
-- Update the `SKILLS.app_id` in [simple-root-bot/config.py](simple-root-bot/config.py) with the `MicrosoftAppId` for the skill you created in the previous step
+- (Optionally) Create a bot registration in the azure portal for the `echo-skill-bot` and update [echo-skill-bot/config.py](echo-skill-bot/config.py) with the `MicrosoftAppId` and `MicrosoftAppPassword` of the new bot registration
+- (Optionally) Create a bot registration in the azure portal for the `simple-root-bot` and update [simple-root-bot/config.py](simple-root-bot/config.py) with the `MicrosoftAppId` and `MicrosoftAppPassword` of the new bot registration
+- (Optionally) Update the `SKILLS.app_id` in [simple-root-bot/config.py](simple-root-bot/config.py) with the `MicrosoftAppId` for the skill you created in the previous step
 - (Optionally) Add the `simple-root-bot` `MicrosoftAppId` to the `AllowedCallers` comma separated list in [echo-skill-bot/config.py](echo-skill-bot/config.py)
 
 ## Running the sample

--- a/samples/python/80.skills-simple-bot-to-bot/echo-skill-bot/config.py
+++ b/samples/python/80.skills-simple-bot-to-bot/echo-skill-bot/config.py
@@ -10,10 +10,10 @@ class DefaultConfig:
 
     PORT = 39783
     APP_ID = os.environ.get(
-        "MicrosoftAppId", "TODO: Add here the App ID for the skill bot"
+        "MicrosoftAppId", ""
     )
     APP_PASSWORD = os.environ.get(
-        "MicrosoftAppPassword", "TODO: Add here the App Password for the skill bot"
+        "MicrosoftAppPassword", ""
     )
 
     # Callers to only those specified, '*' allows any caller.

--- a/samples/python/80.skills-simple-bot-to-bot/simple-root-bot/config.py
+++ b/samples/python/80.skills-simple-bot-to-bot/simple-root-bot/config.py
@@ -12,16 +12,16 @@ class DefaultConfig:
 
     PORT = 3978
     APP_ID = os.environ.get(
-        "MicrosoftAppId", "TODO: Add here the App ID for the root bot"
+        "MicrosoftAppId", ""
     )
     APP_PASSWORD = os.environ.get(
-        "MicrosoftAppPassword", "TODO: Add here the App Password for the root bot"
+        "MicrosoftAppPassword", ""
     )
     SKILL_HOST_ENDPOINT = "http://localhost:3978/api/skills"
     SKILLS = [
         {
             "id": "EchoSkillBot",
-            "app_id": "TODO: Add here the App ID for the skill",
+            "app_id": "",
             "skill_endpoint": "http://localhost:39783/api/messages",
         },
     ]

--- a/samples/python/81.skills-skilldialog/README.md
+++ b/samples/python/81.skills-skilldialog/README.md
@@ -47,9 +47,9 @@ It demonstrates how to post activities from the parent bot to the skill bot and 
     git clone https://github.com/microsoft/botbuilder-samples.git
     ```
 
-- Create a bot registration in the azure portal for the `dialog-skill-bot` and update [dialog-skill-bot/config.py](dialog-skill-bot/config.py) with the `MicrosoftAppId` and `MicrosoftAppPassword` of the new bot registration
-- Create a bot registration in the azure portal for the `dialog-root-bot` and update [dialog-root-bot/config.py](dialog-root-bot/config.py) with the `MicrosoftAppId` and `MicrosoftAppPassword` of the new bot registration
-- Update the `SKILLS.app_id` in [dialog-root-bot/config.py](dialog-root-bot/config.py) with the `MicrosoftAppId` for the skill you created in the previous step
+- (Optionally) Create a bot registration in the azure portal for the `dialog-skill-bot` and update [dialog-skill-bot/config.py](dialog-skill-bot/config.py) with the `MicrosoftAppId` and `MicrosoftAppPassword` of the new bot registration
+- (Optionally) Create a bot registration in the azure portal for the `dialog-root-bot` and update [dialog-root-bot/config.py](dialog-root-bot/config.py) with the `MicrosoftAppId` and `MicrosoftAppPassword` of the new bot registration
+- (Optionally) Update the `SKILLS.app_id` in [dialog-root-bot/config.py](dialog-root-bot/config.py) with the `MicrosoftAppId` for the skill you created in the previous step
 - (Optionally) Add the `dialog-root-bot` `MicrosoftAppId` to the `AllowedCallers` comma separated list in [dialog-skill-bot/config.py](dialog-skill-bot/config.py)
 
 ## Running the sample

--- a/samples/python/81.skills-skilldialog/dialog-root-bot/config.py
+++ b/samples/python/81.skills-skilldialog/dialog-root-bot/config.py
@@ -11,15 +11,15 @@ class DefaultConfig:
     """ Bot Configuration """
 
     PORT = 3978
-    APP_ID = os.environ.get("MicrosoftAppId", "TODO: Add here the App ID for the bot")
+    APP_ID = os.environ.get("MicrosoftAppId", "")
     APP_PASSWORD = os.environ.get(
-        "MicrosoftAppPassword", "TODO: Add here the password for the bot"
+        "MicrosoftAppPassword", ""
     )
     SKILL_HOST_ENDPOINT = "http://localhost:3978/api/skills"
     SKILLS = [
         {
             "id": "DialogSkillBot",
-            "app_id": "TODO: Add here the App ID for the skill",
+            "app_id": "",
             "skill_endpoint": "http://localhost:39783/api/messages",
         },
     ]

--- a/samples/python/81.skills-skilldialog/dialog-root-bot/dialogs/main_dialog.py
+++ b/samples/python/81.skills-skilldialog/dialog-root-bot/dialogs/main_dialog.py
@@ -59,8 +59,6 @@ class MainDialog(ComponentDialog):
         )
 
         bot_id = configuration.APP_ID
-        if not bot_id:
-            raise TypeError("App Id is not in configuration")
 
         self._skills_config = skills_config
         if not self._skills_config:


### PR DESCRIPTION
Fixes #2895

## Proposed Changes
  - Readmes that note creating bot registrations for generating appIds and passwords for use in the bot/skill config files are now marked as optional.
  - Removed placeholders in appIds and passwords in config files, where present
  - Removed validation code requiring an appId value in config files

## Testing
Successfully tested all samples run with and without appIds and passwords