### PR TITLE
Fix bug where parameters were not being passed

### DIFF
--- a/experimental/generation/generator/packages/library/templates/generator.lg
+++ b/experimental/generation/generator/packages/library/templates/generator.lg
@@ -619,7 +619,7 @@ ${if(length(entities[entity]) > 1, `    - @ ${entity} ${entity}`, '')}```
 - ```# ${name}(${list(args)})
 > Activity ${comment}
 [Activity
-    Text = \${${name}_text()}
+    Text = \${${name}_text(${list(args)})}
 ]
 
 # ${name}_text(${list(args)})

--- a/experimental/generation/generator/packages/library/templates/standard/en-us/standard.en-us.lg
+++ b/experimental/generation/generator/packages/library/templates/standard/en-us/standard.en-us.lg
@@ -104,7 +104,7 @@
     - Changed ${propertyName()} from ${propertyCurrentValue()} to ${propertyValue('newVal')}
 
 # removeDefault()
-- Removed ${propertyValue('val')} from ${propertyName()}
+- Removed ${propertyValue('newVal')} from ${propertyName()}
 
 # clearDefault()
 - Cleared ${propertyName()}


### PR DESCRIPTION
to text.

In the transition to activities, the parameter was not being passed to the text.  This caused the remove message to not work correctly.