### PR TITLE
Update sample 51.teams-messaging-extensions-action startup file

### DIFF
--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Startup.cs
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Startup.cs
@@ -26,6 +26,7 @@ namespace Microsoft.BotBuilderSamples
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllers();
+            services.AddHttpClient();
             services.AddMvc();
             services.AddControllers().AddNewtonsoftJson();
             services.AddRazorPages();


### PR DESCRIPTION
Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

While trying to run the C# sample [51.teams-messaging-extensions-action](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/csharp_dotnetcore/51.teams-messaging-extensions-action), it throws up the below error:

![sample 51 1](https://user-images.githubusercontent.com/48731427/126829162-424d4953-eeca-495b-a572-6d30aa4a3223.png)

Related: #3389 
## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->
<!-- If you are introducing a new sample, make sure that the sample adheres to sample guidelines -->

  - Adding `services.AddHttpClient()` in the `Startup.cs` file helps eliminate the error.
  


