### PR TITLE
Add version options to the run pipeline dialog for Samples/E2ETests DotNet & JS pipelines

### DIFF
--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -71,77 +71,68 @@ jobs:
   - checkout: self
     persistCredentials: True
   
-  - task: PowerShell@2
+  - powershell: |
+      $file = "$(SampleRootPath)\nuget.config";
+
+      $content = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <add key="ConversationalAI" value="https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" />
+          <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
+
+      "@;
+
+      New-Item -Path $file -ItemType "file" -Value $content;
+      '-------------'; get-content "$file"; '===================';
     displayName: Create nuget.config for Azure feed
-    inputs:
-      targetType: inline
-      script: |
-        $file = "$(SampleRootPath)\nuget.config";
-
-        $content = @"
-        <?xml version="1.0" encoding="utf-8"?>
-        <configuration>
-          <packageSources>
-            <add key="ConversationalAI" value="https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" />
-            <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
-          </packageSources>
-          <activePackageSource>
-            <add key="All" value="(Aggregate source)" />
-          </activePackageSource>
-        </configuration>
-
-        "@;
-
-        New-Item -Path $file -ItemType "file" -Value $content;
-        '-------------'; get-content "$file"; '===================';
     condition: ${{ eq(parameters.packageFeed, 'Azure') }}
 
-  - task: PowerShell@2
+  - powershell: |
+      $file = "$(SampleRootPath)\nuget.config";
+
+      $content = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <add key="MyGet" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
+
+      "@;
+
+      New-Item -Path $file -ItemType "file" -Value $content;
+      '-------------'; get-content "$file"; '===================';
     displayName: Create nuget.config for MyGet feed
-    inputs:
-      targetType: inline
-      script: |
-        $file = "$(SampleRootPath)\nuget.config";
-
-        $content = @"
-        <?xml version="1.0" encoding="utf-8"?>
-        <configuration>
-          <packageSources>
-            <add key="MyGet" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" />
-          </packageSources>
-          <activePackageSource>
-            <add key="All" value="(Aggregate source)" />
-          </activePackageSource>
-        </configuration>
-
-        "@;
-
-        New-Item -Path $file -ItemType "file" -Value $content;
-        '-------------'; get-content "$file"; '===================';
     condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
 
-  - task: PowerShell@2
+  - powershell: |
+      $file = "$(SampleRootPath)\nuget.config";
+
+      $content = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
+
+      "@;
+
+      New-Item -Path $file -ItemType "file" -Value $content;
+      '-------------'; get-content "$file"; '===================';
     displayName: Create nuget.config for NuGet feed
-    inputs:
-      targetType: inline
-      script: |
-        $file = "$(SampleRootPath)\nuget.config";
-
-        $content = @"
-        <?xml version="1.0" encoding="utf-8"?>
-        <configuration>
-          <packageSources>
-            <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
-          </packageSources>
-          <activePackageSource>
-            <add key="All" value="(Aggregate source)" />
-          </activePackageSource>
-        </configuration>
-
-        "@;
-
-        New-Item -Path $file -ItemType "file" -Value $content;
-        '-------------'; get-content "$file"; '===================';
     condition: ${{ eq(parameters.packageFeed, 'NuGet') }}
 
   - powershell: |

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -166,7 +166,7 @@ jobs:
       $packageName;
       $latestVersion;
       "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
-    displayName: 'Get latest Bot.Builder package version from Azure feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
+    displayName: 'Get latest Bot.Builder version number from Azure feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
 
   - powershell: |
@@ -189,15 +189,15 @@ jobs:
       "Latest version:";
       $package.id;
       $latestVersion;
-      "##vso[task.setvariable variable=LatestVersion;]$latestVersion";    
-    displayName: 'Get latest Bot.Builder package version from Myget feed - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
+    displayName: 'Get latest Bot.Builder version number from Myget feed - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
 
   - powershell: |
      $targetVersion = "${{ parameters.versionToTest }}";
      $targetVersion;
      "##vso[task.setvariable variable=TargetVersion;]$targetVersion";
-    displayName: 'Get specific Bot.Builder package version from user input at queue time'
+    displayName: 'Get specific Bot.Builder version number from user input at queue time'
     condition: ${{ ne(parameters.testLatestPackage, true) }}
 
   - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -274,52 +274,35 @@ jobs:
       scriptLocation: inlineScript
       inlineScript: call az bot directline create --name "$(AzureBotName)" --resource-group "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json" --debug
 
-  - task: PowerShell@2
+  - powershell: |
+      # Key = Direct Line channel "Secret keys" in Azure portal
+      $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
+      $key = $json.properties.properties.sites.key;
+      echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
+      echo "##vso[task.setvariable variable=BOTID;]$(AzureBotName)";
+      Write-Host "setx DIRECTLINE $key";
+      Write-Host "setx BOTID $(AzureBotName)";
     displayName: Set DIRECTLINE key, BOTID for running tests
-    inputs:
-      targetType: inline
-      script: >-
-        # Key = Direct Line channel "Secret keys" in Azure portal
-        $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
-        $key = $json.properties.properties.sites.key;
-        echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
-        echo "##vso[task.setvariable variable=BOTID;]$(AzureBotName)";
-        Write-Host "setx DIRECTLINE $key";
-        Write-Host "setx BOTID $(AzureBotName)";
 
-  - task: PowerShell@2
+  - powershell: |
+      Set-PSDebug -Trace 1;
+
+      # Copy Azure deploy scripts for Linux
+      Move-Item -Path $(SampleRootPath)\DeploymentScripts\Linux\* -Destination $(SampleRootPath)\;
+
+      Set-PSDebug -Trace 0;
     displayName: Move .deployment, deploy.sh scripts into position
-    inputs:
-      targetType: inline
-      script: >-
-        Set-PSDebug -Trace 1;
 
-
-        # Copy Azure deploy scripts for Linux
-
-        Move-Item -Path $(SampleRootPath)\DeploymentScripts\Linux\* -Destination $(SampleRootPath)\;
-
-
-        Set-PSDebug -Trace 0;
-
-  - task: CmdLine@2
-    displayName: Git bot deployment
-    inputs:
-      script: >
-        git config --global user.name "BotBuilderSamplesPipeline"
-
-        git config --global user.email BotBuilderSamples@Pipeline.com
-
-        git init
-
-        git add .
-
-        git commit -m "cibuildtest"
-
-        git remote add azure https://$(AzureDeploymentUser):$(AzureDeploymentPassword)@$(SampleBotName).scm.azurewebsites.net:443/$(SampleBotName).git
-
-        git push azure master
-      workingDirectory: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/$(SampleFolderName)
+  - script: |
+      git config --global user.name "BotBuilderSamplesPipeline"
+      git config --global user.email BotBuilderSamples@Pipeline.com
+      git init
+      git add .
+      git commit -m "cibuildtest"
+      git remote add azure https://$(AzureDeploymentUser):$(AzureDeploymentPassword)@$(AzureBotName).scm.azurewebsites.net:443/$(AzureBotName).git
+      git push azure master
+    workingDirectory: '$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/$(SampleFolderName)'
+    displayName: 'Git bot deployment'
 
   - task: NuGetCommand@2
     displayName: NuGet restore Samples.$(SampleBotName).FunctionalTests.csproj
@@ -335,10 +318,9 @@ jobs:
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
     condition: always()
 
-  - task: InlinePowershell@1
-    displayName: Sleep for 800 seconds
-    inputs:
-      Script: Start-Sleep -Seconds 800
+  - powershell: |
+      Start-Sleep -Seconds 800
+    displayName: 'Sleep for 800 seconds'
     enabled: false
 
   - task: DotNetCoreCLI@2
@@ -355,6 +337,7 @@ jobs:
     inputs:
       script: >
         dir .. /s
+
   - task: AzureCLI@2
     displayName: Delete bot, app service, app service plan, group
     condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -72,7 +72,7 @@ jobs:
     persistCredentials: True
   
   - task: PowerShell@2
-    displayName: Create nuget.config for ConversationalAI/BotFramework feed
+    displayName: Create nuget.config for Azure feed
     inputs:
       targetType: inline
       script: |
@@ -121,7 +121,7 @@ jobs:
     condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
 
   - task: PowerShell@2
-    displayName: Create nuget.config for ConversationalAI/BotFramework feed
+    displayName: Create nuget.config for NuGet feed
     inputs:
       targetType: inline
       script: |
@@ -149,7 +149,7 @@ jobs:
    
       #$url = "https://feeds.dev.azure.com/ConversationalAI/BotFramework/_apis/packaging/Feeds/SDK/Packages/26dde74d-6079-401c-a9e0-c6d839e02c18/versions?api-version=5.1-preview.1"
    
-      Write-Host "Get latest $packageName version number from ConversationalAI BotFramework SDK feed";
+      Write-Host "Get latest $packageName version number from Azure ConversationalAI BotFramework SDK feed";
    
       $RegistryUrlSource = "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" 
       " "
@@ -189,7 +189,7 @@ jobs:
       "Latest version:";
       $package.id;
       $latestVersion;
-      "##vso[task.setvariable variable=LatestVersion;]$latestVersion";    displayName: 'Get latest Bot.Builder package version from MyGet feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
+      "##vso[task.setvariable variable=LatestVersion;]$latestVersion";    
     displayName: 'Get latest Bot.Builder package version from Myget feed - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
 
@@ -197,7 +197,7 @@ jobs:
      $targetVersion = "${{ parameters.versionToTest }}";
      $targetVersion;
      "##vso[task.setvariable variable=TargetVersion;]$targetVersion";
-    displayName: 'Get specified Bot.Builder package version from user input at queue time'
+    displayName: 'Get specific Bot.Builder package version from user input at queue time'
     condition: ${{ ne(parameters.testLatestPackage, true) }}
 
   - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
@@ -272,7 +272,7 @@ jobs:
       connectedServiceNameARM: 0ab0d343-57b9-4390-9a6a-13d71ef36de6
       scriptType: batch
       scriptLocation: inlineScript
-      inlineScript: call az bot directline create -name "$(AzureBotName)" -resource-group "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json" --debug
+      inlineScript: call az bot directline create --name "$(AzureBotName)" --resource-group "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json" --debug
   - task: PowerShell@2
     displayName: Set DIRECTLINE key, BOTID for running tests
     inputs:

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -194,6 +194,27 @@ jobs:
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
 
   - powershell: |
+      $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
+   
+      Write-Host "Get latest $packageName version number from NuGet.org feed";
+         
+      $registryUrlSource = "https://nuget.org/api/v2/";
+
+      $packageList = Find-package -AllVersions -source $registryUrlSource -Name $packageName -AllowPrereleaseVersions | Select -First 30;
+      " "
+      "Available versions:";
+      $PackageList.Version
+
+      $latestVersion = $PackageList.Version[0];
+      " "
+      "Latest version:";
+      $packageName;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+    displayName: 'Get latest Bot.Builder version number from NuGet feed - https://www.nuget.org/packages?q=Bot.Builder'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'NuGet')) }}
+
+  - powershell: |
      $targetVersion = "${{ parameters.versionToTest }}";
      $targetVersion;
      "##vso[task.setvariable variable=TargetVersion;]$targetVersion";

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -256,12 +256,10 @@ jobs:
       scriptLocation: inlineScript
       inlineScript: >-
         Set-PSDebug -Trace 1;
-
         az group create --location westus --name $(BotGroup)
 
         # set up bot channels registration, app service, app service plan
         az deployment group create --resource-group "$(BotGroup)" --template-file "$(SampleRootPath)\DeploymentTemplates\LinuxDotNet\template.json" --parameters appId="$(AppId)" appSecret="$(AppSecret)" botName="$(AzureBotName)" --name "$(AzureBotName)";
-
         #az bot prepare-deploy --lang Csharp --code-dir "$(SampleRootPath)" --proj-file-path "$(SampleBotName).csproj";
 
         Set-PSDebug -Trace 0;

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -21,7 +21,7 @@
 
 parameters:
   - name: testLatestPackage
-    displayName: Test latest daily package version
+    displayName: Test latest package version
     type: boolean
     default: true
   - name: versionToTest
@@ -177,14 +177,15 @@ jobs:
       $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
 
       Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
-      $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+      #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
 
-      $package = $result.packages | Where-Object {$_.id -eq $packageName};
-      " "
-      "Available versions:";
-      $package.versions | Select -Last 30;
+      #$package = $result.packages | Where-Object {$_.id -eq $packageName};
+      #" "
+      #"Available versions:";
+      #$package.versions | Select -Last 30;
 
-      [string]$latestVersion = $package.versions[-1];
+      ### Hard-coded ##########
+      [string]$latestVersion = "4.15.0-preview.20210706-256858";  #$package.versions[-1];
       " "
       "Latest version:";
       $package.id;

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -290,6 +290,27 @@ jobs:
      
        Set-PSDebug -Trace 0;
 
+  - powershell: |
+      Set-PSDebug -Trace 1;
+      # Copy Azure deploy scripts for Linux
+      Move-Item -Path $(SampleRootPath)\DeploymentScripts\Linux\* -Destination $(SampleRootPath)\;
+      Set-PSDebug -Trace 0;
+    displayName: Move .deployment, deploy.sh scripts into position
+
+  - script: |
+      echo on
+      git config --global user.name "BotBuilderSamplesPipeline"
+      git config --global user.email BotBuilderSamples@Pipeline.com
+      git init
+   
+      git add .
+      git commit -m "Add bot source code"
+      git remote add azure https://$(AzureDeploymentUser):$(AzureDeploymentPassword)@$(AzureBotName).scm.azurewebsites.net:443/$(AzureBotName).git
+   
+      git push azure master
+    workingDirectory: '$(SampleRootPath)'
+    displayName: 'Deploy the bot to Azure'
+
   - task: AzureCLI@2
     displayName: Create DirectLine channel
     inputs:
@@ -307,27 +328,6 @@ jobs:
       Write-Host "setx DIRECTLINE $key";
       Write-Host "setx BOTID $(AzureBotName)";
     displayName: Set DIRECTLINE key, BOTID for running tests
-
-  - powershell: |
-      Set-PSDebug -Trace 1;
-
-      # Copy Azure deploy scripts for Linux
-      Move-Item -Path $(SampleRootPath)\DeploymentScripts\Linux\* -Destination $(SampleRootPath)\;
-
-      Set-PSDebug -Trace 0;
-    displayName: Move .deployment, deploy.sh scripts into position
-
-  - script: |
-      echo on
-      git config --global user.name "BotBuilderSamplesPipeline"
-      git config --global user.email BotBuilderSamples@Pipeline.com
-      git init
-      git add .
-      git commit -m "cibuildtest"
-      git remote add azure https://$(AzureDeploymentUser):$(AzureDeploymentPassword)@$(AzureBotName).scm.azurewebsites.net:443/$(AzureBotName).git
-      git push azure master
-    workingDirectory: '$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/$(SampleFolderName)'
-    displayName: 'Git bot deployment'
 
   - task: NuGetCommand@2
     displayName: NuGet restore Samples.$(SampleBotName).FunctionalTests.csproj
@@ -362,26 +362,26 @@ jobs:
         dir .. /s
 
   - task: AzureCLI@2
-    displayName: 'Delete bot, app service, app service plan, group'
+    displayName: Delete bot, app service, app service plan, group
     inputs:
       azureSubscription: 'FUSE Temporary'
       scriptType: ps
       scriptLocation: inlineScript
       inlineScript: |
         Set-PSDebug -Trace 1;
-     
+
         Write-Host "1) Delete Bot:";
         az bot delete --name $(AzureBotName) --resource-group $(BotGroup);
-     
+
         Write-Host "2) Delete App Service:";
         az webapp delete --name $(AzureBotName) --resource-group $(BotGroup);
-     
+
         Write-Host "3) Delete App Service plan:";
         az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes;
-     
+
         Write-Host "4) Delete Resource Group:";
         az group delete --name $(BotGroup) --yes;
-     
+
         Set-PSDebug -Trace 0;
     condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
     continueOnError: True

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -57,10 +57,10 @@ resources:
     type: git
     ref: main
 
-variables:
-- group: AzureDeploymentCredsVariableGroup
-- group: SamplesE2ETestsVariableGroup
-- group: MyGetPersonalAccessTokenVariableGroup
+#variables:
+#- group: AzureDeploymentCredsVariableGroup
+#- group: SamplesE2ETestsVariableGroup
+#- group: MyGetPersonalAccessTokenVariableGroup
 
 jobs:
 - job: Job_1

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -79,7 +79,6 @@ jobs:
         $file = "$(SampleRootPath)\nuget.config";
 
         $content = @"
-
         <?xml version="1.0" encoding="utf-8"?>
         <configuration>
           <packageSources>
@@ -105,7 +104,6 @@ jobs:
         $file = "$(SampleRootPath)\nuget.config";
 
         $content = @"
-
         <?xml version="1.0" encoding="utf-8"?>
         <configuration>
           <packageSources>
@@ -130,7 +128,6 @@ jobs:
         $file = "$(SampleRootPath)\nuget.config";
 
         $content = @"
-
         <?xml version="1.0" encoding="utf-8"?>
         <configuration>
           <packageSources>
@@ -200,7 +197,7 @@ jobs:
      $targetVersion = "${{ parameters.versionToTest }}";
      $targetVersion;
      "##vso[task.setvariable variable=TargetVersion;]$targetVersion";
-    displayName: 'Set Bot.Builder package version per user input at queue time'
+    displayName: 'Get specified Bot.Builder package version from user input at queue time'
     condition: ${{ ne(parameters.testLatestPackage, true) }}
 
   - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -161,22 +161,22 @@ jobs:
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
 
   - powershell: |
-      #$myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
       $myGetFeedName = "botbuilder-v4-dotnet-daily";
       $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
 
       $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
 
       Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
-      #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+      $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
 
-      #$package = $result.packages | Where-Object {$_.id -eq $packageName};
-      #" "
-      #"Available versions:";
-      #$package.versions | Select -Last 30;
+      $package = $result.packages | Where-Object {$_.id -eq $packageName};
+      " "
+      "Available versions:";
+      $package.versions | Select -Last 30;
 
-      ### Hard-coded ##########
-      [string]$latestVersion = "4.15.0-preview.20210706-256858";  #$package.versions[-1];
+      ### Hard-coded ########## [string]$latestVersion = "4.15.0-preview.20210706-256858";
+      [string]$latestVersion = $package.versions[-1];
       " "
       "Latest version:";
       $package.id;

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -360,27 +360,28 @@ jobs:
         dir .. /s
 
   - task: AzureCLI@2
-    displayName: Delete bot, app service, app service plan, group
-    condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
-    continueOnError: True
+    displayName: 'Delete bot, app service, app service plan, group'
     inputs:
-      connectedServiceNameARM: 0ab0d343-57b9-4390-9a6a-13d71ef36de6
+      azureSubscription: 'FUSE Temporary'
       scriptType: ps
       scriptLocation: inlineScript
-      inlineScript: >-
+      inlineScript: |
         Set-PSDebug -Trace 1;
-
-        Write-Host "1) Delete Bot:"
-        az bot delete --name $(AzureBotName) --resource-group $(BotGroup)
-
-        Write-Host "2) Delete App Service:"
-        az webapp delete --name $(AzureBotName) --resource-group $(BotGroup)
-
-        Write-Host "3) Delete App Service plan:"
-        az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes
-
-        Write-Host "4) Delete Resource Group:"
-        az group delete --name $(BotGroup) --yes
-
+     
+        Write-Host "1) Delete Bot:";
+        az bot delete --name $(BotName) --resource-group $(BotGroup);
+     
+        Write-Host "2) Delete App Service:";
+        az webapp delete --name $(BotName) --resource-group $(BotGroup);
+     
+        Write-Host "3) Delete App Service plan:";
+        az appservice plan delete --name $(BotName) --resource-group $(BotGroup) --yes;
+     
+        Write-Host "4) Delete Resource Group:";
+        az group delete --name $(BotGroup) --yes;
+     
         Set-PSDebug -Trace 0;
+    condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
+    continueOnError: True
+
 ...

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -95,7 +95,7 @@ jobs:
 
         New-Item -Path $file -ItemType "file" -Value $content;
         '-------------'; get-content "$file"; '===================';
-    condition: eq("${{ parameters.packageFeed }}", "Azure")
+    condition: ${{ eq(parameters.packageFeed, 'Azure') }}
 
   - task: PowerShell@2
     displayName: Create nuget.config for MyGet feed
@@ -120,7 +120,7 @@ jobs:
 
         New-Item -Path $file -ItemType "file" -Value $content;
         '-------------'; get-content "$file"; '===================';
-    condition: eq("${{ parameters.packageFeed }}", "MyGet")
+    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
 
   - task: PowerShell@2
     displayName: Create nuget.config for ConversationalAI/BotFramework feed
@@ -145,7 +145,7 @@ jobs:
 
         New-Item -Path $file -ItemType "file" -Value $content;
         '-------------'; get-content "$file"; '===================';
-    condition: eq(${{ parameters.packageFeed }}, 'NuGet')
+    condition: ${{ eq(parameters.packageFeed, 'NuGet') }}
 
   - powershell: |
       $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
@@ -170,7 +170,7 @@ jobs:
       $latestVersion;
       "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
     displayName: 'Get latest Bot.Builder package version from Azure feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
-    condition: and(${{ parameters.testLatestPackage }}, eq("${{ parameters.packageFeed }}", "Azure"))
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
 
   - powershell: |
       $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
@@ -193,14 +193,14 @@ jobs:
       $package.id;
       $latestVersion;
       "##vso[task.setvariable variable=LatestVersion;]$latestVersion";    displayName: 'Get latest Bot.Builder package version from MyGet feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
-    condition: and(${{ parameters.testLatestPackage }}, eq("${{ parameters.packageFeed }}", "Azure"))
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
 
   - powershell: |
      $targetVersion = "${{ parameters.versionToTest }}";
      $targetVersion;
      "##vso[task.setvariable variable=TargetVersion;]$targetVersion";
     displayName: 'Set Bot.Builder package version per user input at queue time'
-    condition: ne(${{ parameters.testLatestPackage }}, 'true')
+    condition: ${{ ne(parameters.testLatestPackage, true) }}
 
   - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
     displayName: 'Display env vars'

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -332,13 +332,11 @@ jobs:
       solution: samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
       selectOrConfig: config
       nugetConfigPath: $(SampleRootPath)\nuget.config
-    condition: always()
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build Samples.$(SampleBotName).FunctionalTests.csproj
     inputs:
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
-    condition: always()
 
   - powershell: |
       Start-Sleep -Seconds 800

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -334,7 +334,7 @@ jobs:
 
   - powershell: |
       Start-Sleep -Seconds 800
-    displayName: 'Sleep for 800 seconds'
+    displayName: 'Sleep for 13 min 20 sec'
     enabled: true
 
   - task: DotNetCoreCLI@2

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -339,9 +339,9 @@ jobs:
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
 
   - powershell: |
-      Start-Sleep -Seconds 800
-    displayName: 'Sleep for 800 seconds'
-    enabled: false
+      Start-Sleep -Seconds 120
+    displayName: 'Sleep for 120 seconds'
+    enabled: true
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -222,6 +222,7 @@ jobs:
       tags: |
         Using Bot.Builder version $(TargetVersion)
         From ${{ parameters.packageFeed }} feed 
+        Test latest = ${{ parameters.testLatestPackage }}
 
   - powershell: |
       $path = "$(SampleRootPath)\\$(SampleBotName).csproj";

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -218,7 +218,7 @@ jobs:
      $targetVersion = "${{ parameters.versionToTest }}";
      $targetVersion;
      "##vso[task.setvariable variable=TargetVersion;]$targetVersion";
-    displayName: 'Get specific Bot.Builder version number from user input at queue time'
+    displayName: 'From user input get specific Bot.Builder version number'
     condition: ${{ ne(parameters.testLatestPackage, true) }}
 
   - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
@@ -315,6 +315,7 @@ jobs:
     displayName: Move .deployment, deploy.sh scripts into position
 
   - script: |
+      echo on
       git config --global user.name "BotBuilderSamplesPipeline"
       git config --global user.email BotBuilderSamples@Pipeline.com
       git init

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -193,7 +193,8 @@ jobs:
       $package.id;
       $latestVersion;
       "##vso[task.setvariable variable=LatestVersion;]$latestVersion";    displayName: 'Get latest Bot.Builder package version from MyGet feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
-    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
+    displayName: 'Get latest Bot.Builder package version from Myget feed - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
 
   - powershell: |
      $targetVersion = "${{ parameters.versionToTest }}";

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -251,23 +251,25 @@ jobs:
   - task: AzureCLI@2
     displayName: 'Preexisting RG: create group, create resources, #prepare .deployment file'
     inputs:
-      connectedServiceNameARM: 0ab0d343-57b9-4390-9a6a-13d71ef36de6
+      azureSubscription: 'FUSE Temporary'
       scriptType: ps
       scriptLocation: inlineScript
-      inlineScript: >-
-        Set-PSDebug -Trace 1;
-        az group create --location westus --name $(BotGroup)
-
-        # set up bot channels registration, app service, app service plan
-        az deployment group create --resource-group "$(BotGroup)" --template-file "$(SampleRootPath)\DeploymentTemplates\LinuxDotNet\template.json" --parameters appId="$(AppId)" appSecret="$(AppSecret)" botName="$(AzureBotName)" --name "$(AzureBotName)";
-        #az bot prepare-deploy --lang Csharp --code-dir "$(SampleRootPath)" --proj-file-path "$(SampleBotName).csproj";
-
-        Set-PSDebug -Trace 0;
+      inlineScript: |
+       Set-PSDebug -Trace 1;
+     
+       az group create --location westus --name $(BotGroup)
+     
+       # set up bot channels registration, app service, app service plan
+       az deployment group create --resource-group "$(BotGroup)" --template-file "$(SampleRootPath)\DeploymentTemplates\LinuxDotNet\template.json" --parameters appId="$(AppId)" appSecret="$(AppSecret)" botName="$(AzureBotName)" --name "$(AzureBotName)";
+     
+       #az bot prepare-deploy --lang Csharp --code-dir "$(SampleRootPath)" --proj-file-path "CoreBot.csproj";
+     
+       Set-PSDebug -Trace 0;
 
   - task: AzureCLI@2
     displayName: Create DirectLine channel
     inputs:
-      connectedServiceNameARM: 0ab0d343-57b9-4390-9a6a-13d71ef36de6
+      azureSubscription: 'FUSE Temporary'
       scriptType: batch
       scriptLocation: inlineScript
       inlineScript: call az bot directline create --name "$(AzureBotName)" --resource-group "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json" --debug

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -344,13 +344,11 @@ jobs:
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/**Tests.csproj
       arguments: --verbosity Normal
 
-  - task: CmdLine@2
-    displayName: Dir workspace
+  - script: |
+      dir .. /s
+    displayName: 'Dir workspace'
+    continueOnError: true
     condition: always()
-    continueOnError: True
-    inputs:
-      script: >
-        dir .. /s
 
   - task: AzureCLI@2
     displayName: Delete bot, app service, app service plan, group

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -273,6 +273,7 @@ jobs:
       scriptType: batch
       scriptLocation: inlineScript
       inlineScript: call az bot directline create --name "$(AzureBotName)" --resource-group "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json" --debug
+
   - task: PowerShell@2
     displayName: Set DIRECTLINE key, BOTID for running tests
     inputs:
@@ -300,6 +301,7 @@ jobs:
 
 
         Set-PSDebug -Trace 0;
+
   - task: CmdLine@2
     displayName: Git bot deployment
     inputs:
@@ -318,6 +320,7 @@ jobs:
 
         git push azure master
       workingDirectory: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/$(SampleFolderName)
+
   - task: NuGetCommand@2
     displayName: NuGet restore Samples.$(SampleBotName).FunctionalTests.csproj
     inputs:
@@ -325,23 +328,26 @@ jobs:
       selectOrConfig: config
       nugetConfigPath: $(SampleRootPath)\nuget.config
     condition: always()
+
   - task: DotNetCoreCLI@2
     displayName: dotnet build Samples.$(SampleBotName).FunctionalTests.csproj
     inputs:
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
     condition: always()
+
   - task: InlinePowershell@1
     displayName: Sleep for 800 seconds
     inputs:
       Script: Start-Sleep -Seconds 800
-    enabled: true
+    enabled: false
+
   - task: DotNetCoreCLI@2
     displayName: dotnet test
     inputs:
       command: test
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/**Tests.csproj
       arguments: --verbosity Normal
-    condition: always()
+
   - task: CmdLine@2
     displayName: Dir workspace
     condition: always()

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -28,7 +28,7 @@ parameters:
     displayName: Version to test (Only if 'Test latest' is unchecked)
     type: string
     default: 'Example: 4.15.0-daily.20210714.258979.1220aed'
-  - name: feed
+  - name: packageFeed
     displayName: Package feed to use
     type: string
     default: Conversational AI
@@ -95,6 +95,58 @@ jobs:
 
         New-Item -Path $file -ItemType "file" -Value $content;
         '-------------'; get-content "$file"; '===================';
+    condition: eq(${{ parameters.packageFeed }}, 'Conversational AI')
+
+  - task: PowerShell@2
+    displayName: Create nuget.config for MyGet feed
+    inputs:
+      targetType: inline
+      script: |
+        $file = "$(SampleRootPath)\nuget.config";
+
+        $content = @"
+
+        <?xml version="1.0" encoding="utf-8"?>
+        <configuration>
+          <packageSources>
+            <add key="MyGet" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" />
+          </packageSources>
+          <activePackageSource>
+            <add key="All" value="(Aggregate source)" />
+          </activePackageSource>
+        </configuration>
+
+        "@;
+
+        New-Item -Path $file -ItemType "file" -Value $content;
+        '-------------'; get-content "$file"; '===================';
+    condition: eq(${{ parameters.packageFeed }}, 'MyGet')
+
+  - task: PowerShell@2
+    displayName: Create nuget.config for ConversationalAI/BotFramework feed
+    inputs:
+      targetType: inline
+      script: |
+        $file = "$(SampleRootPath)\nuget.config";
+
+        $content = @"
+
+        <?xml version="1.0" encoding="utf-8"?>
+        <configuration>
+          <packageSources>
+            <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+          </packageSources>
+          <activePackageSource>
+            <add key="All" value="(Aggregate source)" />
+          </activePackageSource>
+        </configuration>
+
+        "@;
+
+        New-Item -Path $file -ItemType "file" -Value $content;
+        '-------------'; get-content "$file"; '===================';
+    condition: eq(${{ parameters.packageFeed }}, 'NuGet')
+
   - powershell: |
      $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
    

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -166,7 +166,7 @@ jobs:
       $packageName;
       $latestVersion;
       "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
-    displayName: 'Get latest Bot.Builder version number from Azure feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
+    displayName: 'From Azure feed get latest Bot.Builder version number - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
 
   - powershell: |
@@ -190,7 +190,7 @@ jobs:
       $package.id;
       $latestVersion;
       "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
-    displayName: 'Get latest Bot.Builder version number from Myget feed - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
+    displayName: 'From MyGet feed get latest Bot.Builder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
 
   - powershell: |
@@ -211,7 +211,7 @@ jobs:
       $packageName;
       $latestVersion;
       "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
-    displayName: 'Get latest Bot.Builder version number from NuGet feed - https://www.nuget.org/packages?q=Bot.Builder'
+    displayName: 'From NuGet feed get latest Bot.Builder version number - https://www.nuget.org/packages?q=Bot.Builder'
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'NuGet')) }}
 
   - powershell: |
@@ -369,13 +369,13 @@ jobs:
         Set-PSDebug -Trace 1;
      
         Write-Host "1) Delete Bot:";
-        az bot delete --name $(BotName) --resource-group $(BotGroup);
+        az bot delete --name $(AzureBotName) --resource-group $(BotGroup);
      
         Write-Host "2) Delete App Service:";
-        az webapp delete --name $(BotName) --resource-group $(BotGroup);
+        az webapp delete --name $(AzureBotName) --resource-group $(BotGroup);
      
         Write-Host "3) Delete App Service plan:";
-        az appservice plan delete --name $(BotName) --resource-group $(BotGroup) --yes;
+        az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes;
      
         Write-Host "4) Delete Resource Group:";
         az group delete --name $(BotGroup) --yes;

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -170,7 +170,7 @@ jobs:
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
 
   - powershell: |
-      $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      #$myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
       $myGetFeedName = "botbuilder-v4-dotnet-daily";
       $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
 

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -95,7 +95,7 @@ jobs:
 
         New-Item -Path $file -ItemType "file" -Value $content;
         '-------------'; get-content "$file"; '===================';
-    condition: eq(${{ parameters.packageFeed }}, 'Azure')
+    condition: eq("${{ parameters.packageFeed }}", "Azure")
 
   - task: PowerShell@2
     displayName: Create nuget.config for MyGet feed
@@ -120,7 +120,7 @@ jobs:
 
         New-Item -Path $file -ItemType "file" -Value $content;
         '-------------'; get-content "$file"; '===================';
-    condition: eq(${{ parameters.packageFeed }}, 'MyGet')
+    condition: eq("${{ parameters.packageFeed }}", "MyGet")
 
   - task: PowerShell@2
     displayName: Create nuget.config for ConversationalAI/BotFramework feed
@@ -170,7 +170,7 @@ jobs:
       $latestVersion;
       "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
     displayName: 'Get latest Bot.Builder package version from Azure feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
-    condition: and(${{ parameters.testLatestPackage }}, eq(${{ parameters.packageFeed }}, 'Azure'))
+    condition: and(${{ parameters.testLatestPackage }}, eq("${{ parameters.packageFeed }}", "Azure"))
 
   - powershell: |
       $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
@@ -193,7 +193,7 @@ jobs:
       $package.id;
       $latestVersion;
       "##vso[task.setvariable variable=LatestVersion;]$latestVersion";    displayName: 'Get latest Bot.Builder package version from MyGet feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
-    condition: and(${{ parameters.testLatestPackage }}, eq(${{ parameters.packageFeed }}, 'MyGet'))
+    condition: and(${{ parameters.testLatestPackage }}, eq("${{ parameters.packageFeed }}", "Azure"))
 
   - powershell: |
      $targetVersion = "${{ parameters.versionToTest }}";
@@ -231,12 +231,14 @@ jobs:
     displayName: Use NuGet 5.5.1
     inputs:
       versionSpec: 5.5.1
+
   - task: NuGetCommand@2
     displayName: NuGet restore $(SampleBotName).csproj
     inputs:
       solution: $(SampleRootPath)\$(SampleBotName).csproj
       selectOrConfig: config
       nugetConfigPath: $(SampleRootPath)\nuget.config
+
   - task: DotNetCoreCLI@2
     displayName: dotnet publish $(SampleBotName).csproj
     inputs:
@@ -247,6 +249,7 @@ jobs:
       arguments: --runtime linux-x64 --configuration $(BuildConfiguration) --output $(SampleRootPath)\publishedbot
       zipAfterPublish: false
       modifyOutputPath: false
+
   - task: AzureCLI@2
     displayName: 'Preexisting RG: create group, create resources, #prepare .deployment file'
     inputs:

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -339,8 +339,8 @@ jobs:
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
 
   - powershell: |
-      Start-Sleep -Seconds 120
-    displayName: 'Sleep for 120 seconds'
+      Start-Sleep -Seconds 800
+    displayName: 'Sleep for 800 seconds'
     enabled: true
 
   - task: DotNetCoreCLI@2

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -31,9 +31,9 @@ parameters:
   - name: packageFeed
     displayName: Package feed to use
     type: string
-    default: Conversational AI
+    default: Azure
     values:
-    - Conversational AI
+    - Azure
     - MyGet
     - NuGet
 
@@ -95,7 +95,7 @@ jobs:
 
         New-Item -Path $file -ItemType "file" -Value $content;
         '-------------'; get-content "$file"; '===================';
-    condition: eq(${{ parameters.packageFeed }}, 'Conversational AI')
+    condition: eq(${{ parameters.packageFeed }}, 'Azure')
 
   - task: PowerShell@2
     displayName: Create nuget.config for MyGet feed
@@ -148,29 +148,52 @@ jobs:
     condition: eq(${{ parameters.packageFeed }}, 'NuGet')
 
   - powershell: |
-     $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
+      $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
    
-     #$url = "https://feeds.dev.azure.com/ConversationalAI/BotFramework/_apis/packaging/Feeds/SDK/Packages/26dde74d-6079-401c-a9e0-c6d839e02c18/versions?api-version=5.1-preview.1"
+      #$url = "https://feeds.dev.azure.com/ConversationalAI/BotFramework/_apis/packaging/Feeds/SDK/Packages/26dde74d-6079-401c-a9e0-c6d839e02c18/versions?api-version=5.1-preview.1"
    
-     Write-Host "Get latest $packageName version number from ConversationalAI BotFramework SDK feed";
+      Write-Host "Get latest $packageName version number from ConversationalAI BotFramework SDK feed";
    
-     $RegistryUrlSource = "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" 
-     " "
-     "Available versions:";
-     nuget list Microsoft.Bot.Builder.Integration.AspNet.Core -Source "$RegistryUrlSource" -PreRelease -AllVersions | Select -First 30;
+      $RegistryUrlSource = "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" 
+      " "
+      "Available versions:";
+      nuget list Microsoft.Bot.Builder.Integration.AspNet.Core -Source "$RegistryUrlSource" -PreRelease -AllVersions | Select -First 30;
 
-     $PackageList = nuget list Microsoft.Bot.Builder.Integration.AspNet.Core -Source "$RegistryUrlSource" -PreRelease;
-     [string]$latestVersion = $PackageList.Split(" ")[-1];
+      $PackageList = nuget list Microsoft.Bot.Builder.Integration.AspNet.Core -Source "$RegistryUrlSource" -PreRelease;
+      [string]$latestVersion = $PackageList.Split(" ")[-1];
    
-     #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
-     #[string]$latestVersion = $result.value[0].protocolMetadata.data.version;
-     " "
-     "Latest version:";
-     $packageName;
-     $latestVersion;
-     "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+      #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+      #[string]$latestVersion = $result.value[0].protocolMetadata.data.version;
+      " "
+      "Latest version:";
+      $packageName;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
     displayName: 'Get latest Bot.Builder package version from Azure feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
-    condition: ${{ parameters.testLatestPackage }}
+    condition: and(${{ parameters.testLatestPackage }}, eq(${{ parameters.packageFeed }}, 'Azure'))
+
+  - powershell: |
+      $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      $myGetFeedName = "botbuilder-v4-dotnet-daily";
+      $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
+
+      $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
+
+      Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
+      $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+
+      $package = $result.packages | Where-Object {$_.id -eq $packageName};
+      " "
+      "Available versions:";
+      $package.versions | Select -Last 30;
+
+      [string]$latestVersion = $package.versions[-1];
+      " "
+      "Latest version:";
+      $package.id;
+      $latestVersion;
+      "##vso[task.setvariable variable=LatestVersion;]$latestVersion";    displayName: 'Get latest Bot.Builder package version from MyGet feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
+    condition: and(${{ parameters.testLatestPackage }}, eq(${{ parameters.packageFeed }}, 'MyGet'))
 
   - powershell: |
      $targetVersion = "${{ parameters.versionToTest }}";

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -277,7 +277,7 @@ jobs:
        # set up bot channels registration, app service, app service plan
        az deployment group create --resource-group "$(BotGroup)" --template-file "$(SampleRootPath)\DeploymentTemplates\LinuxDotNet\template.json" --parameters appId="$(AppId)" appSecret="$(AppSecret)" botName="$(AzureBotName)" --name "$(AzureBotName)";
      
-       #az bot prepare-deploy --lang Csharp --code-dir "$(SampleRootPath)" --proj-file-path "CoreBot.csproj";
+       #az bot prepare-deploy --lang Csharp --code-dir "$(SampleRootPath)" --proj-file-path "$(SampleBotName).csproj";
      
        Set-PSDebug -Trace 0;
 

--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -228,7 +228,9 @@ jobs:
   - task: tagBuildOrRelease@0
     displayName: Tag Build with Bot.Builder version
     inputs:
-      tags: Using Bot.Builder version $(TargetVersion)
+      tags: |
+        Using Bot.Builder version $(TargetVersion)
+        From ${{ parameters.packageFeed }} feed 
 
   - powershell: |
       $path = "$(SampleRootPath)\\$(SampleBotName).csproj";

--- a/build/yaml/sample-dotnet-samplebot-win-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-win-test.yml
@@ -56,9 +56,9 @@ resources:
     type: git
     ref: main
 
-variables:
-- group: SamplesE2ETestsVariableGroup
-- group: MyGetPersonalAccessTokenVariableGroup
+#variables:
+#- group: SamplesE2ETestsVariableGroup
+#- group: MyGetPersonalAccessTokenVariableGroup
 
 jobs:
 - job: Job_1

--- a/build/yaml/sample-dotnet-samplebot-win-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-win-test.yml
@@ -159,22 +159,22 @@ jobs:
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
 
   - powershell: |
-      #$myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
       $myGetFeedName = "botbuilder-v4-dotnet-daily";
       $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
 
       $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
 
       Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
-      #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+      $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
 
-      #$package = $result.packages | Where-Object {$_.id -eq $packageName};
-      #" "
-      #"Available versions:";
-      #$package.versions | Select -Last 30;
+      $package = $result.packages | Where-Object {$_.id -eq $packageName};
+      " "
+      "Available versions:";
+      $package.versions | Select -Last 30;
 
-      ### Hard-coded ##########
-      [string]$latestVersion = "4.15.0-preview.20210706-256858";  #$package.versions[-1];
+      ### Hard-coded ########## [string]$latestVersion = "4.15.0-preview.20210706-256858";
+      [string]$latestVersion = $package.versions[-1];
       " "
       "Latest version:";
       $package.id;

--- a/build/yaml/sample-dotnet-samplebot-win-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-win-test.yml
@@ -360,7 +360,7 @@ jobs:
       command: test
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/**Tests.csproj
       arguments: --verbosity Normal
-    condition: always()
+
   - task: CmdLine@2
     displayName: Dir workspace
     condition: always()
@@ -370,27 +370,28 @@ jobs:
         dir .. /s
 
   - task: AzureCLI@2
-    displayName: Delete bot, app service, app service plan, group
-    condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
-    continueOnError: True
+    displayName: 'Delete bot, app service, app service plan, group'
     inputs:
-      connectedServiceNameARM: 0ab0d343-57b9-4390-9a6a-13d71ef36de6
+      azureSubscription: 'FUSE Temporary'
       scriptType: ps
       scriptLocation: inlineScript
-      inlineScript: >-
+      inlineScript: |
         Set-PSDebug -Trace 1;
-
-        Write-Host "1) Delete Bot:"
-        az bot delete --name $(AzureBotName) --resource-group $(BotGroup)
-
-        Write-Host "2) Delete App Service:"
-        az webapp delete --name $(AzureBotName) --resource-group $(BotGroup)
-
-        Write-Host "3) Delete App Service plan:"
-        az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes
-
-        Write-Host "4) Delete Resource Group:"
-        az group delete --name $(BotGroup) --yes
-
+     
+        Write-Host "1) Delete Bot:";
+        az bot delete --name $(BotName) --resource-group $(BotGroup);
+     
+        Write-Host "2) Delete App Service:";
+        az webapp delete --name $(BotName) --resource-group $(BotGroup);
+     
+        Write-Host "3) Delete App Service plan:";
+        az appservice plan delete --name $(BotName) --resource-group $(BotGroup) --yes;
+     
+        Write-Host "4) Delete Resource Group:";
+        az group delete --name $(BotGroup) --yes;
+     
         Set-PSDebug -Trace 0;
+    condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
+    continueOnError: True
+
 ...

--- a/build/yaml/sample-dotnet-samplebot-win-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-win-test.yml
@@ -168,7 +168,7 @@ jobs:
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
 
   - powershell: |
-      $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      #$myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
       $myGetFeedName = "botbuilder-v4-dotnet-daily";
       $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
 

--- a/build/yaml/sample-dotnet-samplebot-win-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-win-test.yml
@@ -164,7 +164,7 @@ jobs:
       $packageName;
       $latestVersion;
       "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
-    displayName: 'Get latest Bot.Builder version number from Azure feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
+    displayName: 'From Azure feed get latest Bot.Builder version number - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
 
   - powershell: |
@@ -188,7 +188,7 @@ jobs:
       $package.id;
       $latestVersion;
       "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
-    displayName: 'Get latest Bot.Builder version number from Myget feed - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
+    displayName: 'From MyGet feed get latest Bot.Builder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
 
   - powershell: |
@@ -209,7 +209,7 @@ jobs:
       $packageName;
       $latestVersion;
       "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
-    displayName: 'Get latest Bot.Builder version number from NuGet feed - https://www.nuget.org/packages?q=Bot.Builder'
+    displayName: 'From NuGet feed get latest Bot.Builder version number - https://www.nuget.org/packages?q=Bot.Builder'
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'NuGet')) }}
 
   - powershell: |
@@ -379,13 +379,13 @@ jobs:
         Set-PSDebug -Trace 1;
      
         Write-Host "1) Delete Bot:";
-        az bot delete --name $(BotName) --resource-group $(BotGroup);
+        az bot delete --name $(AzureBotName) --resource-group $(BotGroup);
      
         Write-Host "2) Delete App Service:";
-        az webapp delete --name $(BotName) --resource-group $(BotGroup);
+        az webapp delete --name $(AzureBotName) --resource-group $(BotGroup);
      
         Write-Host "3) Delete App Service plan:";
-        az appservice plan delete --name $(BotName) --resource-group $(BotGroup) --yes;
+        az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes;
      
         Write-Host "4) Delete Resource Group:";
         az group delete --name $(BotGroup) --yes;

--- a/build/yaml/sample-dotnet-samplebot-win-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-win-test.yml
@@ -220,6 +220,7 @@ jobs:
       tags: |
         Using Bot.Builder version $(TargetVersion)
         From ${{ parameters.packageFeed }} feed 
+        Test latest = ${{ parameters.testLatestPackage }}
 
   - powershell: |
       $path = "$(SampleRootPath)\\$(SampleBotName).csproj";

--- a/build/yaml/sample-dotnet-samplebot-win-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-win-test.yml
@@ -69,77 +69,68 @@ jobs:
   - checkout: self
     persistCredentials: True
   
-  - task: PowerShell@2
+  - powershell: |
+      $file = "$(SampleRootPath)\nuget.config";
+
+      $content = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <add key="ConversationalAI" value="https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" />
+          <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
+
+      "@;
+
+      New-Item -Path $file -ItemType "file" -Value $content;
+      '-------------'; get-content "$file"; '===================';
     displayName: Create nuget.config for Azure feed
-    inputs:
-      targetType: inline
-      script: |
-        $file = "$(SampleRootPath)\nuget.config";
-
-        $content = @"
-        <?xml version="1.0" encoding="utf-8"?>
-        <configuration>
-          <packageSources>
-            <add key="ConversationalAI" value="https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" />
-            <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
-          </packageSources>
-          <activePackageSource>
-            <add key="All" value="(Aggregate source)" />
-          </activePackageSource>
-        </configuration>
-
-        "@;
-
-        New-Item -Path $file -ItemType "file" -Value $content;
-        '-------------'; get-content "$file"; '===================';
     condition: ${{ eq(parameters.packageFeed, 'Azure') }}
 
-  - task: PowerShell@2
+  - powershell: |
+      $file = "$(SampleRootPath)\nuget.config";
+
+      $content = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <add key="MyGet" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
+
+      "@;
+
+      New-Item -Path $file -ItemType "file" -Value $content;
+      '-------------'; get-content "$file"; '===================';
     displayName: Create nuget.config for MyGet feed
-    inputs:
-      targetType: inline
-      script: |
-        $file = "$(SampleRootPath)\nuget.config";
-
-        $content = @"
-        <?xml version="1.0" encoding="utf-8"?>
-        <configuration>
-          <packageSources>
-            <add key="MyGet" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" />
-          </packageSources>
-          <activePackageSource>
-            <add key="All" value="(Aggregate source)" />
-          </activePackageSource>
-        </configuration>
-
-        "@;
-
-        New-Item -Path $file -ItemType "file" -Value $content;
-        '-------------'; get-content "$file"; '===================';
     condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
 
-  - task: PowerShell@2
+  - powershell: |
+      $file = "$(SampleRootPath)\nuget.config";
+
+      $content = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
+
+      "@;
+
+      New-Item -Path $file -ItemType "file" -Value $content;
+      '-------------'; get-content "$file"; '===================';
     displayName: Create nuget.config for NuGet feed
-    inputs:
-      targetType: inline
-      script: |
-        $file = "$(SampleRootPath)\nuget.config";
-
-        $content = @"
-        <?xml version="1.0" encoding="utf-8"?>
-        <configuration>
-          <packageSources>
-            <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
-          </packageSources>
-          <activePackageSource>
-            <add key="All" value="(Aggregate source)" />
-          </activePackageSource>
-        </configuration>
-
-        "@;
-
-        New-Item -Path $file -ItemType "file" -Value $content;
-        '-------------'; get-content "$file"; '===================';
     condition: ${{ eq(parameters.packageFeed, 'NuGet') }}
 
   - powershell: |

--- a/build/yaml/sample-dotnet-samplebot-win-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-win-test.yml
@@ -226,7 +226,9 @@ jobs:
   - task: tagBuildOrRelease@0
     displayName: Tag Build with Bot.Builder version
     inputs:
-      tags: Using Bot.Builder version $(TargetVersion)
+      tags: |
+        Using Bot.Builder version $(TargetVersion)
+        From ${{ parameters.packageFeed }} feed 
 
   - powershell: |
       $path = "$(SampleRootPath)\\$(SampleBotName).csproj";
@@ -319,6 +321,7 @@ jobs:
         az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(AzureBotName)" --src "$(Build.ArtifactStagingDirectory)/$(SampleFolderName).zip"
 
         az bot directline create -n "$(AzureBotName)" -g "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json"
+
   - powershell: |
       # Key = Direct Line channel "Secret keys" in Azure portal
       $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
@@ -369,26 +372,26 @@ jobs:
         dir .. /s
 
   - task: AzureCLI@2
-    displayName: 'Delete bot, app service, app service plan, group'
+    displayName: Delete bot, app service, app service plan, group
     inputs:
       azureSubscription: 'FUSE Temporary'
       scriptType: ps
       scriptLocation: inlineScript
       inlineScript: |
         Set-PSDebug -Trace 1;
-     
+
         Write-Host "1) Delete Bot:";
         az bot delete --name $(AzureBotName) --resource-group $(BotGroup);
-     
+
         Write-Host "2) Delete App Service:";
         az webapp delete --name $(AzureBotName) --resource-group $(BotGroup);
-     
+
         Write-Host "3) Delete App Service plan:";
         az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes;
-     
+
         Write-Host "4) Delete Resource Group:";
         az group delete --name $(BotGroup) --yes;
-     
+
         Set-PSDebug -Trace 0;
     condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
     continueOnError: True

--- a/build/yaml/sample-dotnet-samplebot-win-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-win-test.yml
@@ -354,7 +354,7 @@ jobs:
   - powershell: |
       Start-Sleep -Seconds 15
     displayName: Sleep for 15 seconds
-    enabled: false
+    enabled: true
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test

--- a/build/yaml/sample-dotnet-samplebot-win-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-win-test.yml
@@ -246,8 +246,8 @@ jobs:
   - task: NuGetCommand@2
     displayName: NuGet restore $(SampleBotName).csproj
     inputs:
-      solution: $(SampleRootPath)\$(SampleBotName).csproj
-      selectOrConfig: config
+      restoreSolution: $(SampleRootPath)\$(SampleBotName).csproj
+      feedsToUse: config
       nugetConfigPath: $(SampleRootPath)\nuget.config
 
   - task: DotNetCoreCLI@2
@@ -256,10 +256,7 @@ jobs:
       command: publish
       publishWebProjects: false
       projects: $(SampleRootPath)\$(SampleBotName).csproj
-      custom: publish
-      arguments: --runtime linux-x64 --configuration $(BuildConfiguration) --output $(SampleRootPath)\publishedbot
-      zipAfterPublish: false
-      modifyOutputPath: false
+      arguments: --configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)
 
   - task: AzureCLI@2
     displayName: 'Preexisting RG: create Azure resources. Runs in even builds.'

--- a/build/yaml/sample-dotnet-samplebot-win-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-win-test.yml
@@ -354,13 +354,11 @@ jobs:
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/**Tests.csproj
       arguments: --verbosity Normal
 
-  - task: CmdLine@2
-    displayName: Dir workspace
+  - script: |
+      dir .. /s
+    displayName: 'Dir workspace'
+    continueOnError: true
     condition: always()
-    continueOnError: True
-    inputs:
-      script: >
-        dir .. /s
 
   - task: AzureCLI@2
     displayName: Delete bot, app service, app service plan, group

--- a/build/yaml/sample-dotnet-samplebot-win-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-win-test.yml
@@ -27,6 +27,14 @@ parameters:
     displayName: Version to test (Only if 'Test latest' is unchecked)
     type: string
     default: 'Example: 4.15.0-daily.20210714.258979.1220aed'
+  - name: packageFeed
+    displayName: Package feed to use
+    type: string
+    default: Azure
+    values:
+    - Azure
+    - MyGet
+    - NuGet
 
 # Run this job every night at 2 AM (PST) on the main branch
 schedules:
@@ -62,14 +70,13 @@ jobs:
     persistCredentials: True
   
   - task: PowerShell@2
-    displayName: Create nuget.config for ConversationalAI/BotFramework feed
+    displayName: Create nuget.config for Azure feed
     inputs:
       targetType: inline
-      script: >-
+      script: |
         $file = "$(SampleRootPath)\nuget.config";
 
         $content = @"
-
         <?xml version="1.0" encoding="utf-8"?>
         <configuration>
           <packageSources>
@@ -85,39 +92,132 @@ jobs:
 
         New-Item -Path $file -ItemType "file" -Value $content;
         '-------------'; get-content "$file"; '===================';
-    condition: ${{ parameters.testLatestPackage }}
+    condition: ${{ eq(parameters.packageFeed, 'Azure') }}
+
+  - task: PowerShell@2
+    displayName: Create nuget.config for MyGet feed
+    inputs:
+      targetType: inline
+      script: |
+        $file = "$(SampleRootPath)\nuget.config";
+
+        $content = @"
+        <?xml version="1.0" encoding="utf-8"?>
+        <configuration>
+          <packageSources>
+            <add key="MyGet" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" />
+          </packageSources>
+          <activePackageSource>
+            <add key="All" value="(Aggregate source)" />
+          </activePackageSource>
+        </configuration>
+
+        "@;
+
+        New-Item -Path $file -ItemType "file" -Value $content;
+        '-------------'; get-content "$file"; '===================';
+    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
+
+  - task: PowerShell@2
+    displayName: Create nuget.config for NuGet feed
+    inputs:
+      targetType: inline
+      script: |
+        $file = "$(SampleRootPath)\nuget.config";
+
+        $content = @"
+        <?xml version="1.0" encoding="utf-8"?>
+        <configuration>
+          <packageSources>
+            <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+          </packageSources>
+          <activePackageSource>
+            <add key="All" value="(Aggregate source)" />
+          </activePackageSource>
+        </configuration>
+
+        "@;
+
+        New-Item -Path $file -ItemType "file" -Value $content;
+        '-------------'; get-content "$file"; '===================';
+    condition: ${{ eq(parameters.packageFeed, 'NuGet') }}
 
   - powershell: |
-     $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
+      $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
    
-     #$url = "https://feeds.dev.azure.com/ConversationalAI/BotFramework/_apis/packaging/Feeds/SDK/Packages/26dde74d-6079-401c-a9e0-c6d839e02c18/versions?api-version=5.1-preview.1"
+      #$url = "https://feeds.dev.azure.com/ConversationalAI/BotFramework/_apis/packaging/Feeds/SDK/Packages/26dde74d-6079-401c-a9e0-c6d839e02c18/versions?api-version=5.1-preview.1"
    
-     Write-Host "Get latest $packageName version number from ConversationalAI BotFramework SDK feed";
+      Write-Host "Get latest $packageName version number from Azure ConversationalAI BotFramework SDK feed";
    
-     $RegistryUrlSource = "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" 
-     " "
-     "Available versions:";
-     nuget list Microsoft.Bot.Builder.Integration.AspNet.Core -Source "$RegistryUrlSource" -PreRelease -AllVersions | Select -First 30;
+      $RegistryUrlSource = "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" 
+      " "
+      "Available versions:";
+      nuget list Microsoft.Bot.Builder.Integration.AspNet.Core -Source "$RegistryUrlSource" -PreRelease -AllVersions | Select -First 30;
 
-     $PackageList = nuget list Microsoft.Bot.Builder.Integration.AspNet.Core -Source "$RegistryUrlSource" -PreRelease;
-     [string]$latestVersion = $PackageList.Split(" ")[-1];
+      $PackageList = nuget list Microsoft.Bot.Builder.Integration.AspNet.Core -Source "$RegistryUrlSource" -PreRelease;
+      [string]$latestVersion = $PackageList.Split(" ")[-1];
    
-     #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
-     #[string]$latestVersion = $result.value[0].protocolMetadata.data.version;
-     " "
-     "Latest version:";
-     $packageName;
-     $latestVersion;
-     "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
-    displayName: 'Get latest Bot.Builder package version from Azure feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
-    condition: ${{ parameters.testLatestPackage }}
+      #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+      #[string]$latestVersion = $result.value[0].protocolMetadata.data.version;
+      " "
+      "Latest version:";
+      $packageName;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+    displayName: 'Get latest Bot.Builder version number from Azure feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
+
+  - powershell: |
+      $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      $myGetFeedName = "botbuilder-v4-dotnet-daily";
+      $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
+
+      $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
+
+      Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
+      $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+
+      $package = $result.packages | Where-Object {$_.id -eq $packageName};
+      " "
+      "Available versions:";
+      $package.versions | Select -Last 30;
+
+      [string]$latestVersion = $package.versions[-1];
+      " "
+      "Latest version:";
+      $package.id;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
+    displayName: 'Get latest Bot.Builder version number from Myget feed - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
+
+  - powershell: |
+      $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
+   
+      Write-Host "Get latest $packageName version number from NuGet.org feed";
+         
+      $registryUrlSource = "https://nuget.org/api/v2/";
+
+      $packageList = Find-package -AllVersions -source $registryUrlSource -Name $packageName -AllowPrereleaseVersions | Select -First 30;
+      " "
+      "Available versions:";
+      $PackageList.Version
+
+      $latestVersion = $PackageList.Version[0];
+      " "
+      "Latest version:";
+      $packageName;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+    displayName: 'Get latest Bot.Builder version number from NuGet feed - https://www.nuget.org/packages?q=Bot.Builder'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'NuGet')) }}
 
   - powershell: |
      $targetVersion = "${{ parameters.versionToTest }}";
      $targetVersion;
      "##vso[task.setvariable variable=TargetVersion;]$targetVersion";
-    displayName: 'Set Bot.Builder package version per user input at queue time'
-    condition: ne(${{ parameters.testLatestPackage }}, 'true')
+    displayName: 'Get specific Bot.Builder version number from user input at queue time'
+    condition: ${{ ne(parameters.testLatestPackage, true) }}
 
   - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
     displayName: 'Display env vars'
@@ -129,19 +229,19 @@ jobs:
 
   - powershell: |
       $path = "$(SampleRootPath)\\$(SampleBotName).csproj";
-      $package = 'Microsoft.Bot.Builder.Integration.AspNet.Core';
+      $packages = @('Microsoft.Bot.Builder.Integration.AspNet.Core','Microsoft.Bot.Builder.AI.Luis','Microsoft.Bot.Builder.Dialogs');
       $newVersion = "$(TargetVersion)";
-   
-      $find = "$package`" Version=`"\S*`"";
-      $replace = "$package`" Version=`"$newVersion`"";
-   
-      Get-ChildItem -Path "$path" | % {
-          $_.FullName; 
-          $content = Get-Content -Raw $_.FullName;
-   
-          $content -Replace "$find", "$replace" | Set-Content $_.FullName;
-          '-------------'; get-content $_.FullName; '===================';
+
+      $content = Get-ChildItem -Path "$path" | Get-Content -Raw
+
+      foreach ($package in $packages) {
+          $find = "$package`" Version=`"\S*`"";
+          $replace = "$package`" Version=`"$newVersion`"";
+          $content = $content -Replace "$find", "$replace";
       }
+
+      Set-Content -Path $path -Value $content;
+      '-------------'; get-content $path; '===================';
     displayName: Set Bot.Builder version reference in $(SampleBotName).csproj
 
   - task: NuGetToolInstaller@1
@@ -155,13 +255,17 @@ jobs:
       solution: $(SampleRootPath)\$(SampleBotName).csproj
       selectOrConfig: config
       nugetConfigPath: $(SampleRootPath)\nuget.config
+
   - task: DotNetCoreCLI@2
     displayName: dotnet publish $(SampleBotName).csproj
     inputs:
       command: publish
       publishWebProjects: false
       projects: $(SampleRootPath)\$(SampleBotName).csproj
-      arguments: --configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)
+      custom: publish
+      arguments: --runtime linux-x64 --configuration $(BuildConfiguration) --output $(SampleRootPath)\publishedbot
+      zipAfterPublish: false
+      modifyOutputPath: false
 
   - task: AzureCLI@2
     displayName: 'Preexisting RG: create Azure resources. Runs in even builds.'
@@ -214,18 +318,15 @@ jobs:
         az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(AzureBotName)" --src "$(Build.ArtifactStagingDirectory)/$(SampleFolderName).zip"
 
         az bot directline create -n "$(AzureBotName)" -g "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json"
-  - task: PowerShell@2
-    displayName: Set DIRECTLINE, BOTID env vars for running tests
-    inputs:
-      targetType: inline
-      script: >-
-        # Key = Direct Line channel "Secret keys" in Azure portal
-        $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
-        $key = $json.properties.properties.sites.key;
-        echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
-        echo "##vso[task.setvariable variable=BOTID;]$(AzureBotName)";
-        Write-Host "setx DIRECTLINE $key";
-        Write-Host "setx BOTID $(AzureBotName)";
+  - powershell: |
+      # Key = Direct Line channel "Secret keys" in Azure portal
+      $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
+      $key = $json.properties.properties.sites.key;
+      echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
+      echo "##vso[task.setvariable variable=BOTID;]$(AzureBotName)";
+      Write-Host "setx DIRECTLINE $key";
+      Write-Host "setx BOTID $(AzureBotName)";
+    displayName: Set DIRECTLINE key, BOTID for running tests
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: $(SampleFolderName)-zip'
@@ -233,6 +334,7 @@ jobs:
     enabled: False
     inputs:
       ArtifactName: $(SampleFolderName)-zip
+
   - task: NuGetCommand@2
     displayName: NuGet restore Samples.$(SampleBotName).FunctionalTests.csproj
     inputs:
@@ -240,16 +342,18 @@ jobs:
       selectOrConfig: config
       nugetConfigPath: $(SampleRootPath)\nuget.config
     condition: always()
+
   - task: DotNetCoreCLI@2
     displayName: dotnet build Samples.$(SampleBotName).FunctionalTests.csproj
     inputs:
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
     condition: always()
-  - task: InlinePowershell@1
+
+  - powershell: |
+      Start-Sleep -Seconds 15
     displayName: Sleep for 15 seconds
-    inputs:
-      Script: Start-Sleep -Seconds 15
     enabled: false
+
   - task: DotNetCoreCLI@2
     displayName: dotnet test
     inputs:
@@ -264,6 +368,7 @@ jobs:
     inputs:
       script: >
         dir .. /s
+
   - task: AzureCLI@2
     displayName: Delete bot, app service, app service plan, group
     condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))

--- a/build/yaml/sample-dotnet-samplebot-win-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-win-test.yml
@@ -20,7 +20,7 @@
 
 parameters:
   - name: testLatestPackage
-    displayName: Test latest daily package version
+    displayName: Test latest package version
     type: boolean
     default: true
   - name: versionToTest
@@ -175,14 +175,15 @@ jobs:
       $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
 
       Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
-      $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+      #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
 
-      $package = $result.packages | Where-Object {$_.id -eq $packageName};
-      " "
-      "Available versions:";
-      $package.versions | Select -Last 30;
+      #$package = $result.packages | Where-Object {$_.id -eq $packageName};
+      #" "
+      #"Available versions:";
+      #$package.versions | Select -Last 30;
 
-      [string]$latestVersion = $package.versions[-1];
+      ### Hard-coded ##########
+      [string]$latestVersion = "4.15.0-preview.20210706-256858";  #$package.versions[-1];
       " "
       "Latest version:";
       $package.id;
@@ -216,7 +217,7 @@ jobs:
      $targetVersion = "${{ parameters.versionToTest }}";
      $targetVersion;
      "##vso[task.setvariable variable=TargetVersion;]$targetVersion";
-    displayName: 'Get specific Bot.Builder version number from user input at queue time'
+    displayName: 'From user input get specific Bot.Builder version number'
     condition: ${{ ne(parameters.testLatestPackage, true) }}
 
   - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
@@ -308,10 +309,10 @@ jobs:
   - task: AzureCLI@2
     displayName: 'Deploy bot, create DirectLine channel '
     inputs:
-      connectedServiceNameARM: 0ab0d343-57b9-4390-9a6a-13d71ef36de6
+      azureSubscription: 'FUSE Temporary'
       scriptType: ps
       scriptLocation: inlineScript
-      inlineScript: >-
+      inlineScript: |
         # prepare .deployment file
         az bot prepare-deploy --lang Csharp --code-dir "$(SampleRootPath)" --proj-file-path "$(SampleBotName).csproj";
 
@@ -341,13 +342,11 @@ jobs:
       solution: samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
       selectOrConfig: config
       nugetConfigPath: $(SampleRootPath)\nuget.config
-    condition: always()
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build Samples.$(SampleBotName).FunctionalTests.csproj
     inputs:
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
-    condition: always()
 
   - powershell: |
       Start-Sleep -Seconds 15

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -236,28 +236,27 @@ jobs:
       versionSpec: 5.5.1
 
   - powershell: |
-        $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
+      $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
 
-        $content = @"
+      $content = @"
 
-        <?xml version="1.0" encoding="utf-8"?>
+      <?xml version="1.0" encoding="utf-8"?>
 
-        <configuration>
-          <packageSources>
-            <add key="MyGet" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" />
-          </packageSources>
-          <activePackageSource>
-            <add key="All" value="(Aggregate source)" />
-          </activePackageSource>
-        </configuration>
+      <configuration>
+        <packageSources>
+          <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
 
-        "@;
+      "@;
 
 
-        New-Item -Path $file -ItemType "file" -Value $content;
-         '-------------'; get-content "$file"; '==================='
-    displayName: Create nuget.config for Samples.$(SampleBotName).FunctionalTests.csproj for MyGet feed
-    enabled: False
+      New-Item -Path $file -ItemType "file" -Value $content;
+        '-------------'; get-content "$file"; '==================='
+    displayName: Create nuget.config for Samples.$(SampleBotName).FunctionalTests.csproj for NuGet.org feed
 
   - task: NuGetCommand@2
     displayName: NuGet restore dotnet Samples.$(SampleBotName).FunctionalTests.csproj
@@ -277,13 +276,11 @@ jobs:
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/**Tests.csproj
       arguments: --verbosity Normal
 
-  - task: CmdLine@2
-    displayName: Dir workspace
+  - script: |
+      dir .. /s
+    displayName: 'Dir workspace'
+    continueOnError: true
     condition: always()
-    continueOnError: True
-    inputs:
-      script: >
-        dir .. /s
 
   - task: AzureCLI@2
     displayName: Delete bot, app service, app service plan, group

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -26,7 +26,7 @@ parameters:
   - name: versionToTest
     displayName: Version to test (Only if 'Test latest' is unchecked)
     type: string
-    default: 'Example: 4.15.0-dev.7afa288'
+    default: 'Example: 4.15.0-dev.20210726.c56bbf1'
   - name: packageFeed
     displayName: Package feed to use
     type: string

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -114,7 +114,7 @@ jobs:
       $package.id;
       $latestVersion;
       "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
-    displayName: 'From MyGet feed get latest botbuilder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
+    displayName: 'From MyGet feed get latest botbuilder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-js-daily'
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
 
   - powershell: |

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -194,14 +194,14 @@ jobs:
   - powershell: |
       Set-PSDebug -Trace 1;
       # Copy Azure deploy scripts for Linux
-      Move-Item -Path $(SampleRootPath)\DeploymentScripts\Linux\* -Destination $(SampleRootPath)\;
+      Move-Item -Path $(SampleRootPath)\deploymentScripts\linux\* -Destination $(SampleRootPath)\;
       Set-PSDebug -Trace 0;
     displayName: Move .deployment, deploy.sh scripts into position
 
   - script: |
       echo on
-      git config --global user.name "SampleJsTs$(SampleBotName)LinuxTestPipeline"
-      git config --global user.email BotBuilderJsTs@Pipeline.com
+      git config --global user.name "SampleTs$(SampleBotName)LinuxTestPipeline"
+      git config --global user.email BotBuilderTs@Pipeline.com
       git init
    
       git add .
@@ -209,7 +209,7 @@ jobs:
       git remote add azure https://$(AzureDeploymentUser):$(AzureDeploymentPassword)@$(AzureBotName).scm.azurewebsites.net:443/$(AzureBotName).git
    
       git push azure master
-    workingDirectory: '$(SampleRootPath)'
+    workingDirectory: '$(System.DefaultWorkingDirectory)/samples/javascript_nodejs/$(SampleFolderName)'
     displayName: 'Deploy the bot to Azure'
 
   - task: AzureCLI@2

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -94,8 +94,8 @@ jobs:
 
   - powershell: |
       #$myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
-      $myGetFeedName = "botbuilder-v4-dotnet-daily";
-      $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
+      $myGetFeedName = "botbuilder-v4-js-daily";
+      $packageName = "botbuilder-ai";
 
       $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
 
@@ -108,7 +108,7 @@ jobs:
       #$package.versions | Select -Last 30;
 
       ### Hard-coded ##########
-      [string]$latestVersion = "4.15.0-preview.20210706-256858";  #$package.versions[-1];
+      [string]$latestVersion = "4.15.0-dev.ffde26a";  #$package.versions[-1];
       " "
       "Latest version:";
       $package.id;

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -93,7 +93,7 @@ jobs:
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'npm')) }}
 
   - powershell: |
-      $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      #$myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
       $myGetFeedName = "botbuilder-v4-dotnet-daily";
       $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
 

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -70,22 +70,6 @@ jobs:
     persistCredentials: True
 
   - powershell: |
-        Set-Location -Path "$(SampleRootPath)"
-
-        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://registry.npmjs.com/"
-    displayName: Create .npmrc for npm feed - https://www.npmjs.com/search?q=botbuilder
-    condition: ${{ eq(parameters.packageFeed, 'npm') }}
-
-  - powershell: |
-      Set-Location -Path "$(SampleRootPath)"
-
-      New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
-    displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
-    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
-
-  - powershell: |
-      Set-Location -Path "$(SampleRootPath)"
-
       $packageName = "botbuilder";
 
       Write-Host "Get $packageName preview version tagged 'next' from npmjs.com";
@@ -106,33 +90,32 @@ jobs:
       #$versions = npm show botbuilder versions | ConvertFrom-Json
       #$next = $versions[1][-1]
     displayName: From npm feed get latest botbuilder package version  - https://www.npmjs.com/package/botbuilder
-    condition: ${{ eq(parameters.testLatestPackage, true) }}
-    #condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'npm')) }}
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'npm')) }}
 
-  #- powershell: |
-  #    #$myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
-  #    $myGetFeedName = "botbuilder-v4-js-daily";
-  #    $packageName = "botbuilder-ai";
+  - powershell: |
+      #$myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      $myGetFeedName = "botbuilder-v4-js-daily";
+      $packageName = "botbuilder-ai";
 
-  #    $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
+      $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
 
-  #    Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
-  #    #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+      Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
+      #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
 
-  #    #$package = $result.packages | Where-Object {$_.id -eq $packageName};
-  #    #" "
-  #    #"Available versions:";
-  #    #$package.versions | Select -Last 30;
+      #$package = $result.packages | Where-Object {$_.id -eq $packageName};
+      #" "
+      #"Available versions:";
+      #$package.versions | Select -Last 30;
 
-  #    ### Hard-coded ##########
-  #    [string]$latestVersion = "4.15.0-dev.ffde26a";  #$package.versions[-1];
-  #    " "
-  #    "Latest version:";
-  #    $package.id;
-  #    $latestVersion;
-  #    "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
-  #  displayName: 'From MyGet feed get latest botbuilder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
-  #  condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
+      ### Hard-coded ##########
+      [string]$latestVersion = "4.15.0-dev.ffde26a";  #$package.versions[-1];
+      " "
+      "Latest version:";
+      $package.id;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
+    displayName: 'From MyGet feed get latest botbuilder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
 
   - powershell: |
      $targetVersion = "${{ parameters.versionToTest }}";
@@ -169,19 +152,19 @@ jobs:
       '-------------'; get-content $path; '===================';
     displayName: 'Set botbuilder version reference in package.json'
 
-  #- powershell: |
-  #      Set-Location -Path "$(SampleRootPath)"
+  - powershell: |
+        Set-Location -Path "$(SampleRootPath)"
 
-  #      New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://registry.npmjs.com/"
-  #  displayName: Create .npmrc for npm feed - https://www.npmjs.com/search?q=botbuilder
-  #  condition: ${{ eq(parameters.packageFeed, 'npm') }}
+        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://registry.npmjs.com/"
+    displayName: Create .npmrc for npm feed - https://www.npmjs.com/search?q=botbuilder
+    condition: ${{ eq(parameters.packageFeed, 'npm') }}
 
-  #- powershell: |
-  #      Set-Location -Path "$(SampleRootPath)"
+  - powershell: |
+        Set-Location -Path "$(SampleRootPath)"
 
-  #      New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
-  #  displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
-  #  condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
+        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
+    displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
+    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
 
   - task: Npm@1
     displayName: npm install $(SampleFolderName)

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -187,7 +187,7 @@ jobs:
         az deployment group create --resource-group "$(BotGroup)" --template-file "$(SampleRootPath)\deploymentTemplates\linux\template.json" --parameters appId="$(AppId)" appSecret="$(AppSecret)" botName="$(AzureBotName)" --name "$(AzureBotName)";
      
         # Generate web.config for bot deploy
-        az bot prepare-deploy --code-dir "$(System.DefaultWorkingDirectory)/samples/javascript_nodejs/$(SampleFolderName)" --lang Javascript
+        az bot prepare-deploy --code-dir "$(SampleRootPath)" --lang Javascript
      
         Set-PSDebug -Trace 0;
 

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -236,12 +236,7 @@ jobs:
     inputs:
       versionSpec: 5.5.1
 
-  - task: PowerShell@2
-    displayName: Create nuget.config for Samples.$(SampleBotName).FunctionalTests.csproj for MyGet feed
-    enabled: False
-    inputs:
-      targetType: inline
-      script: >-
+  - powershell: |
         $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
 
         $content = @"
@@ -262,6 +257,8 @@ jobs:
 
         New-Item -Path $file -ItemType "file" -Value $content;
          '-------------'; get-content "$file"; '==================='
+    displayName: Create nuget.config for Samples.$(SampleBotName).FunctionalTests.csproj for MyGet feed
+    enabled: False
 
   - task: NuGetCommand@2
     displayName: NuGet restore dotnet Samples.$(SampleBotName).FunctionalTests.csproj

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -200,8 +200,8 @@ jobs:
 
   - script: |
       echo on
-     git config --global user.name "SampleJs$(SampleBotName)LinuxTestPipeline"
-     git config --global user.email BotBuilderJs@Pipeline.com
+      git config --global user.name "SampleJs$(SampleBotName)LinuxTestPipeline"
+      git config --global user.email BotBuilderJs@Pipeline.com
       git init
    
       git add .

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -70,6 +70,22 @@ jobs:
     persistCredentials: True
 
   - powershell: |
+        Set-Location -Path "$(SampleRootPath)"
+
+        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://registry.npmjs.com/"
+    displayName: Create .npmrc for npm feed - https://www.npmjs.com/search?q=botbuilder
+    condition: ${{ eq(parameters.packageFeed, 'npm') }}
+
+  - powershell: |
+      Set-Location -Path "$(SampleRootPath)"
+
+      New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
+    displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
+    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
+
+  - powershell: |
+      Set-Location -Path "$(SampleRootPath)"
+
       $packageName = "botbuilder";
 
       Write-Host "Get $packageName preview version tagged 'next' from npmjs.com";
@@ -90,32 +106,33 @@ jobs:
       #$versions = npm show botbuilder versions | ConvertFrom-Json
       #$next = $versions[1][-1]
     displayName: From npm feed get latest botbuilder package version  - https://www.npmjs.com/package/botbuilder
-    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'npm')) }}
+    condition: ${{ eq(parameters.testLatestPackage, true) }}
+    #condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'npm')) }}
 
-  - powershell: |
-      #$myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
-      $myGetFeedName = "botbuilder-v4-js-daily";
-      $packageName = "botbuilder-ai";
+  #- powershell: |
+  #    #$myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+  #    $myGetFeedName = "botbuilder-v4-js-daily";
+  #    $packageName = "botbuilder-ai";
 
-      $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
+  #    $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
 
-      Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
-      #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+  #    Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
+  #    #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
 
-      #$package = $result.packages | Where-Object {$_.id -eq $packageName};
-      #" "
-      #"Available versions:";
-      #$package.versions | Select -Last 30;
+  #    #$package = $result.packages | Where-Object {$_.id -eq $packageName};
+  #    #" "
+  #    #"Available versions:";
+  #    #$package.versions | Select -Last 30;
 
-      ### Hard-coded ##########
-      [string]$latestVersion = "4.15.0-dev.ffde26a";  #$package.versions[-1];
-      " "
-      "Latest version:";
-      $package.id;
-      $latestVersion;
-      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
-    displayName: 'From MyGet feed get latest botbuilder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
-    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
+  #    ### Hard-coded ##########
+  #    [string]$latestVersion = "4.15.0-dev.ffde26a";  #$package.versions[-1];
+  #    " "
+  #    "Latest version:";
+  #    $package.id;
+  #    $latestVersion;
+  #    "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
+  #  displayName: 'From MyGet feed get latest botbuilder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
+  #  condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
 
   - powershell: |
      $targetVersion = "${{ parameters.versionToTest }}";
@@ -152,19 +169,19 @@ jobs:
       '-------------'; get-content $path; '===================';
     displayName: 'Set botbuilder version reference in package.json'
 
-  - powershell: |
-        Set-Location -Path "$(SampleRootPath)"
+  #- powershell: |
+  #      Set-Location -Path "$(SampleRootPath)"
 
-        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://registry.npmjs.com/"
-    displayName: Create .npmrc for npm feed - https://www.npmjs.com/search?q=botbuilder
-    condition: ${{ eq(parameters.packageFeed, 'npm') }}
+  #      New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://registry.npmjs.com/"
+  #  displayName: Create .npmrc for npm feed - https://www.npmjs.com/search?q=botbuilder
+  #  condition: ${{ eq(parameters.packageFeed, 'npm') }}
 
-  - powershell: |
-        Set-Location -Path "$(SampleRootPath)"
+  #- powershell: |
+  #      Set-Location -Path "$(SampleRootPath)"
 
-        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
-    displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
-    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
+  #      New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
+  #  displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
+  #  condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
 
   - task: Npm@1
     displayName: npm install $(SampleFolderName)

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -200,8 +200,8 @@ jobs:
 
   - script: |
       echo on
-      git config --global user.name "SampleTs$(SampleBotName)LinuxTestPipeline"
-      git config --global user.email BotBuilderTs@Pipeline.com
+     git config --global user.name "SampleJs$(SampleBotName)LinuxTestPipeline"
+     git config --global user.email BotBuilderJs@Pipeline.com
       git init
    
       git add .

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -70,6 +70,29 @@ jobs:
     persistCredentials: True
 
   - powershell: |
+      $packageName = "botbuilder";
+
+      Write-Host "Get $packageName preview version tagged 'next' from npmjs.com";
+      " "
+      "Available versions:";
+      npm view $packageName versions | Select -Last 30;
+
+      $dist = npm dist-tag ls $packageName;
+      $next = $dist.Where({$_.StartsWith("next:")});
+      [string]$latestVersion = $next.Split(':')[-1].Trim();
+
+      "Latest version:";
+      $packageName;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+
+      # This gets latest version from all versions.
+      #$versions = npm show botbuilder versions | ConvertFrom-Json
+      #$next = $versions[1][-1]
+    displayName: From npm feed get latest botbuilder package version  - https://www.npmjs.com/package/botbuilder
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'npm')) }}
+
+  - powershell: |
       $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
       $myGetFeedName = "botbuilder-v4-dotnet-daily";
       $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
@@ -91,34 +114,8 @@ jobs:
       $package.id;
       $latestVersion;
       "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
-    displayName: 'From MyGet feed get latest Bot.Builder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
+    displayName: 'From MyGet feed get latest botbuilder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
-
-  - task: PowerShell@2
-    displayName: Get latest botbuilder package version from npmjs feed - https://www.npmjs.com/package/botbuilder
-    inputs:
-      targetType: inline
-      script: |
-        $packageName = "botbuilder";
-
-        Write-Host "Get $packageName preview version tagged 'next' from npmjs.com";
-        " "
-        "Available versions:";
-        npm view $packageName versions | Select -Last 30;
-
-        $dist = npm dist-tag ls $packageName;
-        $next = $dist.Where({$_.StartsWith("next:")});
-        [string]$latestVersion = $next.Split(':')[-1].Trim();
-
-        "Latest version:";
-        $packageName;
-        $latestVersion;
-        "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
-
-        # This gets latest version from all versions.
-        #$versions = npm show botbuilder versions | ConvertFrom-Json
-        #$next = $versions[1][-1]
-    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'npm')) }}
 
   - powershell: |
      $targetVersion = "${{ parameters.versionToTest }}";
@@ -155,24 +152,18 @@ jobs:
       '-------------'; get-content $path; '===================';
     displayName: 'Set botbuilder version reference in package.json'
 
-  - task: PowerShell@2
-    displayName: Create .npmrc for npm feed - https://www.npmjs.com/search?q=botbuilder
-    inputs:
-      targetType: inline
-      script: |
+  - powershell: |
         Set-Location -Path "$(SampleRootPath)"
 
         New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://registry.npmjs.com/"
+    displayName: Create .npmrc for npm feed - https://www.npmjs.com/search?q=botbuilder
     condition: ${{ eq(parameters.packageFeed, 'npm') }}
 
-  - task: PowerShell@2
-    displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
-    inputs:
-      targetType: inline
-      script: |
+  - powershell: |
         Set-Location -Path "$(SampleRootPath)"
 
         New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
+    displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
     condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
 
   - task: Npm@1
@@ -200,24 +191,25 @@ jobs:
      
         Set-PSDebug -Trace 0;
 
+  - powershell: |
+      Set-PSDebug -Trace 1;
+      # Copy Azure deploy scripts for Linux
+      Move-Item -Path $(SampleRootPath)\DeploymentScripts\Linux\* -Destination $(SampleRootPath)\;
+      Set-PSDebug -Trace 0;
+    displayName: Move .deployment, deploy.sh scripts into position
 
   - script: |
-     echo Move $(SampleRootPath)\deploymentScripts\linux\* $(SampleRootPath)
-     Move $(SampleRootPath)\deploymentScripts\linux\* $(SampleRootPath)
+      echo on
+      git config --global user.name "SampleJs$(SampleBotName)LinuxTestPipeline"
+      git config --global user.email BotBuilderJs@Pipeline.com
+      git init
    
-     echo git config
-     git config --global user.name "SampleJs$(SampleBotName)LinuxTestPipeline"
-     git config --global user.email BotBuilderJs@Pipeline.com
-     git init
+      git add .
+      git commit -m "Add bot source code"
+      git remote add azure https://$(AzureDeploymentUser):$(AzureDeploymentPassword)@$(AzureBotName).scm.azurewebsites.net:443/$(AzureBotName).git
    
-     echo git add .
-     git add .
-     git commit -m "Add bot source code"
-     git remote add azure https://$(AzureDeploymentUser):$(AzureDeploymentPassword)@$(AzureBotName).scm.azurewebsites.net:443/$(AzureBotName).git
-   
-     echo git push azure master
-     git push azure master
-    workingDirectory: '$(System.DefaultWorkingDirectory)/samples/javascript_nodejs/$(SampleFolderName)'
+      git push azure master
+    workingDirectory: '$(SampleRootPath)'
     displayName: 'Deploy the bot to Azure'
 
   - task: AzureCLI@2
@@ -252,7 +244,6 @@ jobs:
       script: >-
         $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
 
-
         $content = @"
 
         <?xml version="1.0" encoding="utf-8"?>
@@ -270,7 +261,6 @@ jobs:
 
 
         New-Item -Path $file -ItemType "file" -Value $content;
-
          '-------------'; get-content "$file"; '==================='
 
   - task: NuGetCommand@2
@@ -304,26 +294,27 @@ jobs:
 
   - task: AzureCLI@2
     displayName: Delete bot, app service, app service plan, group
-    condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
-    continueOnError: True
     inputs:
-      connectedServiceNameARM: 0ab0d343-57b9-4390-9a6a-13d71ef36de6
+      azureSubscription: 'FUSE Temporary'
       scriptType: ps
       scriptLocation: inlineScript
-      inlineScript: >-
+      inlineScript: |
         Set-PSDebug -Trace 1;
 
-        Write-Host "1) Delete Bot:"
-        az bot delete --name $(AzureBotName) --resource-group $(BotGroup)
+        Write-Host "1) Delete Bot:";
+        az bot delete --name $(AzureBotName) --resource-group $(BotGroup);
 
-        Write-Host "2) Delete App Service:"
-        az webapp delete --name $(AzureBotName) --resource-group $(BotGroup)
+        Write-Host "2) Delete App Service:";
+        az webapp delete --name $(AzureBotName) --resource-group $(BotGroup);
 
-        Write-Host "3) Delete App Service plan:"
-        az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes
+        Write-Host "3) Delete App Service plan:";
+        az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes;
 
-        Write-Host "4) Delete Resource Group:"
-        az group delete --name $(BotGroup) --yes
+        Write-Host "4) Delete Resource Group:";
+        az group delete --name $(BotGroup) --yes;
 
         Set-PSDebug -Trace 0;
+    condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
+    continueOnError: True
+
 ...

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -239,9 +239,7 @@ jobs:
       $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
 
       $content = @"
-
       <?xml version="1.0" encoding="utf-8"?>
-
       <configuration>
         <packageSources>
           <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
@@ -252,7 +250,6 @@ jobs:
       </configuration>
 
       "@;
-
 
       New-Item -Path $file -ItemType "file" -Value $content;
         '-------------'; get-content "$file"; '==================='

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -150,7 +150,7 @@ jobs:
 
       Set-Content -Path $path -Value $content;
       '-------------'; get-content $path; '===================';
-    displayName: 'Set botbuilder version reference in package.json'
+    displayName: Set botbuilder version reference in package.json
 
   - powershell: |
         Set-Location -Path "$(SampleRootPath)"

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -77,15 +77,13 @@ jobs:
     condition: ${{ eq(parameters.packageFeed, 'npm') }}
 
   - powershell: |
-      Set-Location -Path "$(SampleRootPath)"
+        Set-Location -Path "$(SampleRootPath)"
 
-      New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
+        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
     displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
     condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
 
   - powershell: |
-      Set-Location -Path "$(SampleRootPath)"
-
       $packageName = "botbuilder";
 
       Write-Host "Get $packageName preview version tagged 'next' from npmjs.com";

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -200,8 +200,8 @@ jobs:
 
   - script: |
       echo on
-      git config --global user.name "SampleJs$(SampleBotName)LinuxTestPipeline"
-      git config --global user.email BotBuilderJs@Pipeline.com
+      git config --global user.name "SampleJsTs$(SampleBotName)LinuxTestPipeline"
+      git config --global user.email BotBuilderJsTs@Pipeline.com
       git init
    
       git add .
@@ -232,7 +232,6 @@ jobs:
 
   - task: NuGetToolInstaller@1
     displayName: Use NuGet 5.5.1
-    enabled: False
     inputs:
       versionSpec: 5.5.1
 

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -70,20 +70,6 @@ jobs:
     persistCredentials: True
 
   - powershell: |
-        Set-Location -Path "$(SampleRootPath)"
-
-        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://registry.npmjs.com/"
-    displayName: Create .npmrc for npm feed - https://www.npmjs.com/search?q=botbuilder
-    condition: ${{ eq(parameters.packageFeed, 'npm') }}
-
-  - powershell: |
-        Set-Location -Path "$(SampleRootPath)"
-
-        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
-    displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
-    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
-
-  - powershell: |
       $packageName = "botbuilder";
 
       Write-Host "Get $packageName preview version tagged 'next' from npmjs.com";
@@ -104,33 +90,32 @@ jobs:
       #$versions = npm show botbuilder versions | ConvertFrom-Json
       #$next = $versions[1][-1]
     displayName: From npm feed get latest botbuilder package version  - https://www.npmjs.com/package/botbuilder
-    condition: ${{ eq(parameters.testLatestPackage, true) }}
-    #condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'npm')) }}
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'npm')) }}
 
-  #- powershell: |
-  #    #$myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
-  #    $myGetFeedName = "botbuilder-v4-js-daily";
-  #    $packageName = "botbuilder-ai";
+  - powershell: |
+      #$myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      $myGetFeedName = "botbuilder-v4-js-daily";
+      $packageName = "botbuilder-ai";
 
-  #    $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
+      $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
 
-  #    Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
-  #    #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+      Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
+      #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
 
-  #    #$package = $result.packages | Where-Object {$_.id -eq $packageName};
-  #    #" "
-  #    #"Available versions:";
-  #    #$package.versions | Select -Last 30;
+      #$package = $result.packages | Where-Object {$_.id -eq $packageName};
+      #" "
+      #"Available versions:";
+      #$package.versions | Select -Last 30;
 
-  #    ### Hard-coded ##########
-  #    [string]$latestVersion = "4.15.0-dev.ffde26a";  #$package.versions[-1];
-  #    " "
-  #    "Latest version:";
-  #    $package.id;
-  #    $latestVersion;
-  #    "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
-  #  displayName: 'From MyGet feed get latest botbuilder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
-  #  condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
+      ### Hard-coded ##########
+      [string]$latestVersion = "4.15.0-dev.ffde26a";  #$package.versions[-1];
+      " "
+      "Latest version:";
+      $package.id;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
+    displayName: 'From MyGet feed get latest botbuilder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
 
   - powershell: |
      $targetVersion = "${{ parameters.versionToTest }}";
@@ -167,19 +152,19 @@ jobs:
       '-------------'; get-content $path; '===================';
     displayName: 'Set botbuilder version reference in package.json'
 
-  #- powershell: |
-  #      Set-Location -Path "$(SampleRootPath)"
+  - powershell: |
+        Set-Location -Path "$(SampleRootPath)"
 
-  #      New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://registry.npmjs.com/"
-  #  displayName: Create .npmrc for npm feed - https://www.npmjs.com/search?q=botbuilder
-  #  condition: ${{ eq(parameters.packageFeed, 'npm') }}
+        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://registry.npmjs.com/"
+    displayName: Create .npmrc for npm feed - https://www.npmjs.com/search?q=botbuilder
+    condition: ${{ eq(parameters.packageFeed, 'npm') }}
 
-  #- powershell: |
-  #      Set-Location -Path "$(SampleRootPath)"
+  - powershell: |
+        Set-Location -Path "$(SampleRootPath)"
 
-  #      New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
-  #  displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
-  #  condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
+        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
+    displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
+    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
 
   - task: Npm@1
     displayName: npm install $(SampleFolderName)

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -48,10 +48,10 @@ resources:
     type: git
     ref: main
 
-variables:
-- group: AzureDeploymentCredsVariableGroup
-- group: SamplesE2ETestsVariableGroup
-- group: MyGetPersonalAccessTokenVariableGroup
+#variables:
+#- group: AzureDeploymentCredsVariableGroup
+#- group: SamplesE2ETestsVariableGroup
+#- group: MyGetPersonalAccessTokenVariableGroup
 
 jobs:
 - job: Job_1

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -70,6 +70,20 @@ jobs:
     persistCredentials: True
 
   - powershell: |
+        Set-Location -Path "$(SampleRootPath)"
+
+        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://registry.npmjs.com/"
+    displayName: Create .npmrc for npm feed - https://www.npmjs.com/search?q=botbuilder
+    condition: ${{ eq(parameters.packageFeed, 'npm') }}
+
+  - powershell: |
+        Set-Location -Path "$(SampleRootPath)"
+
+        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
+    displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
+    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
+
+  - powershell: |
       $packageName = "botbuilder";
 
       Write-Host "Get $packageName preview version tagged 'next' from npmjs.com";
@@ -90,32 +104,33 @@ jobs:
       #$versions = npm show botbuilder versions | ConvertFrom-Json
       #$next = $versions[1][-1]
     displayName: From npm feed get latest botbuilder package version  - https://www.npmjs.com/package/botbuilder
-    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'npm')) }}
+    condition: ${{ eq(parameters.testLatestPackage, true) }}
+    #condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'npm')) }}
 
-  - powershell: |
-      #$myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
-      $myGetFeedName = "botbuilder-v4-js-daily";
-      $packageName = "botbuilder-ai";
+  #- powershell: |
+  #    #$myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+  #    $myGetFeedName = "botbuilder-v4-js-daily";
+  #    $packageName = "botbuilder-ai";
 
-      $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
+  #    $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
 
-      Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
-      #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+  #    Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
+  #    #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
 
-      #$package = $result.packages | Where-Object {$_.id -eq $packageName};
-      #" "
-      #"Available versions:";
-      #$package.versions | Select -Last 30;
+  #    #$package = $result.packages | Where-Object {$_.id -eq $packageName};
+  #    #" "
+  #    #"Available versions:";
+  #    #$package.versions | Select -Last 30;
 
-      ### Hard-coded ##########
-      [string]$latestVersion = "4.15.0-dev.ffde26a";  #$package.versions[-1];
-      " "
-      "Latest version:";
-      $package.id;
-      $latestVersion;
-      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
-    displayName: 'From MyGet feed get latest botbuilder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
-    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
+  #    ### Hard-coded ##########
+  #    [string]$latestVersion = "4.15.0-dev.ffde26a";  #$package.versions[-1];
+  #    " "
+  #    "Latest version:";
+  #    $package.id;
+  #    $latestVersion;
+  #    "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
+  #  displayName: 'From MyGet feed get latest botbuilder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
+  #  condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
 
   - powershell: |
      $targetVersion = "${{ parameters.versionToTest }}";
@@ -152,19 +167,19 @@ jobs:
       '-------------'; get-content $path; '===================';
     displayName: 'Set botbuilder version reference in package.json'
 
-  - powershell: |
-        Set-Location -Path "$(SampleRootPath)"
+  #- powershell: |
+  #      Set-Location -Path "$(SampleRootPath)"
 
-        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://registry.npmjs.com/"
-    displayName: Create .npmrc for npm feed - https://www.npmjs.com/search?q=botbuilder
-    condition: ${{ eq(parameters.packageFeed, 'npm') }}
+  #      New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://registry.npmjs.com/"
+  #  displayName: Create .npmrc for npm feed - https://www.npmjs.com/search?q=botbuilder
+  #  condition: ${{ eq(parameters.packageFeed, 'npm') }}
 
-  - powershell: |
-        Set-Location -Path "$(SampleRootPath)"
+  #- powershell: |
+  #      Set-Location -Path "$(SampleRootPath)"
 
-        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
-    displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
-    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
+  #      New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
+  #  displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
+  #  condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
 
   - task: Npm@1
     displayName: npm install $(SampleFolderName)

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -77,13 +77,15 @@ jobs:
     condition: ${{ eq(parameters.packageFeed, 'npm') }}
 
   - powershell: |
-        Set-Location -Path "$(SampleRootPath)"
+      Set-Location -Path "$(SampleRootPath)"
 
-        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
+      New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
     displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
     condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
 
   - powershell: |
+      Set-Location -Path "$(SampleRootPath)"
+
       $packageName = "botbuilder";
 
       Write-Host "Get $packageName preview version tagged 'next' from npmjs.com";

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -93,22 +93,22 @@ jobs:
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'npm')) }}
 
   - powershell: |
-      #$myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
       $myGetFeedName = "botbuilder-v4-js-daily";
       $packageName = "botbuilder-ai";
 
       $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
 
       Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
-      #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+      $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
 
-      #$package = $result.packages | Where-Object {$_.id -eq $packageName};
-      #" "
-      #"Available versions:";
-      #$package.versions | Select -Last 30;
+      $package = $result.packages | Where-Object {$_.id -eq $packageName};
+      " "
+      "Available versions:";
+      $package.versions | Select -Last 30;
 
-      ### Hard-coded ##########
-      [string]$latestVersion = "4.15.0-dev.ffde26a";  #$package.versions[-1];
+      ### Hard-coded ########## [string]$latestVersion = "4.15.0-dev.ffde26a";
+      [string]$latestVersion = $package.versions[-1];
       " "
       "Latest version:";
       $package.id;

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -1,4 +1,4 @@
-# This is used in the pipelines Sample-Js-CoreBot-Win-Test-yaml and Sample-Js-EchoBot-Win-Test-yaml.
+# This is used in the pipelines Sample-Js-CoreBot-Linux-Test-yaml and Sample-Js-EchoBot-Linux-Test-yaml.
 
 # 'Allow scripts to access the OAuth token' was selected in pipeline.  Add the following YAML to any steps requiring access:
 #       env:
@@ -20,13 +20,20 @@
 
 parameters:
   - name: testLatestPackage
-    displayName: Test latest daily package version
+    displayName: Test latest package version
     type: boolean
     default: true
   - name: versionToTest
     displayName: Version to test (Only if 'Test latest' is unchecked)
     type: string
     default: 'Example: 4.15.0-dev.7afa288'
+  - name: packageFeed
+    displayName: Package feed to use
+    type: string
+    default: npm
+    values:
+    - npm
+    - MyGet
 
 # Run this job every night at 2 AM (PST) on the main branch
 schedules:
@@ -61,7 +68,32 @@ jobs:
   steps:
   - checkout: self
     persistCredentials: True
-  
+
+  - powershell: |
+      $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      $myGetFeedName = "botbuilder-v4-dotnet-daily";
+      $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
+
+      $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
+
+      Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
+      #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+
+      #$package = $result.packages | Where-Object {$_.id -eq $packageName};
+      #" "
+      #"Available versions:";
+      #$package.versions | Select -Last 30;
+
+      ### Hard-coded ##########
+      [string]$latestVersion = "4.15.0-preview.20210706-256858";  #$package.versions[-1];
+      " "
+      "Latest version:";
+      $package.id;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
+    displayName: 'From MyGet feed get latest Bot.Builder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
+
   - task: PowerShell@2
     displayName: Get latest botbuilder package version from npmjs feed - https://www.npmjs.com/package/botbuilder
     inputs:
@@ -86,14 +118,14 @@ jobs:
         # This gets latest version from all versions.
         #$versions = npm show botbuilder versions | ConvertFrom-Json
         #$next = $versions[1][-1]
-    condition: ${{ parameters.testLatestPackage }}
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'npm')) }}
 
   - powershell: |
      $targetVersion = "${{ parameters.versionToTest }}";
      $targetVersion;
      "##vso[task.setvariable variable=TargetVersion;]$targetVersion";
-    displayName: 'Set botbuilder package version per user input at queue time'
-    condition: ne(${{ parameters.testLatestPackage }}, 'true')
+    displayName: 'From user input get specific botbuilder version number'
+    condition: ${{ ne(parameters.testLatestPackage, true) }}
 
   - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
     displayName: 'Display env vars'
@@ -101,7 +133,9 @@ jobs:
   - task: tagBuildOrRelease@0
     displayName: Tag Build with botbuilder version
     inputs:
-      tags: Using botbuilder version $(TargetVersion)
+      tags: |
+        Using botbuilder version $(TargetVersion)
+        From ${{ parameters.packageFeed }} feed 
 
   - powershell: |
      # SetDependencyVersionInPackageJsonFile0.ps1
@@ -122,13 +156,24 @@ jobs:
     displayName: 'Set botbuilder version reference in package.json'
 
   - task: PowerShell@2
-    displayName: Create .npmrc for npmjs feed - https://www.npmjs.com/search?q=botbuilder
+    displayName: Create .npmrc for npm feed - https://www.npmjs.com/search?q=botbuilder
     inputs:
       targetType: inline
       script: |
         Set-Location -Path "$(SampleRootPath)"
 
         New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://registry.npmjs.com/"
+    condition: ${{ eq(parameters.packageFeed, 'npm') }}
+
+  - task: PowerShell@2
+    displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
+    inputs:
+      targetType: inline
+      script: |
+        Set-Location -Path "$(SampleRootPath)"
+
+        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
+    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
 
   - task: Npm@1
     displayName: npm install $(SampleFolderName)
@@ -175,31 +220,30 @@ jobs:
     workingDirectory: '$(System.DefaultWorkingDirectory)/samples/javascript_nodejs/$(SampleFolderName)'
     displayName: 'Deploy the bot to Azure'
 
-  - task: AzureCLI@1
-    displayName: 'Create directline channel '
+  - task: AzureCLI@2
+    displayName: Create DirectLine channel
     inputs:
-      connectedServiceNameARM: 0ab0d343-57b9-4390-9a6a-13d71ef36de6
+      azureSubscription: 'FUSE Temporary'
+      scriptType: batch
       scriptLocation: inlineScript
-      inlineScript: >
-        call az bot directline create --name "$(AzureBotName)" --resource-group "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json" --debug
-  - task: PowerShell@2
+      inlineScript: call az bot directline create --name "$(AzureBotName)" --resource-group "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json" --debug
+
+  - powershell: |
+      # Key = Direct Line channel "Secret keys" in Azure portal
+      $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
+      $key = $json.properties.properties.sites.key;
+      echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
+      echo "##vso[task.setvariable variable=BOTID;]$(AzureBotName)";
+      Write-Host "setx DIRECTLINE $key";
+      Write-Host "setx BOTID $(AzureBotName)";
     displayName: Set DIRECTLINE key, BOTID for running tests
-    inputs:
-      targetType: inline
-      script: >-
-        # Key = Direct Line channel "Secret keys" in Azure portal
-        $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
-        $key = $json.properties.properties.sites.key;
-        echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
-        echo "##vso[task.setvariable variable=BOTID;]$(AzureBotName)";
-        Write-Host "setx DIRECTLINE $key";
-        Write-Host "setx BOTID $(AzureBotName)";
 
   - task: NuGetToolInstaller@1
     displayName: Use NuGet 5.5.1
     enabled: False
     inputs:
       versionSpec: 5.5.1
+
   - task: PowerShell@2
     displayName: Create nuget.config for Samples.$(SampleBotName).FunctionalTests.csproj for MyGet feed
     enabled: False
@@ -235,11 +279,13 @@ jobs:
       solution: samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
       nugetConfigPath: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config
     condition: always()
+
   - task: DotNetCoreCLI@2
     displayName: dotnet build dotnet Samples.$(SampleBotName).FunctionalTests.csproj
     inputs:
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
     condition: always()
+
   - task: DotNetCoreCLI@2
     displayName: dotnet test
     inputs:
@@ -247,6 +293,7 @@ jobs:
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/**Tests.csproj
       arguments: --verbosity Normal
     condition: always()
+
   - task: CmdLine@2
     displayName: Dir workspace
     condition: always()
@@ -254,6 +301,7 @@ jobs:
     inputs:
       script: >
         dir .. /s
+
   - task: AzureCLI@2
     displayName: Delete bot, app service, app service plan, group
     condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -133,6 +133,7 @@ jobs:
       tags: |
         Using botbuilder version $(TargetVersion)
         From ${{ parameters.packageFeed }} feed 
+        Test latest = ${{ parameters.testLatestPackage }}
 
   - powershell: |
      # SetDependencyVersionInPackageJsonFile0.ps1

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -268,13 +268,11 @@ jobs:
     inputs:
       solution: samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
       nugetConfigPath: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config
-    condition: always()
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build dotnet Samples.$(SampleBotName).FunctionalTests.csproj
     inputs:
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
-    condition: always()
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test
@@ -282,7 +280,6 @@ jobs:
       command: test
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/**Tests.csproj
       arguments: --verbosity Normal
-    condition: always()
 
   - task: CmdLine@2
     displayName: Dir workspace

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -248,11 +248,10 @@ jobs:
           <add key="All" value="(Aggregate source)" />
         </activePackageSource>
       </configuration>
-
       "@;
 
       New-Item -Path $file -ItemType "file" -Value $content;
-        '-------------'; get-content "$file"; '==================='
+      '-------------'; get-content "$file"; '==================='
     displayName: Create nuget.config for Samples.$(SampleBotName).FunctionalTests.csproj for NuGet.org feed
 
   - task: NuGetCommand@2

--- a/build/yaml/sample-js-samplebot-win-test.yml
+++ b/build/yaml/sample-js-samplebot-win-test.yml
@@ -92,8 +92,8 @@ jobs:
 
   - powershell: |
       #$myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
-      $myGetFeedName = "botbuilder-v4-dotnet-daily";
-      $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
+      $myGetFeedName = "botbuilder-v4-js-daily";
+      $packageName = "botbuilder-ai";
 
       $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
 
@@ -106,7 +106,7 @@ jobs:
       #$package.versions | Select -Last 30;
 
       ### Hard-coded ##########
-      [string]$latestVersion = "4.15.0-preview.20210706-256858";  #$package.versions[-1];
+      [string]$latestVersion = "4.15.0-dev.ffde26a";  #$package.versions[-1];
       " "
       "Latest version:";
       $package.id;

--- a/build/yaml/sample-js-samplebot-win-test.yml
+++ b/build/yaml/sample-js-samplebot-win-test.yml
@@ -171,6 +171,16 @@ jobs:
       verbose: false
 
   - powershell: |
+      $file = "$(SampleRootPath)\package.json";
+   
+      $content = Get-Content -Raw $file | ConvertFrom-Json
+      $content.scripts.start = 'node ./lib/index.js'
+      $content | ConvertTo-Json | Set-Content $file
+   
+      '-------------'; get-content $file; '==================='
+    displayName: 'Fix start-up command script for Win deploy'
+
+  - powershell: |
       #Set-PSDebug -Trace 1;
 
       move-item -path $(SampleRootPath)/deploymentScripts/windows/* -destination $(SampleRootPath);

--- a/build/yaml/sample-js-samplebot-win-test.yml
+++ b/build/yaml/sample-js-samplebot-win-test.yml
@@ -19,13 +19,20 @@
 
 parameters:
   - name: testLatestPackage
-    displayName: Test latest daily package version
+    displayName: Test latest package version
     type: boolean
     default: true
   - name: versionToTest
     displayName: Version to test (Only if 'Test latest' is unchecked)
     type: string
     default: 'Example: 4.15.0-dev.7afa288'
+  - name: packageFeed
+    displayName: Package feed to use
+    type: string
+    default: npm
+    values:
+    - npm
+    - MyGet
 
 # Run this job every night at 2 AM (PST) on the main branch
 schedules:
@@ -59,39 +66,61 @@ jobs:
   steps:
   - checkout: self
     persistCredentials: True
-  
-  - task: PowerShell@2
-    displayName: Get latest botbuilder package version from npmjs feed - https://www.npmjs.com/package/botbuilder
-    inputs:
-      targetType: inline
-      script: |
-        $packageName = "botbuilder";
 
-        Write-Host "Get $packageName preview version tagged 'next' from npmjs.com";
-        " "
-        "Available versions:";
-        npm view $packageName versions | Select -Last 30;
+  - powershell: |
+      $packageName = "botbuilder";
 
-        $dist = npm dist-tag ls $packageName;
-        $next = $dist.Where({$_.StartsWith("next:")});
-        [string]$latestVersion = $next.Split(':')[-1].Trim();
+      Write-Host "Get $packageName preview version tagged 'next' from npmjs.com";
+      " "
+      "Available versions:";
+      npm view $packageName versions | Select -Last 30;
 
-        "Latest version:";
-        $packageName;
-        $latestVersion;
-        "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+      $dist = npm dist-tag ls $packageName;
+      $next = $dist.Where({$_.StartsWith("next:")});
+      [string]$latestVersion = $next.Split(':')[-1].Trim();
 
-        # This gets latest version from all versions.
-        #$versions = npm show botbuilder versions | ConvertFrom-Json
-        #$next = $versions[1][-1]
-    condition: ${{ parameters.testLatestPackage }}
+      "Latest version:";
+      $packageName;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+
+      # This gets latest version from all versions.
+      #$versions = npm show botbuilder versions | ConvertFrom-Json
+      #$next = $versions[1][-1]
+    displayName: From npm feed get latest botbuilder package version  - https://www.npmjs.com/package/botbuilder
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'npm')) }}
+
+  - powershell: |
+      $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      $myGetFeedName = "botbuilder-v4-dotnet-daily";
+      $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
+
+      $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
+
+      Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
+      #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+
+      #$package = $result.packages | Where-Object {$_.id -eq $packageName};
+      #" "
+      #"Available versions:";
+      #$package.versions | Select -Last 30;
+
+      ### Hard-coded ##########
+      [string]$latestVersion = "4.15.0-preview.20210706-256858";  #$package.versions[-1];
+      " "
+      "Latest version:";
+      $package.id;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
+    displayName: 'From MyGet feed get latest botbuilder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
 
   - powershell: |
      $targetVersion = "${{ parameters.versionToTest }}";
      $targetVersion;
      "##vso[task.setvariable variable=TargetVersion;]$targetVersion";
-    displayName: 'Set botbuilder package version per user input at queue time'
-    condition: ne(${{ parameters.testLatestPackage }}, 'true')
+    displayName: 'From user input get specific botbuilder version number'
+    condition: ${{ ne(parameters.testLatestPackage, true) }}
 
   - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
     displayName: 'Display env vars'
@@ -99,7 +128,9 @@ jobs:
   - task: tagBuildOrRelease@0
     displayName: Tag Build with botbuilder version
     inputs:
-      tags: Using botbuilder version $(TargetVersion)
+      tags: |
+        Using botbuilder version $(TargetVersion)
+        From ${{ parameters.packageFeed }} feed 
 
   - powershell: |
      # SetDependencyVersionInPackageJsonFile0.ps1
@@ -119,14 +150,19 @@ jobs:
      }
     displayName: Set botbuilder version reference in package.json
 
-  - task: PowerShell@2
-    displayName: Create .npmrc for npmjs feed - https://www.npmjs.com/search?q=botbuilder
-    inputs:
-      targetType: inline
-      script: |
+  - powershell: |
         Set-Location -Path "$(SampleRootPath)"
 
         New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://registry.npmjs.com/"
+    displayName: Create .npmrc for npm feed - https://www.npmjs.com/search?q=botbuilder
+    condition: ${{ eq(parameters.packageFeed, 'npm') }}
+
+  - powershell: |
+        Set-Location -Path "$(SampleRootPath)"
+
+        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
+    displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
+    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
 
   - task: Npm@1
     displayName: npm install $(SampleFolderName)
@@ -215,18 +251,15 @@ jobs:
 
         az bot directline create --name "$(AzureBotName)" --resource-group "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json" --debug
 
-  - task: PowerShell@2
-    displayName: Set DIRECTLINE, BOTID env vars for running tests
-    inputs:
-      targetType: inline
-      script: >-
-        # Key = Direct Line channel "Secret keys" in Azure portal
-        $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
-        $key = $json.properties.properties.sites.key;
-        echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
-        echo "##vso[task.setvariable variable=BOTID;]$(AzureBotName)";
-        Write-Host "setx DIRECTLINE $key";
-        Write-Host "setx BOTID $(AzureBotName)";
+  - powershell: |
+      # Key = Direct Line channel "Secret keys" in Azure portal
+      $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
+      $key = $json.properties.properties.sites.key;
+      echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
+      echo "##vso[task.setvariable variable=BOTID;]$(AzureBotName)";
+      Write-Host "setx DIRECTLINE $key";
+      Write-Host "setx BOTID $(AzureBotName)";
+    displayName: Set DIRECTLINE key, BOTID for running tests
 
   - task: NuGetToolInstaller@1
     displayName: Use NuGet 5.5.1
@@ -268,8 +301,9 @@ jobs:
       selectOrConfig: config
       nugetConfigPath: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config
     condition: always()
+
   - task: DotNetCoreCLI@2
-    displayName: dotnet build Samples.$(SampleBotName).FunctionalTests.csproj
+    displayName: dotnet build dotnet Samples.$(SampleBotName).FunctionalTests.csproj
     inputs:
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
     condition: always()
@@ -281,6 +315,7 @@ jobs:
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/**Tests.csproj
       arguments: --verbosity Normal
     condition: always()
+
   - task: CmdLine@2
     displayName: Dir workspace
     condition: always()
@@ -288,28 +323,30 @@ jobs:
     inputs:
       script: >
         dir .. /s
+
   - task: AzureCLI@2
     displayName: Delete bot, app service, app service plan, group
-    condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
-    continueOnError: True
     inputs:
-      connectedServiceNameARM: 0ab0d343-57b9-4390-9a6a-13d71ef36de6
+      azureSubscription: 'FUSE Temporary'
       scriptType: ps
       scriptLocation: inlineScript
-      inlineScript: >-
+      inlineScript: |
         Set-PSDebug -Trace 1;
 
-        Write-Host "1) Delete Bot:"
-        az bot delete --name $(AzureBotName) --resource-group $(BotGroup)
+        Write-Host "1) Delete Bot:";
+        az bot delete --name $(AzureBotName) --resource-group $(BotGroup);
 
-        Write-Host "2) Delete App Service:"
-        az webapp delete --name $(AzureBotName) --resource-group $(BotGroup)
+        Write-Host "2) Delete App Service:";
+        az webapp delete --name $(AzureBotName) --resource-group $(BotGroup);
 
-        Write-Host "3) Delete App Service plan:"
-        az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes
+        Write-Host "3) Delete App Service plan:";
+        az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes;
 
-        Write-Host "4) Delete Resource Group:"
-        az group delete --name $(BotGroup) --yes
+        Write-Host "4) Delete Resource Group:";
+        az group delete --name $(BotGroup) --yes;
 
         Set-PSDebug -Trace 0;
+    condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
+    continueOnError: True
+
 ...

--- a/build/yaml/sample-js-samplebot-win-test.yml
+++ b/build/yaml/sample-js-samplebot-win-test.yml
@@ -134,20 +134,20 @@ jobs:
 
   - powershell: |
      # SetDependencyVersionInPackageJsonFile0.ps1
-     $path = "$(SampleRootPath)/package.json";
-     $package = 'botbuilder';
-     $newVersion = "$(TargetVersion)";
-   
-     $find = "$package`": `"\S*`"";
-     $replace = "$package`": `"$newVersion`"";
-   
-     Get-ChildItem -Path "$path" | % {
-         $_.FullName; 
-         $content = Get-Content -Raw $_.FullName;
-   
-         $content -Replace "$find", "$replace" | Set-Content $_.FullName;
-         '-------------'; get-content $_.FullName; '==================='
-     }
+      $path = "$(SampleRootPath)/package.json";
+      $packages = @('botbuilder','botbuilder-ai','botbuilder-dialogs','botbuilder-testing');
+      $newVersion = "$(TargetVersion)";
+
+      $content = Get-ChildItem -Path "$path" | Get-Content -Raw
+
+      foreach ($package in $packages) {
+          $find = "$package`": `"\S*`"";
+          $replace = "$package`": `"$newVersion`"";
+          $content = $content -Replace "$find", "$replace";
+      }
+
+      Set-Content -Path $path -Value $content;
+      '-------------'; get-content $path; '===================';
     displayName: Set botbuilder version reference in package.json
 
   - powershell: |

--- a/build/yaml/sample-js-samplebot-win-test.yml
+++ b/build/yaml/sample-js-samplebot-win-test.yml
@@ -305,13 +305,11 @@ jobs:
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/**Tests.csproj
       arguments: --verbosity Normal
 
-  - task: CmdLine@2
-    displayName: Dir workspace
+  - script: |
+      dir .. /s
+    displayName: 'Dir workspace'
+    continueOnError: true
     condition: always()
-    continueOnError: True
-    inputs:
-      script: >
-        dir .. /s
 
   - task: AzureCLI@2
     displayName: Delete bot, app service, app service plan, group

--- a/build/yaml/sample-js-samplebot-win-test.yml
+++ b/build/yaml/sample-js-samplebot-win-test.yml
@@ -91,22 +91,22 @@ jobs:
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'npm')) }}
 
   - powershell: |
-      #$myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
       $myGetFeedName = "botbuilder-v4-js-daily";
       $packageName = "botbuilder-ai";
 
       $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
 
       Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
-      #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+      $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
 
-      #$package = $result.packages | Where-Object {$_.id -eq $packageName};
-      #" "
-      #"Available versions:";
-      #$package.versions | Select -Last 30;
+      $package = $result.packages | Where-Object {$_.id -eq $packageName};
+      " "
+      "Available versions:";
+      $package.versions | Select -Last 30;
 
-      ### Hard-coded ##########
-      [string]$latestVersion = "4.15.0-dev.ffde26a";  #$package.versions[-1];
+      ### Hard-coded ########## [string]$latestVersion = "4.15.0-dev.ffde26a";
+      [string]$latestVersion = $package.versions[-1];
       " "
       "Latest version:";
       $package.id;

--- a/build/yaml/sample-js-samplebot-win-test.yml
+++ b/build/yaml/sample-js-samplebot-win-test.yml
@@ -131,6 +131,7 @@ jobs:
       tags: |
         Using botbuilder version $(TargetVersion)
         From ${{ parameters.packageFeed }} feed 
+        Test latest = ${{ parameters.testLatestPackage }}
 
   - powershell: |
      # SetDependencyVersionInPackageJsonFile0.ps1

--- a/build/yaml/sample-js-samplebot-win-test.yml
+++ b/build/yaml/sample-js-samplebot-win-test.yml
@@ -181,7 +181,7 @@ jobs:
     displayName: 'Fix start-up command script for Win deploy'
 
   - powershell: |
-      #Set-PSDebug -Trace 1;
+      Set-PSDebug -Trace 1;
 
       move-item -path $(SampleRootPath)/deploymentScripts/windows/* -destination $(SampleRootPath);
 
@@ -192,7 +192,7 @@ jobs:
 
       Compress-Archive -Path $files -DestinationPath $ZipFileDestination;
 
-      #Set-PSDebug -Trace 0;
+      Set-PSDebug -Trace 0;
     displayName: Set up deploy scripts, zip the bot
 
   - task: CopyFiles@2
@@ -201,6 +201,7 @@ jobs:
       SourceFolder: $(SampleRootPath)
       Contents: testbot.zip
       TargetFolder: $(Build.ArtifactStagingDirectory)
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: testbot-zip'
     inputs:

--- a/build/yaml/sample-js-samplebot-win-test.yml
+++ b/build/yaml/sample-js-samplebot-win-test.yml
@@ -170,23 +170,20 @@ jobs:
       workingDir: $(SampleRootPath)
       verbose: false
 
-  - task: PowerShell@2
+  - powershell: |
+      #Set-PSDebug -Trace 1;
+
+      move-item -path $(SampleRootPath)/deploymentScripts/windows/* -destination $(SampleRootPath);
+
+      $DirToCompress = "$(SampleRootPath)";
+      $DirtoExclude =@("node_modules", "deploymentTemplates", "deploymentScripts");
+      $files = Get-ChildItem -Path $DirToCompress -Exclude $DirtoExclude;
+      $ZipFileDestination ="$(SampleRootPath)/testbot.zip";
+
+      Compress-Archive -Path $files -DestinationPath $ZipFileDestination;
+
+      #Set-PSDebug -Trace 0;
     displayName: Set up deploy scripts, zip the bot
-    inputs:
-      targetType: inline
-      script: >-
-        #Set-PSDebug -Trace 1;
-
-        move-item -path $(SampleRootPath)/deploymentScripts/windows/* -destination $(SampleRootPath);
-
-        $DirToCompress = "$(SampleRootPath)";
-        $DirtoExclude =@("node_modules", "deploymentTemplates", "deploymentScripts");
-        $files = Get-ChildItem -Path $DirToCompress -Exclude $DirtoExclude;
-        $ZipFileDestination ="$(SampleRootPath)/testbot.zip";
-
-        Compress-Archive -Path $files -DestinationPath $ZipFileDestination;
-
-        #Set-PSDebug -Trace 0;
 
   - task: CopyFiles@2
     displayName: 'Copy testbot.zip to: $(Build.ArtifactStagingDirectory)'
@@ -266,31 +263,28 @@ jobs:
     inputs:
       versionSpec: 5.5.1
 
-  - task: PowerShell@2
+  - powershell: |
+      $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
+
+      $content = @"
+
+      <?xml version="1.0" encoding="utf-8"?>
+
+      <configuration>
+        <packageSources>
+          <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
+
+      "@;
+
+
+      New-Item -Path $file -ItemType "file" -Value $content;
+        '-------------'; get-content "$file"; '==================='
     displayName: Create nuget.config for Samples.$(SampleBotName).FunctionalTests.csproj for NuGet.org feed
-    inputs:
-      targetType: inline
-      script: >-
-        $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
-
-        $content = @"
-
-        <?xml version="1.0" encoding="utf-8"?>
-
-        <configuration>
-          <packageSources>
-            <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-          </packageSources>
-          <activePackageSource>
-            <add key="All" value="(Aggregate source)" />
-          </activePackageSource>
-        </configuration>
-
-        "@;
-
-
-        New-Item -Path $file -ItemType "file" -Value $content;
-         '-------------'; get-content "$file"; '==================='
 
   - task: NuGetCommand@2
     displayName: NuGet restore dotnet Samples.$(SampleBotName).FunctionalTests.csproj

--- a/build/yaml/sample-js-samplebot-win-test.yml
+++ b/build/yaml/sample-js-samplebot-win-test.yml
@@ -267,9 +267,7 @@ jobs:
       $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
 
       $content = @"
-
       <?xml version="1.0" encoding="utf-8"?>
-
       <configuration>
         <packageSources>
           <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
@@ -280,7 +278,6 @@ jobs:
       </configuration>
 
       "@;
-
 
       New-Item -Path $file -ItemType "file" -Value $content;
         '-------------'; get-content "$file"; '==================='

--- a/build/yaml/sample-js-samplebot-win-test.yml
+++ b/build/yaml/sample-js-samplebot-win-test.yml
@@ -25,7 +25,7 @@ parameters:
   - name: versionToTest
     displayName: Version to test (Only if 'Test latest' is unchecked)
     type: string
-    default: 'Example: 4.15.0-dev.7afa288'
+    default: 'Example: 4.15.0-dev.20210726.c56bbf1'
   - name: packageFeed
     displayName: Package feed to use
     type: string

--- a/build/yaml/sample-js-samplebot-win-test.yml
+++ b/build/yaml/sample-js-samplebot-win-test.yml
@@ -47,9 +47,9 @@ resources:
     type: git
     ref: main
 
-variables:
-- group: SamplesE2ETestsVariableGroup
-- group: MyGetPersonalAccessTokenVariableGroup
+#variables:
+#- group: SamplesE2ETestsVariableGroup
+#- group: MyGetPersonalAccessTokenVariableGroup
 
 jobs:
 - job: Job_1

--- a/build/yaml/sample-js-samplebot-win-test.yml
+++ b/build/yaml/sample-js-samplebot-win-test.yml
@@ -91,7 +91,7 @@ jobs:
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'npm')) }}
 
   - powershell: |
-      $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      #$myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
       $myGetFeedName = "botbuilder-v4-dotnet-daily";
       $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
 

--- a/build/yaml/sample-js-samplebot-win-test.yml
+++ b/build/yaml/sample-js-samplebot-win-test.yml
@@ -265,7 +265,6 @@ jobs:
     displayName: Use NuGet 5.5.1
     inputs:
       versionSpec: 5.5.1
-    condition: always()
 
   - task: PowerShell@2
     displayName: Create nuget.config for Samples.$(SampleBotName).FunctionalTests.csproj for NuGet.org feed
@@ -292,7 +291,6 @@ jobs:
 
         New-Item -Path $file -ItemType "file" -Value $content;
          '-------------'; get-content "$file"; '==================='
-    condition: always()
 
   - task: NuGetCommand@2
     displayName: NuGet restore dotnet Samples.$(SampleBotName).FunctionalTests.csproj
@@ -300,13 +298,11 @@ jobs:
       solution: samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
       selectOrConfig: config
       nugetConfigPath: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config
-    condition: always()
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build dotnet Samples.$(SampleBotName).FunctionalTests.csproj
     inputs:
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
-    condition: always()
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test
@@ -314,7 +310,6 @@ jobs:
       command: test
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/**Tests.csproj
       arguments: --verbosity Normal
-    condition: always()
 
   - task: CmdLine@2
     displayName: Dir workspace

--- a/build/yaml/sample-py-corebot-linux-test.yml
+++ b/build/yaml/sample-py-corebot-linux-test.yml
@@ -1,0 +1,312 @@
+# This is used in the pipelines Sample-Py-CoreBot-Linux-Test-yaml and Sample-Py-EchoBot-Linux-Test-yaml.
+
+# 'Allow scripts to access the OAuth token' was selected in pipeline.  Add the following YAML to any steps requiring access:
+#       env:
+#           MY_ACCESS_TOKEN: $(System.AccessToken)
+# Variable 'AppId' is defined in Azure
+# Variable 'AppSecret' is defined in Azure
+# Variable 'AzureBotName' is defined in Azure
+# Variable 'AzureSubscription' is defined in Azure
+# Variable 'BotGroup' is defined in Azure
+# Variable 'DeleteResourceGroup' is defined in Azure
+# Variable 'MyGetPersonalAccessToken' is defined in Azure
+# Variable 'runCodesignValidationInjection' is defined in Azure
+# Variable 'SampleBotName' is defined in Azure
+# Variable 'SampleFolderName' is defined in Azure
+# Variable 'SampleRootPath' is defined in Azure
+# Variable Group 'AzureDeploymentCredsVariableGroup' is defined in Azure
+# Variable Group 'SamplesE2ETestsVariableGroup' is defined in Azure
+# Variable Group 'MyGetPersonalAccessTokenVariableGroup' is defined in Azure
+
+parameters:
+  - name: testLatestPackage
+    displayName: Test latest package version
+    type: boolean
+    default: true
+  - name: versionToTest
+    displayName: Version to test (Only if 'Test latest' is unchecked)
+    type: string
+    default: 'Example: 4.15.0-dev.7afa288'
+  - name: packageFeed
+    displayName: Package feed to use
+    type: string
+    default: npm
+    values:
+    - npm
+    - MyGet
+
+# Run this job every night at 2 AM (PST) on the main branch
+schedules:
+- cron: 0 9 * * *
+  branches:
+    include:
+    - main
+  always: true
+
+# Do not run PR validation
+pr: none
+
+# Do not run CI validation
+trigger: none
+
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: main
+
+#variables:
+#- group: AzureDeploymentCredsVariableGroup
+#- group: SamplesE2ETestsVariableGroup
+#- group: MyGetPersonalAccessTokenVariableGroup
+
+jobs:
+- job: Job_1
+  displayName: Agent job 1
+  pool:
+    vmImage: windows-2019
+  steps:
+  - checkout: self
+    persistCredentials: True
+
+  - task: AzureCLI@2
+    displayName: 'Delete bot, app service, app service plan, group'
+    inputs:
+      azureSubscription: 'FUSE Temporary (174c5021-8109-4087-a3e2-a1de20420569)'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+       Set-PSDebug -Trace 1;
+     
+       Write-Host "1) Delete Bot:"
+       az bot delete --name $(BotName) --resource-group $(BotGroup)
+     
+       Write-Host "2) Delete App Service:"
+       az webapp delete --name $(BotName) --resource-group $(BotGroup)
+     
+       Write-Host "3) Delete App Service plan:"
+       az appservice plan delete --name $(BotName) --resource-group $(BotGroup) --yes
+     
+       Write-Host "4) Delete Resource Group:"
+       az group delete --name $(BotGroup) --yes
+     
+       Set-PSDebug -Trace 0;
+    enabled: false
+    continueOnError: true
+    condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
+
+  - powershell: |
+     $packageName = "botbuilder-integration-aiohttp";
+     $url = "https://feeds.dev.azure.com/ConversationalAI/BotFramework/_apis/packaging/Feeds/SDK/Packages/26dde74d-6079-401c-a9e0-c6d839e02c18/versions?api-version=5.1-preview.1"
+   
+     Write-Host "Get latest $packageName version number from ConversationalAI BotFramework SDK feed";
+     $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+     [string]$latestVersion = $result.value[0].protocolMetadata.data.version;
+   
+     $packageName;
+     $latestVersion;
+     "##vso[task.setvariable variable=LatestVersion;]$latestVersion";
+    displayName: 'Get latest botbuilder package version from Azure feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
+
+  - task: tagBuildOrRelease@0
+    displayName: Tag Build with botbuilder version
+    inputs:
+      tags: Using botbuilder version $(LatestVersion)
+
+  - powershell: |
+     # This adapted from PyPySkillBotFunctionalTest, file BotFramework-FunctionalTests\build\yaml\pythonDeploySteps.yml, task Set BotBuilder Package Version & Registry Url.
+   
+     $file = "$(SampleRootPath)/requirements.txt";
+   
+     $indexUrl = "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/pypi/simple/"
+     $extraIndexUrl = "https://pypi.org/simple/"
+   
+     $comparisonOperator = ""
+     $newVersion = ""
+     $pipInstallOption =  "--pre" # Include prerelease and development versions.
+   
+     # Add the index URL specs at the beginning of the requirements.txt file
+     $content = @(Get-Content $file)
+     Set-Content -Path $file -Value ("$pipInstallOption --index-url $indexUrl --extra-index-url $extraIndexUrl".Trim())
+     Add-Content -Path $file -Value $content
+   
+     function UpdatePackageVersion($package) {
+       # Set Package version to empty value
+       $content = @(Get-Content $file)
+       $matchinfo = Select-String -Path $file -Pattern $package
+   
+       $script = "$package $comparisonOperator $newVersion"
+   
+       # Update or add dependency
+       if($matchinfo.LineNumber -gt 0) {
+         $content[$matchinfo.LineNumber - 1] = $script
+         Set-Content -Path $file -Value $content
+     
+       } else {
+         Add-Content -Path $file -Value $script
+       }
+     }
+   
+     UpdatePackageVersion "botbuilder-integration-aiohttp"
+     UpdatePackageVersion "botbuilder-dialogs" 
+     UpdatePackageVersion "botbuilder-ai" 
+   
+     '------ $file -------'; get-content $file; '===================';
+    displayName: 'Set index urls and dependencies in requirements.txt to get latest botframework packages'
+
+  - task: AzureCLI@2
+    displayName: 'Preexisting RG: create Azure resources. Runs in even builds.'
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+       Write-Host "`n***** Creating Azure resources using the preexisting-rg template *****";
+       Write-Host "This task runs for even-numbered builds. Build ID = $(Build.BuildId)";
+       Write-Host "************************************************************************";
+       #Set-PSDebug -Trace 1;
+     
+       az group create --location westus --name $(BotGroup);
+     
+       # set up bot channels registration, app service, app service plan
+       az deployment group create --resource-group "$(BotGroup)" --template-file "$(SampleRootPath)\deploymentTemplates\template-with-preexisting-rg.json" --parameters botId="$(BotName)" appId="$(AppId)" appSecret="$(AppSecret)" newAppServicePlanName="$(BotName)" appServicePlanLocation="westus" --name "$(BotName)";
+     
+       #Set-PSDebug -Trace 0;
+    condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 0), endsWith(variables['Build.BuildId'], 2), endsWith(variables['Build.BuildId'], 4), endsWith(variables['Build.BuildId'], 6), endsWith(variables['Build.BuildId'], 8)))
+
+  - task: AzureCLI@2
+    displayName: 'New RG: create Azure resources. Runs in odd builds.'
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+       Write-Host "`n***** Creating Azure resources using the new-rg template *****";
+       Write-Host "This task runs for odd-numbered builds. Build ID = $(Build.BuildId)";
+       Write-Host "****************************************************************";
+       #Set-PSDebug -Trace 1;
+     
+       # set up resource group, bot channels registration, app service, app service plan
+       az deployment sub create --name "$(BotGroup)" --template-file "$(SampleRootPath)\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(BotName)" botSku=S1 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus";
+     
+       #Set-PSDebug -Trace 0;
+    condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 1), endsWith(variables['Build.BuildId'], 3), endsWith(variables['Build.BuildId'], 5), endsWith(variables['Build.BuildId'], 7), endsWith(variables['Build.BuildId'], 9)))
+
+  - task: AzureCLI@2
+    displayName: 'Create directline channel'
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+       az bot directline create --name "$(AzureBotName)" --resource-group "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json" --debug
+     
+       #az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(BotName)" --src "$(SampleRootPath)\testbot.zip" --debug
+
+  - script: |
+     echo git config
+     git config --global user.name "SamplePyCoreBotLinuxTestPipeline"
+     git config --global user.email BotBuilderPy@Pipeline.com
+     git init
+   
+     echo git add .
+     git add .
+     git commit -m "Add bot source code"
+     git remote add azure https://$(AzureDeploymentUser):$(AzureDeploymentPassword)@$(BotName).scm.azurewebsites.net:443/$(BotName).git
+   
+     echo git push azure master
+     git push azure master
+    workingDirectory: '$(SampleRootPath)'
+    displayName: 'git push the bot to Azure'
+
+  - powershell: |
+      # Key = Direct Line channel "Secret keys" in Azure portal
+      $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
+      $key = $json.properties.properties.sites.key;
+      echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
+      echo "##vso[task.setvariable variable=BOTID;]$(AzureBotName)";
+      Write-Host "setx DIRECTLINE $key";
+      Write-Host "setx BOTID $(AzureBotName)";
+    displayName: Set DIRECTLINE key, BOTID for running tests
+
+  - task: NuGetToolInstaller@1
+    displayName: Use NuGet 5.5.1
+    inputs:
+      versionSpec: 5.5.1
+      checkLatest: true
+
+  - powershell: |
+     $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.CoreBot.FunctionalTests/nuget.config";
+   
+     $content = @"
+     <?xml version="1.0" encoding="utf-8"?>
+     <configuration>
+       <packageSources>
+         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+       </packageSources>
+       <activePackageSource>
+         <add key="All" value="(Aggregate source)" />
+       </activePackageSource>
+     </configuration>
+     "@;
+   
+     New-Item -Path $file -ItemType "file" -Value $content;
+   
+      '-------------'; get-content "$file"; '==================='
+    displayName: 'Create nuget.config for Samples.CoreBot.FunctionalTests.csproj for NuGet.org feed'
+
+  - task: NuGetCommand@2
+    displayName: NuGet restore Samples.$(SampleBotName).FunctionalTests.csproj
+    inputs:
+      solution: samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
+      selectOrConfig: config
+      nugetConfigPath: $(SampleRootPath)\nuget.config
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build Samples.$(SampleBotName).FunctionalTests.csproj
+    inputs:
+      projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
+
+  - powershell: |
+      Start-Sleep -Seconds 700
+    displayName: 'Sleep for 700 seconds'
+    enabled: true
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test
+    inputs:
+      command: test
+      projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/**Tests.csproj
+      arguments: --verbosity Normal
+
+  - script: |
+      dir .. /s
+    displayName: 'Dir workspace'
+    continueOnError: true
+    condition: always()
+
+  - task: AzureCLI@2
+    displayName: Delete bot, app service, app service plan, group
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        Set-PSDebug -Trace 1;
+
+        Write-Host "1) Delete Bot:";
+        az bot delete --name $(AzureBotName) --resource-group $(BotGroup);
+
+        Write-Host "2) Delete App Service:";
+        az webapp delete --name $(AzureBotName) --resource-group $(BotGroup);
+
+        Write-Host "3) Delete App Service plan:";
+        az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes;
+
+        Write-Host "4) Delete Resource Group:";
+        az group delete --name $(BotGroup) --yes;
+
+        Set-PSDebug -Trace 0;
+    condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
+    continueOnError: True
+...

--- a/build/yaml/sample-py-samplebot-linux-test.yml
+++ b/build/yaml/sample-py-samplebot-linux-test.yml
@@ -34,7 +34,7 @@ parameters:
     values:
     - Azure
     - MyGet
-    - PythonPI
+    - PyPI
 
 # Run this job every night at 2 AM (PST) on the main branch
 schedules:
@@ -97,16 +97,16 @@ jobs:
     condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
 
   - powershell: |
-     $packageName = "botbuilder-integration-aiohttp";
-     $url = "https://feeds.dev.azure.com/ConversationalAI/BotFramework/_apis/packaging/Feeds/SDK/Packages/26dde74d-6079-401c-a9e0-c6d839e02c18/versions?api-version=5.1-preview.1"
+      $packageName = "botbuilder-integration-aiohttp";
+      $url = "https://feeds.dev.azure.com/ConversationalAI/BotFramework/_apis/packaging/Feeds/SDK/Packages/26dde74d-6079-401c-a9e0-c6d839e02c18/versions?api-version=5.1-preview.1"
    
-     Write-Host "Get latest $packageName version number from ConversationalAI BotFramework SDK feed";
-     $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
-     [string]$latestVersion = $result.value[0].protocolMetadata.data.version;
+      Write-Host "Get latest $packageName version number from ConversationalAI BotFramework SDK feed";
+      $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+      [string]$latestVersion = $result.value[0].protocolMetadata.data.version;
    
-     $packageName;
-     $latestVersion;
-     "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+      $packageName;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
     displayName: 'Get latest botbuilder package version from Azure feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
 
@@ -134,6 +134,22 @@ jobs:
       "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
     displayName: 'From MyGet feed get latest botbuilder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-js-daily'
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
+
+  - powershell: |
+      $packageName = "botbuilder-integration-aiohttp";
+   
+      py -m pip install yolk3k;
+      $result = py -m yolk -V $packageName;
+   
+      $array = $result -split " ";
+      $latestVersion = $array[1];
+      " ";
+      $packageName;
+      $latestVersion;
+   
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+    displayName: 'Get latest botbuilder package version from PyPI feed - https://pypi.org/search/?q=botbuilder&o='
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'PythonPI')) }}
 
   - powershell: |
      $targetVersion = "${{ parameters.versionToTest }}";

--- a/build/yaml/sample-py-samplebot-linux-test.yml
+++ b/build/yaml/sample-py-samplebot-linux-test.yml
@@ -205,7 +205,7 @@ jobs:
 
   - script: |
      echo git config
-     git config --global user.name "SamplePyCoreBotLinuxTestPipeline"
+     git config --global user.name "SamplePy$(SampleBotName)LinuxTestPipeline"
      git config --global user.email BotBuilderPy@Pipeline.com
      git init
    
@@ -236,7 +236,7 @@ jobs:
       checkLatest: true
 
   - powershell: |
-     $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.CoreBot.FunctionalTests/nuget.config";
+     $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
    
      $content = @"
      <?xml version="1.0" encoding="utf-8"?>
@@ -253,7 +253,7 @@ jobs:
      New-Item -Path $file -ItemType "file" -Value $content;
    
       '-------------'; get-content "$file"; '==================='
-    displayName: 'Create nuget.config for Samples.CoreBot.FunctionalTests.csproj for NuGet.org feed'
+    displayName: 'Create nuget.config for Samples.$(SampleBotName).FunctionalTests.csproj for NuGet.org feed'
 
   - task: NuGetCommand@2
     displayName: NuGet restore Samples.$(SampleBotName).FunctionalTests.csproj

--- a/build/yaml/sample-py-samplebot-linux-test.yml
+++ b/build/yaml/sample-py-samplebot-linux-test.yml
@@ -79,13 +79,13 @@ jobs:
        Set-PSDebug -Trace 1;
      
        Write-Host "1) Delete Bot:"
-       az bot delete --name $(BotName) --resource-group $(BotGroup)
+       az bot delete --name $(AzureBotName) --resource-group $(BotGroup)
      
        Write-Host "2) Delete App Service:"
-       az webapp delete --name $(BotName) --resource-group $(BotGroup)
+       az webapp delete --name $(AzureBotName) --resource-group $(BotGroup)
      
        Write-Host "3) Delete App Service plan:"
-       az appservice plan delete --name $(BotName) --resource-group $(BotGroup) --yes
+       az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes
      
        Write-Host "4) Delete Resource Group:"
        az group delete --name $(BotGroup) --yes
@@ -169,7 +169,7 @@ jobs:
        az group create --location westus --name $(BotGroup);
      
        # set up bot channels registration, app service, app service plan
-       az deployment group create --resource-group "$(BotGroup)" --template-file "$(SampleRootPath)\deploymentTemplates\template-with-preexisting-rg.json" --parameters botId="$(BotName)" appId="$(AppId)" appSecret="$(AppSecret)" newAppServicePlanName="$(BotName)" appServicePlanLocation="westus" --name "$(BotName)";
+       az deployment group create --resource-group "$(BotGroup)" --template-file "$(SampleRootPath)\deploymentTemplates\template-with-preexisting-rg.json" --parameters botId="$(AzureBotName)" appId="$(AppId)" appSecret="$(AppSecret)" newAppServicePlanName="$(AzureBotName)" appServicePlanLocation="westus" --name "$(AzureBotName)";
      
        #Set-PSDebug -Trace 0;
     condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 0), endsWith(variables['Build.BuildId'], 2), endsWith(variables['Build.BuildId'], 4), endsWith(variables['Build.BuildId'], 6), endsWith(variables['Build.BuildId'], 8)))
@@ -187,7 +187,7 @@ jobs:
        #Set-PSDebug -Trace 1;
      
        # set up resource group, bot channels registration, app service, app service plan
-       az deployment sub create --name "$(BotGroup)" --template-file "$(SampleRootPath)\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(BotName)" botSku=S1 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus";
+       az deployment sub create --name "$(BotGroup)" --template-file "$(SampleRootPath)\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(AzureBotName)" botSku=S1 newAppServicePlanName="$(AzureBotName)" newWebAppName="$(AzureBotName)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus";
      
        #Set-PSDebug -Trace 0;
     condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 1), endsWith(variables['Build.BuildId'], 3), endsWith(variables['Build.BuildId'], 5), endsWith(variables['Build.BuildId'], 7), endsWith(variables['Build.BuildId'], 9)))
@@ -201,7 +201,7 @@ jobs:
       inlineScript: |
        az bot directline create --name "$(AzureBotName)" --resource-group "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json" --debug
      
-       #az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(BotName)" --src "$(SampleRootPath)\testbot.zip" --debug
+       #az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(AzureBotName)" --src "$(SampleRootPath)\testbot.zip" --debug
 
   - script: |
      echo git config
@@ -212,7 +212,7 @@ jobs:
      echo git add .
      git add .
      git commit -m "Add bot source code"
-     git remote add azure https://$(AzureDeploymentUser):$(AzureDeploymentPassword)@$(BotName).scm.azurewebsites.net:443/$(BotName).git
+     git remote add azure https://$(AzureDeploymentUser):$(AzureDeploymentPassword)@$(AzureBotName).scm.azurewebsites.net:443/$(AzureBotName).git
    
      echo git push azure master
      git push azure master

--- a/build/yaml/sample-py-samplebot-linux-test.yml
+++ b/build/yaml/sample-py-samplebot-linux-test.yml
@@ -208,7 +208,92 @@ jobs:
      UpdatePackageVersion "botbuilder-ai" 
    
      '------ $file -------'; get-content $file; '===================';
-    displayName: 'Set index urls and dependencies in requirements.txt to get latest botframework packages'
+    displayName: 'For Azure feed, set requirements.txt to get targeted botframework packages'
+    condition: ${{ eq(parameters.packageFeed, 'Azure') }}
+
+  - powershell: |
+     # This adapted from PyPySkillBotFunctionalTest, file BotFramework-FunctionalTests\build\yaml\pythonDeploySteps.yml, task Set BotBuilder Package Version & Registry Url.
+   
+     $file = "$(SampleRootPath)/requirements.txt";
+   
+     $indexUrl = "https://botbuilder.myget.org/F/botbuilderdaily_python/python/"
+     $extraIndexUrl = "https://pypi.org/simple/"
+   
+     $comparisonOperator = ""
+     $newVersion = ""
+     $pipInstallOption =  "--pre" # Include prerelease and development versions.
+   
+     # Add the index URL specs at the beginning of the requirements.txt file
+     $content = @(Get-Content $file)
+     Set-Content -Path $file -Value ("$pipInstallOption --index-url $indexUrl --extra-index-url $extraIndexUrl".Trim())
+     Add-Content -Path $file -Value $content
+   
+     function UpdatePackageVersion($package) {
+       # Set Package version to empty value
+       $content = @(Get-Content $file)
+       $matchinfo = Select-String -Path $file -Pattern $package
+   
+       $script = "$package $comparisonOperator $newVersion"
+   
+       # Update or add dependency
+       if($matchinfo.LineNumber -gt 0) {
+         $content[$matchinfo.LineNumber - 1] = $script
+         Set-Content -Path $file -Value $content
+     
+       } else {
+         Add-Content -Path $file -Value $script
+       }
+     }
+   
+     UpdatePackageVersion "botbuilder-integration-aiohttp"
+     UpdatePackageVersion "botbuilder-dialogs" 
+     UpdatePackageVersion "botbuilder-ai" 
+   
+     '------ $file -------'; get-content $file; '===================';
+    displayName: 'For MyGet feed, set requirements.txt to get targeted botframework packages'
+    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
+
+  - powershell: |
+     # This adapted from PyPySkillBotFunctionalTest, file BotFramework-FunctionalTests\build\yaml\pythonDeploySteps.yml, task Set BotBuilder Package Version & Registry Url.
+   
+     $file = "$(SampleRootPath)/requirements.txt";
+   
+     $indexUrl = "https://pypi.org/simple/"
+     $extraIndexUrl = "https://pypi.org/simple/"
+   
+     $comparisonOperator = ""
+     $newVersion = ""
+     $pipInstallOption =  "--pre" # Include prerelease and development versions.
+   
+     # Add the index URL specs at the beginning of the requirements.txt file
+     $content = @(Get-Content $file)
+     Set-Content -Path $file -Value ("$pipInstallOption --index-url $indexUrl --extra-index-url $extraIndexUrl".Trim())
+     Add-Content -Path $file -Value $content
+   
+     function UpdatePackageVersion($package) {
+       # Set Package version to empty value
+       $content = @(Get-Content $file)
+       $matchinfo = Select-String -Path $file -Pattern $package
+   
+       $script = "$package $comparisonOperator $newVersion"
+   
+       # Update or add dependency
+       if($matchinfo.LineNumber -gt 0) {
+         $content[$matchinfo.LineNumber - 1] = $script
+         Set-Content -Path $file -Value $content
+     
+       } else {
+         Add-Content -Path $file -Value $script
+       }
+     }
+   
+     UpdatePackageVersion "botbuilder-integration-aiohttp"
+     UpdatePackageVersion "botbuilder-dialogs" 
+     UpdatePackageVersion "botbuilder-ai" 
+   
+     '------ $file -------'; get-content $file; '===================';
+    displayName: 'For PyPI feed, set requirements.txt to get targeted botframework packages'
+    condition: ${{ eq(parameters.packageFeed, 'PyPI') }}
 
   - task: AzureCLI@2
     displayName: 'Preexisting RG: create Azure resources. Runs in even builds.'

--- a/build/yaml/sample-py-samplebot-linux-test.yml
+++ b/build/yaml/sample-py-samplebot-linux-test.yml
@@ -112,7 +112,7 @@ jobs:
 
   - powershell: |
       $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
-      $myGetFeedName = "botbuilder-v4-js-daily";
+      $myGetFeedName = "botbuilderdaily_python";
       $packageName = "botbuilder-ai";
 
       $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";

--- a/build/yaml/sample-py-samplebot-linux-test.yml
+++ b/build/yaml/sample-py-samplebot-linux-test.yml
@@ -106,7 +106,7 @@ jobs:
    
      $packageName;
      $latestVersion;
-     "##vso[task.setvariable variable=LatestVersion;]$latestVersion";
+     "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
     displayName: 'Get latest botbuilder package version from Azure feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
 

--- a/build/yaml/sample-py-samplebot-linux-test.yml
+++ b/build/yaml/sample-py-samplebot-linux-test.yml
@@ -30,10 +30,11 @@ parameters:
   - name: packageFeed
     displayName: Package feed to use
     type: string
-    default: npm
+    default: Azure
     values:
-    - npm
+    - Azure
     - MyGet
+    - PythonPI
 
 # Run this job every night at 2 AM (PST) on the main branch
 schedules:
@@ -107,6 +108,7 @@ jobs:
      $latestVersion;
      "##vso[task.setvariable variable=LatestVersion;]$latestVersion";
     displayName: 'Get latest botbuilder package version from Azure feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
 
   - task: tagBuildOrRelease@0
     displayName: Tag Build with botbuilder version

--- a/build/yaml/sample-py-samplebot-linux-test.yml
+++ b/build/yaml/sample-py-samplebot-linux-test.yml
@@ -122,6 +122,10 @@ jobs:
       Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
       $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
 
+      "======================";
+      $result;
+      "======================";
+
       $package = $result.packages | Where-Object {$_.id -eq $packageName};
       " "
       "Available versions:";

--- a/build/yaml/sample-py-samplebot-linux-test.yml
+++ b/build/yaml/sample-py-samplebot-linux-test.yml
@@ -151,6 +151,7 @@ jobs:
       tags: |
         Using botbuilder version $(TargetVersion)
         From ${{ parameters.packageFeed }} feed 
+        Test latest = ${{ parameters.testLatestPackage }}
 
   - powershell: |
      # This adapted from PyPySkillBotFunctionalTest, file BotFramework-FunctionalTests\build\yaml\pythonDeploySteps.yml, task Set BotBuilder Package Version & Registry Url.

--- a/build/yaml/sample-py-samplebot-linux-test.yml
+++ b/build/yaml/sample-py-samplebot-linux-test.yml
@@ -111,6 +111,8 @@ jobs:
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
 
   - powershell: |
+      Set-PSDebug -Trace 1;
+
       $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
       $myGetFeedName = "botbuilderdaily_python";
       $packageName = "botbuilder-ai";
@@ -132,6 +134,8 @@ jobs:
       $package.id;
       $latestVersion;
       "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
+
+      Set-PSDebug -Trace 0;
     displayName: 'From MyGet feed get latest botbuilder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-js-daily'
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
 

--- a/build/yaml/sample-py-samplebot-linux-test.yml
+++ b/build/yaml/sample-py-samplebot-linux-test.yml
@@ -107,7 +107,7 @@ jobs:
       $packageName;
       $latestVersion;
       "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
-    displayName: 'Get latest botbuilder package version from Azure feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
+    displayName: 'From Azure feed get latest botbuilder package version - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
 
   - powershell: |
@@ -148,8 +148,8 @@ jobs:
       $latestVersion;
    
       "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
-    displayName: 'Get latest botbuilder package version from PyPI feed - https://pypi.org/search/?q=botbuilder&o='
-    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'PythonPI')) }}
+    displayName: 'From PyPI feed get latest botbuilder package version - https://pypi.org/search/?q=botbuilder&o='
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'PyPI')) }}
 
   - powershell: |
      $targetVersion = "${{ parameters.versionToTest }}";

--- a/build/yaml/sample-py-samplebot-linux-test.yml
+++ b/build/yaml/sample-py-samplebot-linux-test.yml
@@ -306,7 +306,7 @@ jobs:
 
   - powershell: |
       Start-Sleep -Seconds 700
-    displayName: 'Sleep for 700 seconds'
+    displayName: 'Sleep for 11 min 40 sec'
     enabled: true
 
   - task: DotNetCoreCLI@2

--- a/build/yaml/sample-py-samplebot-linux-test.yml
+++ b/build/yaml/sample-py-samplebot-linux-test.yml
@@ -258,11 +258,11 @@ jobs:
     displayName: 'Create nuget.config for Samples.$(SampleBotName).FunctionalTests.csproj for NuGet.org feed'
 
   - task: NuGetCommand@2
-    displayName: NuGet restore Samples.$(SampleBotName).FunctionalTests.csproj
+    displayName: NuGet restore dotnet Samples.$(SampleBotName).FunctionalTests.csproj
     inputs:
       solution: samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
       selectOrConfig: config
-      nugetConfigPath: $(SampleRootPath)\nuget.config
+      nugetConfigPath: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build Samples.$(SampleBotName).FunctionalTests.csproj

--- a/build/yaml/sample-py-samplebot-linux-test.yml
+++ b/build/yaml/sample-py-samplebot-linux-test.yml
@@ -110,10 +110,47 @@ jobs:
     displayName: 'Get latest botbuilder package version from Azure feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
 
+  - powershell: |
+      $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      $myGetFeedName = "botbuilder-v4-js-daily";
+      $packageName = "botbuilder-ai";
+
+      $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
+
+      Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
+      $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+
+      $package = $result.packages | Where-Object {$_.id -eq $packageName};
+      " "
+      "Available versions:";
+      $package.versions | Select -Last 30;
+
+      ### Hard-coded ########## [string]$latestVersion = "4.15.0-dev.ffde26a";
+      [string]$latestVersion = $package.versions[-1];
+      " "
+      "Latest version:";
+      $package.id;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
+    displayName: 'From MyGet feed get latest botbuilder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-js-daily'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
+
+  - powershell: |
+     $targetVersion = "${{ parameters.versionToTest }}";
+     $targetVersion;
+     "##vso[task.setvariable variable=TargetVersion;]$targetVersion";
+    displayName: 'From user input get specific botbuilder version number'
+    condition: ${{ ne(parameters.testLatestPackage, true) }}
+
+  - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
+    displayName: 'Display env vars'
+ 
   - task: tagBuildOrRelease@0
     displayName: Tag Build with botbuilder version
     inputs:
-      tags: Using botbuilder version $(LatestVersion)
+      tags: |
+        Using botbuilder version $(TargetVersion)
+        From ${{ parameters.packageFeed }} feed 
 
   - powershell: |
      # This adapted from PyPySkillBotFunctionalTest, file BotFramework-FunctionalTests\build\yaml\pythonDeploySteps.yml, task Set BotBuilder Package Version & Registry Url.
@@ -235,37 +272,34 @@ jobs:
     displayName: Use NuGet 5.5.1
     inputs:
       versionSpec: 5.5.1
-      checkLatest: true
 
   - powershell: |
-     $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
-   
-     $content = @"
-     <?xml version="1.0" encoding="utf-8"?>
-     <configuration>
-       <packageSources>
-         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-       </packageSources>
-       <activePackageSource>
-         <add key="All" value="(Aggregate source)" />
-       </activePackageSource>
-     </configuration>
-     "@;
-   
-     New-Item -Path $file -ItemType "file" -Value $content;
-   
+      $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
+
+      $content = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
+      "@;
+
+      New-Item -Path $file -ItemType "file" -Value $content;
       '-------------'; get-content "$file"; '==================='
-    displayName: 'Create nuget.config for Samples.$(SampleBotName).FunctionalTests.csproj for NuGet.org feed'
+    displayName: Create nuget.config for Samples.$(SampleBotName).FunctionalTests.csproj for NuGet.org feed
 
   - task: NuGetCommand@2
     displayName: NuGet restore dotnet Samples.$(SampleBotName).FunctionalTests.csproj
     inputs:
       solution: samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
-      selectOrConfig: config
       nugetConfigPath: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config
 
   - task: DotNetCoreCLI@2
-    displayName: dotnet build Samples.$(SampleBotName).FunctionalTests.csproj
+    displayName: dotnet build dotnet Samples.$(SampleBotName).FunctionalTests.csproj
     inputs:
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
 

--- a/build/yaml/sample-py-zipdeploy-echobot-linux-test.yml
+++ b/build/yaml/sample-py-zipdeploy-echobot-linux-test.yml
@@ -109,7 +109,7 @@ jobs:
       $packageName;
       $latestVersion;
       "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
-    displayName: 'Get latest botbuilder package version from Azure feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
+    displayName: 'From Azure feed get latest botbuilder package version - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
 
   - powershell: |
@@ -150,8 +150,8 @@ jobs:
       $latestVersion;
    
       "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
-    displayName: 'Get latest botbuilder package version from PyPI feed - https://pypi.org/search/?q=botbuilder&o='
-    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'PythonPI')) }}
+    displayName: 'From PyPI feed get latest botbuilder package version - https://pypi.org/search/?q=botbuilder&o='
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'PyPI')) }}
 
   - powershell: |
      $targetVersion = "${{ parameters.versionToTest }}";

--- a/build/yaml/sample-py-zipdeploy-echobot-linux-test.yml
+++ b/build/yaml/sample-py-zipdeploy-echobot-linux-test.yml
@@ -1,4 +1,4 @@
-# This is used in the pipelines Sample-Py-CoreBot-Linux-Test-yaml and Sample-Py-EchoBot-Linux-Test-yaml.
+# This is used in the pipeline Sample-Py-Zipdeploy-EchoBot-Linux-Test-yaml.
 
 # 'Allow scripts to access the OAuth token' was selected in pipeline.  Add the following YAML to any steps requiring access:
 #       env:
@@ -10,6 +10,8 @@
 # Variable 'BotGroup' is defined in Azure
 # Variable 'DeleteResourceGroup' is defined in Azure
 # Variable 'MyGetPersonalAccessToken' is defined in Azure
+# Variable 'MyGetFeedName' was defined in the Variables tab
+# Variable 'PackageDependencyName' was defined in the Variables tab
 # Variable 'runCodesignValidationInjection' is defined in Azure
 # Variable 'SampleBotName' is defined in Azure
 # Variable 'SampleFolderName' is defined in Azure
@@ -193,8 +195,12 @@ jobs:
      '------ $file -------'; get-content $file; '===================';
     displayName: 'Set index urls and dependencies in requirements.txt to get latest botframework packages'
 
+  - task: UsePythonVersion@0
+    displayName: Use Python 3.x
+
   - task: AzureCLI@2
     displayName: 'Preexisting RG: create Azure resources. Runs in even builds.'
+    enabled: False
     inputs:
       azureSubscription: 'FUSE Temporary'
       scriptType: ps
@@ -214,23 +220,22 @@ jobs:
     condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 0), endsWith(variables['Build.BuildId'], 2), endsWith(variables['Build.BuildId'], 4), endsWith(variables['Build.BuildId'], 6), endsWith(variables['Build.BuildId'], 8)))
 
   - task: AzureCLI@2
-    displayName: 'New RG: create Azure resources. Runs in odd builds.'
+    displayName: 'New RG: create Azure resources. '
     inputs:
       azureSubscription: 'FUSE Temporary'
       scriptType: ps
       scriptLocation: inlineScript
       inlineScript: |
         Write-Host "`n***** Creating Azure resources using the new-rg template *****";
-        Write-Host "This task runs for odd-numbered builds. Build ID = $(Build.BuildId)";
+
         Write-Host "****************************************************************";
 
-        #Set-PSDebug -Trace 1;
+        Set-PSDebug -Trace 1;
 
         # set up resource group, bot channels registration, app service, app service plan
         az deployment sub create --name "$(BotGroup)" --template-file "$(SampleRootPath)\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(AzureBotName)" botSku=S1 newAppServicePlanName="$(AzureBotName)" newWebAppName="$(AzureBotName)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus";
 
-        #Set-PSDebug -Trace 0;
-    condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 1), endsWith(variables['Build.BuildId'], 3), endsWith(variables['Build.BuildId'], 5), endsWith(variables['Build.BuildId'], 7), endsWith(variables['Build.BuildId'], 9)))
+        Set-PSDebug -Trace 0;
 
   - task: AzureCLI@2
     displayName: Create directline channel
@@ -241,23 +246,27 @@ jobs:
       inlineScript: |
        az bot directline create --name "$(AzureBotName)" --resource-group "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json" --debug
 
-       #az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(AzureBotName)" --src "$(SampleRootPath)\testbot.zip" --debug
+  - task: ArchiveFiles@2
+    displayName: Zip the bot
+    inputs:
+      rootFolderOrFile: $(SampleRootPath)
+      includeRootFolder: false
+      archiveFile: $(Build.ArtifactStagingDirectory)/testbot.zip
 
-  - script: |
-     echo git config
-     git config --global user.name "SamplePy$(SampleBotName)LinuxTestPipeline"
-     git config --global user.email BotBuilderPy@Pipeline.com
-     git init
-   
-     echo git add .
-     git add .
-     git commit -m "Add bot source code"
-     git remote add azure https://$(AzureDeploymentUser):$(AzureDeploymentPassword)@$(AzureBotName).scm.azurewebsites.net:443/$(AzureBotName).git
-   
-     echo git push azure master
-     git push azure master
-    workingDirectory: '$(SampleRootPath)'
-    displayName: 'git push the bot to Azure'
+  - task: PublishPipelineArtifact@1
+    displayName: Publish zip file to Pipeline Artifacts
+    inputs:
+      path: $(Build.ArtifactStagingDirectory)
+      artifactName: zipfile
+
+  - task: AzureCLI@2
+    displayName: Zip deploy the bot to Azure
+    inputs:
+      connectedServiceNameARM: 0ab0d343-57b9-4390-9a6a-13d71ef36de6
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: >
+        az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(AzureBotName)" --src "$(Build.ArtifactStagingDirectory)/testbot.zip" --debug
 
   - powershell: |
       # Key = Direct Line channel "Secret keys" in Azure portal
@@ -305,8 +314,8 @@ jobs:
       projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
 
   - powershell: |
-      Start-Sleep -Seconds 700
-    displayName: 'Sleep for 700 seconds'
+      Start-Sleep -Seconds 800
+    displayName: 'Sleep for 800 seconds'
     enabled: true
 
   - task: DotNetCoreCLI@2

--- a/build/yaml/sample-py-zipdeploy-echobot-linux-test.yml
+++ b/build/yaml/sample-py-zipdeploy-echobot-linux-test.yml
@@ -114,7 +114,7 @@ jobs:
 
   - powershell: |
       $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
-      $myGetFeedName = "botbuilder-v4-js-daily";
+      $myGetFeedName = "botbuilderdaily_python";
       $packageName = "botbuilder-ai";
 
       $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";

--- a/build/yaml/sample-py-zipdeploy-echobot-linux-test.yml
+++ b/build/yaml/sample-py-zipdeploy-echobot-linux-test.yml
@@ -210,7 +210,92 @@ jobs:
      UpdatePackageVersion "botbuilder-ai" 
    
      '------ $file -------'; get-content $file; '===================';
-    displayName: 'Set index urls and dependencies in requirements.txt to get latest botframework packages'
+    displayName: 'For Azure feed, set requirements.txt to get targeted botframework packages'
+    condition: ${{ eq(parameters.packageFeed, 'Azure') }}
+
+  - powershell: |
+     # This adapted from PyPySkillBotFunctionalTest, file BotFramework-FunctionalTests\build\yaml\pythonDeploySteps.yml, task Set BotBuilder Package Version & Registry Url.
+   
+     $file = "$(SampleRootPath)/requirements.txt";
+   
+     $indexUrl = "https://botbuilder.myget.org/F/botbuilderdaily_python/python/"
+     $extraIndexUrl = "https://pypi.org/simple/"
+   
+     $comparisonOperator = ""
+     $newVersion = ""
+     $pipInstallOption =  "--pre" # Include prerelease and development versions.
+   
+     # Add the index URL specs at the beginning of the requirements.txt file
+     $content = @(Get-Content $file)
+     Set-Content -Path $file -Value ("$pipInstallOption --index-url $indexUrl --extra-index-url $extraIndexUrl".Trim())
+     Add-Content -Path $file -Value $content
+   
+     function UpdatePackageVersion($package) {
+       # Set Package version to empty value
+       $content = @(Get-Content $file)
+       $matchinfo = Select-String -Path $file -Pattern $package
+   
+       $script = "$package $comparisonOperator $newVersion"
+   
+       # Update or add dependency
+       if($matchinfo.LineNumber -gt 0) {
+         $content[$matchinfo.LineNumber - 1] = $script
+         Set-Content -Path $file -Value $content
+     
+       } else {
+         Add-Content -Path $file -Value $script
+       }
+     }
+   
+     UpdatePackageVersion "botbuilder-integration-aiohttp"
+     UpdatePackageVersion "botbuilder-dialogs" 
+     UpdatePackageVersion "botbuilder-ai" 
+   
+     '------ $file -------'; get-content $file; '===================';
+    displayName: 'For MyGet feed, set requirements.txt to get targeted botframework packages'
+    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
+
+  - powershell: |
+     # This adapted from PyPySkillBotFunctionalTest, file BotFramework-FunctionalTests\build\yaml\pythonDeploySteps.yml, task Set BotBuilder Package Version & Registry Url.
+   
+     $file = "$(SampleRootPath)/requirements.txt";
+   
+     $indexUrl = "https://pypi.org/simple/"
+     $extraIndexUrl = "https://pypi.org/simple/"
+   
+     $comparisonOperator = ""
+     $newVersion = ""
+     $pipInstallOption =  "--pre" # Include prerelease and development versions.
+   
+     # Add the index URL specs at the beginning of the requirements.txt file
+     $content = @(Get-Content $file)
+     Set-Content -Path $file -Value ("$pipInstallOption --index-url $indexUrl --extra-index-url $extraIndexUrl".Trim())
+     Add-Content -Path $file -Value $content
+   
+     function UpdatePackageVersion($package) {
+       # Set Package version to empty value
+       $content = @(Get-Content $file)
+       $matchinfo = Select-String -Path $file -Pattern $package
+   
+       $script = "$package $comparisonOperator $newVersion"
+   
+       # Update or add dependency
+       if($matchinfo.LineNumber -gt 0) {
+         $content[$matchinfo.LineNumber - 1] = $script
+         Set-Content -Path $file -Value $content
+     
+       } else {
+         Add-Content -Path $file -Value $script
+       }
+     }
+   
+     UpdatePackageVersion "botbuilder-integration-aiohttp"
+     UpdatePackageVersion "botbuilder-dialogs" 
+     UpdatePackageVersion "botbuilder-ai" 
+   
+     '------ $file -------'; get-content $file; '===================';
+    displayName: 'For PyPI feed, set requirements.txt to get targeted botframework packages'
+    condition: ${{ eq(parameters.packageFeed, 'PyPI') }}
 
   - task: UsePythonVersion@0
     displayName: Use Python 3.x

--- a/build/yaml/sample-py-zipdeploy-echobot-linux-test.yml
+++ b/build/yaml/sample-py-zipdeploy-echobot-linux-test.yml
@@ -99,16 +99,16 @@ jobs:
     condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
 
   - powershell: |
-     $packageName = "botbuilder-integration-aiohttp";
-     $url = "https://feeds.dev.azure.com/ConversationalAI/BotFramework/_apis/packaging/Feeds/SDK/Packages/26dde74d-6079-401c-a9e0-c6d839e02c18/versions?api-version=5.1-preview.1"
+      $packageName = "botbuilder-integration-aiohttp";
+      $url = "https://feeds.dev.azure.com/ConversationalAI/BotFramework/_apis/packaging/Feeds/SDK/Packages/26dde74d-6079-401c-a9e0-c6d839e02c18/versions?api-version=5.1-preview.1"
    
-     Write-Host "Get latest $packageName version number from ConversationalAI BotFramework SDK feed";
-     $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
-     [string]$latestVersion = $result.value[0].protocolMetadata.data.version;
+      Write-Host "Get latest $packageName version number from ConversationalAI BotFramework SDK feed";
+      $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+      [string]$latestVersion = $result.value[0].protocolMetadata.data.version;
    
-     $packageName;
-     $latestVersion;
-     "##vso[task.setvariable variable=LatestVersion;]$latestVersion";
+      $packageName;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
     displayName: 'Get latest botbuilder package version from Azure feed - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
 

--- a/build/yaml/sample-py-zipdeploy-echobot-linux-test.yml
+++ b/build/yaml/sample-py-zipdeploy-echobot-linux-test.yml
@@ -153,6 +153,7 @@ jobs:
       tags: |
         Using botbuilder version $(TargetVersion)
         From ${{ parameters.packageFeed }} feed 
+        Test latest = ${{ parameters.testLatestPackage }}
 
   - powershell: |
      # This adapted from PyPySkillBotFunctionalTest, file BotFramework-FunctionalTests\build\yaml\pythonDeploySteps.yml, task Set BotBuilder Package Version & Registry Url.

--- a/build/yaml/sample-py-zipdeploy-echobot-linux-test.yml
+++ b/build/yaml/sample-py-zipdeploy-echobot-linux-test.yml
@@ -36,7 +36,7 @@ parameters:
     values:
     - Azure
     - MyGet
-    - PythonPI
+    - PyPI
 
 # Run this job every night at 2 AM (PST) on the main branch
 schedules:
@@ -136,6 +136,22 @@ jobs:
       "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
     displayName: 'From MyGet feed get latest botbuilder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-js-daily'
     condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
+
+  - powershell: |
+      $packageName = "botbuilder-integration-aiohttp";
+   
+      py -m pip install yolk3k;
+      $result = py -m yolk -V $packageName;
+   
+      $array = $result -split " ";
+      $latestVersion = $array[1];
+      " ";
+      $packageName;
+      $latestVersion;
+   
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+    displayName: 'Get latest botbuilder package version from PyPI feed - https://pypi.org/search/?q=botbuilder&o='
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'PythonPI')) }}
 
   - powershell: |
      $targetVersion = "${{ parameters.versionToTest }}";

--- a/build/yaml/sample-ts-samplebot-linux-test.yml
+++ b/build/yaml/sample-ts-samplebot-linux-test.yml
@@ -26,7 +26,7 @@ parameters:
   - name: versionToTest
     displayName: Version to test (Only if 'Test latest' is unchecked)
     type: string
-    default: 'Example: 4.15.0-dev.7afa288'
+    default: 'Example: 4.15.0-dev.20210726.c56bbf1'
   - name: packageFeed
     displayName: Package feed to use
     type: string

--- a/build/yaml/sample-ts-samplebot-linux-test.yml
+++ b/build/yaml/sample-ts-samplebot-linux-test.yml
@@ -1,4 +1,4 @@
-# This is used in the pipelines Sample-Js-CoreBot-Win-Test-yaml and Sample-Js-EchoBot-Win-Test-yaml.
+# This is used in the pipelines Sample-Ts-CoreBot-Linux-Test-yaml and Sample-Ts-EchoBot-Linux-Test-yaml.
 
 # 'Allow scripts to access the OAuth token' was selected in pipeline.  Add the following YAML to any steps requiring access:
 #       env:
@@ -14,6 +14,7 @@
 # Variable 'SampleBotName' is defined in Azure
 # Variable 'SampleFolderName' is defined in Azure
 # Variable 'SampleRootPath' is defined in Azure
+# Variable Group 'AzureDeploymentCredsVariableGroup' is defined in Azure
 # Variable Group 'SamplesE2ETestsVariableGroup' is defined in Azure
 # Variable Group 'MyGetPersonalAccessTokenVariableGroup' is defined in Azure
 
@@ -55,6 +56,7 @@ resources:
     ref: main
 
 #variables:
+#- group: AzureDeploymentCredsVariableGroup
 #- group: SamplesE2ETestsVariableGroup
 #- group: MyGetPersonalAccessTokenVariableGroup
 
@@ -170,84 +172,53 @@ jobs:
       workingDir: $(SampleRootPath)
       verbose: false
 
-  - powershell: |
-      Set-PSDebug -Trace 1;
-
-      move-item -path $(SampleRootPath)/deploymentScripts/windows/* -destination $(SampleRootPath);
-
-      $DirToCompress = "$(SampleRootPath)";
-      $DirtoExclude =@("node_modules", "deploymentTemplates", "deploymentScripts");
-      $files = Get-ChildItem -Path $DirToCompress -Exclude $DirtoExclude;
-      $ZipFileDestination ="$(SampleRootPath)/testbot.zip";
-
-      Compress-Archive -Path $files -DestinationPath $ZipFileDestination;
-
-      Set-PSDebug -Trace 0;
-    displayName: Set up deploy scripts, zip the bot
-
-  - task: CopyFiles@2
-    displayName: 'Copy testbot.zip to: $(Build.ArtifactStagingDirectory)'
-    inputs:
-      SourceFolder: $(SampleRootPath)
-      Contents: testbot.zip
-      TargetFolder: $(Build.ArtifactStagingDirectory)
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: testbot-zip'
-    inputs:
-      ArtifactName: testbot-zip
-
   - task: AzureCLI@2
-    displayName: 'Preexisting RG: create Azure resources. Runs in even builds.'
+    displayName: 'create group, create resources, generate web.config (uses dotnet template)'
     inputs:
       azureSubscription: 'FUSE Temporary'
       scriptType: ps
       scriptLocation: inlineScript
       inlineScript: |
-        Write-Host "`n***** Creating Azure resources using the preexisting-rg template *****";
-        Write-Host "This task runs for even-numbered builds. Build ID = $(Build.BuildId)";
-        Write-Host "************************************************************************";
         Set-PSDebug -Trace 1;
      
         az group create --location westus --name $(BotGroup);
      
         # set up bot channels registration, app service, app service plan
-        az deployment group create --resource-group "$(BotGroup)" --template-file "$(SampleRootPath)\DeploymentTemplates\template-with-preexisting-rg.json" --parameters appId="$(AppId)" appSecret="$(AppSecret)" botId="$(AzureBotName)" newWebAppName="$(AzureBotName)" newAppServicePlanName="$(AzureBotName)" appServicePlanLocation="westus" --name "$(AzureBotName)";
+        az deployment group create --resource-group "$(BotGroup)" --template-file "$(SampleRootPath)\deploymentTemplates\linux\template.json" --parameters appId="$(AppId)" appSecret="$(AppSecret)" botName="$(AzureBotName)" --name "$(AzureBotName)";
      
-        Set-PSDebug -Trace 0;
-    condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 0), endsWith(variables['Build.BuildId'], 2), endsWith(variables['Build.BuildId'], 4), endsWith(variables['Build.BuildId'], 6), endsWith(variables['Build.BuildId'], 8)))
-
-  - task: AzureCLI@2
-    displayName: 'New RG: create Azure resources. Runs in odd builds.'
-    inputs:
-      azureSubscription: 'FUSE Temporary'
-      scriptType: ps
-      scriptLocation: inlineScript
-      inlineScript: |
-        Write-Host "`n***** Creating Azure resources using the new-rg template *****";
-        Write-Host "This task runs for odd-numbered builds. Build ID = $(Build.BuildId)";
-        Write-Host "****************************************************************";
-        Set-PSDebug -Trace 1;
-
-        # set up resource group, bot channels registration, app service, app service plan
-        az deployment sub create --name "$(BotGroup)" --template-file "$(SampleRootPath)\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(AzureBotName)" botSku=F0 newAppServicePlanName="$(AzureBotName)" newWebAppName="$(AzureBotName)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus";
-     
-        Set-PSDebug -Trace 0;
-    condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 1), endsWith(variables['Build.BuildId'], 3), endsWith(variables['Build.BuildId'], 5), endsWith(variables['Build.BuildId'], 7), endsWith(variables['Build.BuildId'], 9)))
-
-  - task: AzureCLI@2
-    displayName: 'Deploy bot, create directline channel '
-    inputs:
-      connectedServiceNameARM: 0ab0d343-57b9-4390-9a6a-13d71ef36de6
-      scriptType: ps
-      scriptLocation: inlineScript
-      inlineScript: >
         # Generate web.config for bot deploy
         az bot prepare-deploy --code-dir "$(SampleRootPath)" --lang Javascript
+     
+        Set-PSDebug -Trace 0;
 
-        az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(AzureBotName)" --src "$(Build.ArtifactStagingDirectory)\testbot.zip" --debug
+  - powershell: |
+      Set-PSDebug -Trace 1;
+      # Copy Azure deploy scripts for Linux
+      Move-Item -Path $(SampleRootPath)\deploymentScripts\linux\* -Destination $(SampleRootPath)\;
+      Set-PSDebug -Trace 0;
+    displayName: Move .deployment, deploy.sh scripts into position
 
-        az bot directline create --name "$(AzureBotName)" --resource-group "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json" --debug
+  - script: |
+      echo on
+      git config --global user.name "SampleTs$(SampleBotName)LinuxTestPipeline"
+      git config --global user.email BotBuilderTs@Pipeline.com
+      git init
+   
+      git add .
+      git commit -m "Add bot source code"
+      git remote add azure https://$(AzureDeploymentUser):$(AzureDeploymentPassword)@$(AzureBotName).scm.azurewebsites.net:443/$(AzureBotName).git
+   
+      git push azure master
+    workingDirectory: '$(System.DefaultWorkingDirectory)/samples/javascript_nodejs/$(SampleFolderName)'
+    displayName: 'Deploy the bot to Azure'
+
+  - task: AzureCLI@2
+    displayName: Create DirectLine channel
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: batch
+      scriptLocation: inlineScript
+      inlineScript: call az bot directline create --name "$(AzureBotName)" --resource-group "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json" --debug
 
   - powershell: |
       # Key = Direct Line channel "Secret keys" in Azure portal
@@ -288,7 +259,6 @@ jobs:
     displayName: NuGet restore dotnet Samples.$(SampleBotName).FunctionalTests.csproj
     inputs:
       solution: samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
-      selectOrConfig: config
       nugetConfigPath: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config
 
   - task: DotNetCoreCLI@2

--- a/build/yaml/sample-ts-samplebot-linux-test.yml
+++ b/build/yaml/sample-ts-samplebot-linux-test.yml
@@ -133,6 +133,7 @@ jobs:
       tags: |
         Using botbuilder version $(TargetVersion)
         From ${{ parameters.packageFeed }} feed 
+        Test latest = ${{ parameters.testLatestPackage }}
 
   - powershell: |
      # SetDependencyVersionInPackageJsonFile0.ps1

--- a/build/yaml/sample-ts-samplebot-win-test.yml
+++ b/build/yaml/sample-ts-samplebot-win-test.yml
@@ -1,4 +1,4 @@
-# This is used in the pipelines Sample-Js-CoreBot-Win-Test-yaml and Sample-Js-EchoBot-Win-Test-yaml.
+# This is used in the pipelines Sample-Ts-CoreBot-Win-Test-yaml and Sample-Ts-EchoBot-Win-Test-yaml.
 
 # 'Allow scripts to access the OAuth token' was selected in pipeline.  Add the following YAML to any steps requiring access:
 #       env:
@@ -169,6 +169,16 @@ jobs:
     inputs:
       workingDir: $(SampleRootPath)
       verbose: false
+
+  - powershell: |
+      $file = "$(SampleRootPath)\package.json";
+   
+      $content = Get-Content -Raw $file | ConvertFrom-Json
+      $content.scripts.start = 'node ./lib/index.js'
+      $content | ConvertTo-Json | Set-Content $file
+   
+      '-------------'; get-content $file; '==================='
+    displayName: 'Fix start-up command script for Win deploy'
 
   - powershell: |
       Set-PSDebug -Trace 1;

--- a/build/yaml/sample-ts-samplebot-win-test.yml
+++ b/build/yaml/sample-ts-samplebot-win-test.yml
@@ -131,6 +131,7 @@ jobs:
       tags: |
         Using botbuilder version $(TargetVersion)
         From ${{ parameters.packageFeed }} feed 
+        Test latest = ${{ parameters.testLatestPackage }}
 
   - powershell: |
      # SetDependencyVersionInPackageJsonFile0.ps1

--- a/build/yaml/sample-ts-samplebot-win-test.yml
+++ b/build/yaml/sample-ts-samplebot-win-test.yml
@@ -25,7 +25,7 @@ parameters:
   - name: versionToTest
     displayName: Version to test (Only if 'Test latest' is unchecked)
     type: string
-    default: 'Example: 4.15.0-dev.7afa288'
+    default: 'Example: 4.15.0-dev.20210726.c56bbf1'
   - name: packageFeed
     displayName: Package feed to use
     type: string


### PR DESCRIPTION
Fixes #3386

This would let you pick which Bot.Builder version to run tests against when manually queuing.
Adds a "Test latest daily package version" checkbox and a "Version to test" entry box to the "Run pipeline" dialog.

Note - Completing this PR is blocked: I cannot authorize the yaml pipelines to get secrets from the SdkSamplesE2ETests key vault. Required would be 'User Access Administrator' permissions on subscription Bot Service Testing (Scratch).

### Changes:

1. Create new yaml pipelines to replace the old classics. Classics do not support customizing the "Run pipeline" dialog.

Add 4 .yml files to cover these 8 new replacement pipelines:
- Sample-DotNet-CoreBot-Linux-Test-yaml
- Sample-DotNet-CoreBot-Win-Test-yaml
- Sample-DotNet-EchoBot-Linux-Test-yaml
- Sample-DotNet-EchoBot-Win-Test-yaml
- Sample-Js-CoreBot-Linux-Test-yaml
- Sample-Js-CoreBot-Win-Test-yaml
- Sample-Js-EchoBot-Linux-Test-yaml
- Sample-Js-EchoBot-Win-Test-yaml
Link to the new pipelines: [https://dev.azure.com/FuseLabs/SDK_v4/_build?definitionScope=%5CSamples%5C-experimental](https://dev.azure.com/FuseLabs/SDK_v4/_build?definitionScope=%5CSamples%5C-experimental)

2. Replace Assert.Inconclusive() with Assert.Fail(). Assert.Inconclusive() causes the test run to succeed when it should fail.
