### PR TITLE
Fix for yes/no prompt after login.

### DIFF
--- a/samples/java_springboot/18.bot-authentication/src/main/java/com/microsoft/bot/sample/authentication/MainDialog.java
+++ b/samples/java_springboot/18.bot-authentication/src/main/java/com/microsoft/bot/sample/authentication/MainDialog.java
@@ -55,10 +55,12 @@ class MainDialog extends LogoutDialog {
         // token directly from the prompt itself. There instanceof an example of this in the next method.
         TokenResponse tokenResponse = (TokenResponse) stepContext.getResult();
         if (tokenResponse != null) {
-            stepContext.getContext().sendActivity(MessageFactory.text("You are now logged in."));
-            PromptOptions options = new PromptOptions();
-            options.setPrompt(MessageFactory.text("Would you like to view your token?"));
-            return stepContext.prompt("ConfirmPrompt", options);
+            return stepContext.getContext().sendActivity(MessageFactory.text("You are now logged in."))
+            .thenCompose(result->{
+                PromptOptions options = new PromptOptions();
+                options.setPrompt(MessageFactory.text("Would you like to view your token?"));
+                return stepContext.prompt("ConfirmPrompt", options);
+            });
         }
 
         stepContext.getContext()


### PR DESCRIPTION
Fixes #2268

## Proposed Changes
Corrected issue with missing yes/no prompt after successful login in Sample 18.bot-authentication. The issue was a CompletableFuture that wasn't being waited for a result before executing the next future. Modified the code to combine the two futures into a single return statement by using composer to return the result of both futures.


## Testing
Tested sample with both bot framework emulator and web chat.