### PR TITLE
Making consistent .NET Core launch setting. Fixes 3364

### DIFF
--- a/samples/csharp_dotnetcore/02.echo-bot/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/02.echo-bot/Properties/launchSettings.json
@@ -16,7 +16,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "EchoBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "applicationUrl": "https://localhost:3979;http://localhost:3978",

--- a/samples/csharp_dotnetcore/03.welcome-user/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/03.welcome-user/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "Welcome-Users": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/05.multi-turn-prompt/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/05.multi-turn-prompt/Properties/launchSettings.json
@@ -16,7 +16,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "MultiTurnPromptBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/06.using-cards/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/06.using-cards/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "CardsBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/07.using-adaptive-cards/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/07.using-adaptive-cards/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "Using_Cards": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/08.suggested-actions/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/08.suggested-actions/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "SuggestedActions": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/11.qnamaker/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/11.qnamaker/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "QnABot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/13.core-bot.tests/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/13.core-bot.tests/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "CoreBot.Tests": {
+    ".NET Core": {
       "commandName": "Project"
     }
   }

--- a/samples/csharp_dotnetcore/13.core-bot/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/13.core-bot/Properties/launchSettings.json
@@ -16,7 +16,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "CoreBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "applicationUrl": "http://localhost:3978",

--- a/samples/csharp_dotnetcore/14.nlp-with-orchestrator/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/14.nlp-with-orchestrator/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "10.EchoBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/15.handling-attachments/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/15.handling-attachments/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "handling-attachments": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/16.proactive-messages/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/16.proactive-messages/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "Proactive-Bot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/17.multilingual-bot/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "MultiLingualBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/18.bot-authentication/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/18.bot-authentication/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "AuthenticationBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/19.custom-dialogs/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/19.custom-dialogs/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "Custom_Dialogs": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/21.corebot-app-insights/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/21.corebot-app-insights/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "CoreBot-AppInsights": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "applicationUrl": "http://localhost:3978/",

--- a/samples/csharp_dotnetcore/23.facebook-events/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/23.facebook-events/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "Facebook-Events-Bot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/24.bot-authentication-msgraph/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/24.bot-authentication-msgraph/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "Bot-Authentication-MSGraph": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/25.message-reaction/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/25.message-reaction/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "MessageReaction": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/42.scaleout/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/42.scaleout/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "ScaleoutBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/43.complex-dialog/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/43.complex-dialog/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "ComplexDialog": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/44.prompt-users-for-input/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/44.prompt-users-for-input/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "PromptUsersForInput": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/45.state-management/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/45.state-management/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "StateBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/46.teams-auth/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/46.teams-auth/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "AuthenticationBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/47.inspection/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/47.inspection/Properties/launchSettings.json
@@ -16,7 +16,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "EchoBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "applicationUrl": "https://localhost:3979;http://localhost:3978",

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "QnABot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/Properties/launchSettings.json
@@ -16,7 +16,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "EchoBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "applicationUrl": "https://localhost:3979;http://localhost:3978",

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Properties/launchSettings.json
@@ -16,7 +16,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "EchoBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "TeamsMessagingExtensionsSearchAuthConfig": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "TeamsMessagingExtensionsActionPreview": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/54.teams-task-module/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/54.teams-task-module/Properties/launchSettings.json
@@ -16,7 +16,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "EchoBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "applicationUrl": "https://localhost:3979;http://localhost:3978",

--- a/samples/csharp_dotnetcore/55.teams-link-unfurling/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/55.teams-link-unfurling/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "LinkUnfurling": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/56.teams-file-upload/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/56.teams-file-upload/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "TeamsFileBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/Properties/launchSettings.json
@@ -16,7 +16,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "TeamsConversationBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "applicationUrl": "https://localhost:3979;http://localhost:3978",

--- a/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/Properties/launchSettings.json
@@ -17,7 +17,7 @@
       }
     },
     "EchoBot": {
-      "commandName": "Project",
+      "commandName": ".NET Core",
       "launchBrowser": true,
       "applicationUrl": "https://localhost:3979;http://localhost:3978",
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/60.slack-adapter/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/60.slack-adapter/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "Microsoft.Bot.Builder.Adapters.Slack.TestBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/61.facebook-adapter/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/61.facebook-adapter/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "Microsoft.Bot.Builder.Facebook.Sample": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/62.webex-adapter/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/62.webex-adapter/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "Microsoft.Bot.Builder.Webex.Sample": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/63.twilio-adapter/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/63.twilio-adapter/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "Microsoft.Bot.Builder.Twilio.Sample": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/Properties/launchSettings.json
@@ -16,7 +16,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "EchoSkillBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "applicationUrl": "http://localhost:1205/",

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/Properties/launchSettings.json
@@ -16,7 +16,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "SimpleRootBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "applicationUrl": "http://localhost:3978",

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/Properties/launchSettings.json
@@ -17,7 +17,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "DialogRootBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "applicationUrl": "https://localhost:5001;http://localhost:5000",

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/Properties/launchSettings.json
@@ -16,7 +16,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "DialogSkillBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "applicationUrl": "http://localhost:1205/",

--- a/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/adaptive-dialog/01.multi-turn-prompt/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "02.Multi-turn-prompt": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/adaptive-dialog/02.using-cards/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/adaptive-dialog/02.using-cards/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "03.Using-cards": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/adaptive-dialog/03.core-bot/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/adaptive-dialog/03.core-bot/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "04.Core-bot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/adaptive-dialog/04.waterfall-or-custom-dialog-with-adaptive/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/adaptive-dialog/04.waterfall-or-custom-dialog-with-adaptive/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "Custom_Dialogs": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/adaptive-dialog/05.interruptions-bot/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/adaptive-dialog/05.interruptions-bot/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "Custom_Dialogs": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/adaptive-dialog/06.todo-bot/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/adaptive-dialog/06.todo-bot/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "ToDoBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/adaptive-dialog/07.qnamaker/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/adaptive-dialog/07.qnamaker/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "ToDoBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/adaptive-dialog/08.todo-bot-luis-qnamaker/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/adaptive-dialog/08.todo-bot-luis-qnamaker/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "ToDoBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/adaptive-dialog/09.integrating-composer-dialogs/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/adaptive-dialog/09.integrating-composer-dialogs/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "ToDoBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/adaptive-dialog/20.EchoBot-declarative/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/adaptive-dialog/20.EchoBot-declarative/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "10.EchoBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/adaptive-dialog/21.AdaptiveBot-declarative/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/adaptive-dialog/21.AdaptiveBot-declarative/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "60.AdaptiveBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/language-generation/05.a.multi-turn-prompt-with-language-fallback/Properties/launchSettings.json
@@ -16,7 +16,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "MultiTurnPromptBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/language-generation/05.multi-turn-prompt/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/language-generation/05.multi-turn-prompt/Properties/launchSettings.json
@@ -16,7 +16,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "MultiTurnPromptBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/language-generation/06.using-cards/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/language-generation/06.using-cards/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "CardsBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/language-generation/13.core-bot/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/language-generation/13.core-bot/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "CoreBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {

--- a/samples/csharp_dotnetcore/language-generation/20.extending-with-custom-functions/Properties/launchSettings.json
+++ b/samples/csharp_dotnetcore/language-generation/20.extending-with-custom-functions/Properties/launchSettings.json
@@ -16,7 +16,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "EchoBot": {
+    ".NET Core": {
       "commandName": "Project",
       "launchBrowser": true,
       "applicationUrl": "http://localhost:3978",


### PR DESCRIPTION
Fixes #3364

## Proposed Changes
Use consistent naming for .NET Core/Kestrel server settings in launchsettings.json
Set name to `.NET Core`


## Testing
Bots will run the same regardless of .NET core launch name. Tested 5 different ones to be sure.