### PR TITLE
Update Readme.md for Java Sample 46.Teams-Auth

### DIFF
--- a/samples/java_springboot/46.teams-auth/README.md
+++ b/samples/java_springboot/46.teams-auth/README.md
@@ -30,6 +30,7 @@ the Teams service needs to call into the bot.
     - Ensure that you've [enabled the Teams Channel](https://docs.microsoft.com/en-us/azure/bot-service/channel-connect-teams?view=azure-bot-service-4.0)
     - __*If you don't have an Azure account*__ you can use this [Bot Framework registration](https://docs.microsoft.com/en-us/microsoftteams/platform/bots/how-to/create-a-bot-for-teams#register-your-web-service-with-the-bot-framework)  
 - Update the `resources/application.properties` configuration for the bot to use the Microsoft App Id and App Password from the Bot Framework registration. (Note the App Password is referred to as the "client secret" in the azure portal and you can always create a new client secret anytime.)
+- Follow the instructions here [Add Authentication to Your Bot Via Azure Bot Service](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-authentication?view=azure-bot-service-4.0&tabs=csharp) to configure authentication for the bot. This is required for this sample to work correctly and prompt the user to authenticate.
 - __*This step is specific to Teams.*__
     - **Edit** the `manifest.json` contained in the  `teamsAppManifest` folder to replace your Microsoft App Id (that was created when you registered your bot earlier) *everywhere* you see the place holder string `<<YOUR-MICROSOFT-APP-ID>>` (depending on the scenario the Microsoft App Id may occur multiple times in the `manifest.json`)
     - **Zip** up the contents of the `teamsAppManifest` folder to create a `manifest.zip`


### PR DESCRIPTION
Fixes #3405 

## Proposed Changes
Added line Readme.md to instruct user to set up authentication following the separate instructions that are documented to do this. We had a case where someone trying to set up this sample didn't realize they needed to do this as it was only mentioned the the "Additional Reading" section and they reported the sample didn't work. The failure was likely due to the authentication having not been set up correctly.
