### PR TITLE
[#3399] Fixing Echobot VSIX templates namespace and type conflict build error when creating project named "Echobot"

### DIFF
--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot-Core21/Startup.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot-Core21/Startup.cs
@@ -11,8 +11,6 @@ using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
-using $safeprojectname$.Bots;
-
 namespace $safeprojectname$
 {
     public class Startup
@@ -33,7 +31,7 @@ namespace $safeprojectname$
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
-            services.AddTransient<IBot, EchoBot>();
+            services.AddTransient<IBot, Bots.EchoBot>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/Startup.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/Startup.cs
@@ -11,8 +11,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-using $safeprojectname$.Bots;
-
 namespace $safeprojectname$
 {
     public class Startup
@@ -33,7 +31,7 @@ namespace $safeprojectname$
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
-            services.AddTransient<IBot, EchoBot>();
+            services.AddTransient<IBot, Bots.EchoBot>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
Fixes #3399

## Proposed Changes
When a new project is created using Echobot VSIX template and project is named as "Echobot", a namespace and type conflict is causing compilation error when building the project. This PR fixes the build issue, by using the fully qualified name to reference the type.

## Testing
Tested that build succeeds by created new projects using EchoBot Templates(.Net Core 2.1 and .Net Core 3.1)

![VSIX Bug test1 0](https://user-images.githubusercontent.com/30093161/129770127-3c572b65-8ce1-4ad4-a796-38bd080e18be.png)
![VSIX Bug test1](https://user-images.githubusercontent.com/30093161/129770247-fdb6a29a-5e25-4ac3-88d1-dbc4eef91858.png)
![VSIX Bug test core 3 1](https://user-images.githubusercontent.com/30093161/129770245-981c834d-f21e-4bb9-aea0-30fb375abc39.png)
![VSIX Bug  core 2 1](https://user-images.githubusercontent.com/30093161/129770341-7e0fd9d6-294b-49c2-9641-e163d652a0eb.png)
![VSIX Bug  core 2 1 test 1](https://user-images.githubusercontent.com/30093161/129770337-c6e6fde9-68cb-41a3-9e02-1de1001c6e0a.png)
![VSIX Bug  core 2 1 test 2](https://user-images.githubusercontent.com/30093161/129770347-e4632d93-b001-4213-b32e-c141058535e9.png)
