### PR TITLE
[#3340] Deployment ARM templates update (template-with-new-rg) - samples/python

### DIFF
--- a/samples/python/02.echo-bot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/02.echo-bot/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/03.welcome-user/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/03.welcome-user/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/05.multi-turn-prompt/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/05.multi-turn-prompt/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/06.using-cards/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/06.using-cards/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/07.using-adaptive-cards/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/07.using-adaptive-cards/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/08.suggested-actions/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/08.suggested-actions/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/11.qnamaker/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/11.qnamaker/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/13.core-bot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/13.core-bot/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/14.nlp-with-dispatch/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/14.nlp-with-dispatch/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/15.handling-attachments/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/15.handling-attachments/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/16.proactive-messages/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/16.proactive-messages/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/17.multilingual-bot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/17.multilingual-bot/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/18.bot-authentication/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/18.bot-authentication/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/19.custom-dialogs/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/19.custom-dialogs/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/21.corebot-app-insights/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/21.corebot-app-insights/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/23.facebook-events/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/23.facebook-events/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/24.bot-authentication-msgraph/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/24.bot-authentication-msgraph/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/42.scaleout/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/42.scaleout/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/43.complex-dialog/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/43.complex-dialog/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/44.prompt-for-user-input/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/44.prompt-for-user-input/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/45.state-management/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/45.state-management/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/46.teams-auth/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/46.teams-auth/deploymentTemplates/template-with-new-rg.json
@@ -233,42 +233,44 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
-                            "resources": [
-                                {
-                                    "name": "MsTeamsChannel",
-                                    "type": "channels",
-                                    "location": "global",
-                                    "apiVersion": "2018-07-12",
-                                    "kind": "bot",
-                                    "properties": {
-                                        "channelName": "MsTeamsChannel"
-                                    },
-                                    "dependsOn": [
-                                        "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
-                                    ]
-                                }
-                            ],
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/python/47.inspection/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/47.inspection/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/49.qnamaker-all-features/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/49.qnamaker-all-features/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/50.teams-messaging-extension-search/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/50.teams-messaging-extension-search/deploymentTemplates/template-with-new-rg.json
@@ -233,42 +233,44 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
-                            "resources": [
-                                {
-                                    "name": "MsTeamsChannel",
-                                    "type": "channels",
-                                    "location": "global",
-                                    "apiVersion": "2018-07-12",
-                                    "kind": "bot",
-                                    "properties": {
-                                        "channelName": "MsTeamsChannel"
-                                    },
-                                    "dependsOn": [
-                                        "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
-                                    ]
-                                }
-                            ],
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/python/51.teams-messaging-extensions-action/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/51.teams-messaging-extensions-action/deploymentTemplates/template-with-new-rg.json
@@ -233,42 +233,44 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
-                            "resources": [
-                                {
-                                    "name": "MsTeamsChannel",
-                                    "type": "channels",
-                                    "location": "global",
-                                    "apiVersion": "2018-07-12",
-                                    "kind": "bot",
-                                    "properties": {
-                                        "channelName": "MsTeamsChannel"
-                                    },
-                                    "dependsOn": [
-                                        "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
-                                    ]
-                                }
-                            ],
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/python/52.teams-messaging-extensions-search-auth-config/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/52.teams-messaging-extensions-search-auth-config/deploymentTemplates/template-with-new-rg.json
@@ -233,42 +233,44 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
-                            "resources": [
-                                {
-                                    "name": "MsTeamsChannel",
-                                    "type": "channels",
-                                    "location": "global",
-                                    "apiVersion": "2018-07-12",
-                                    "kind": "bot",
-                                    "properties": {
-                                        "channelName": "MsTeamsChannel"
-                                    },
-                                    "dependsOn": [
-                                        "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
-                                    ]
-                                }
-                            ],
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/python/53.teams-messaging-extensions-action-preview/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/53.teams-messaging-extensions-action-preview/deploymentTemplates/template-with-new-rg.json
@@ -233,42 +233,44 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
-                            "resources": [
-                                {
-                                    "name": "MsTeamsChannel",
-                                    "type": "channels",
-                                    "location": "global",
-                                    "apiVersion": "2018-07-12",
-                                    "kind": "bot",
-                                    "properties": {
-                                        "channelName": "MsTeamsChannel"
-                                    },
-                                    "dependsOn": [
-                                        "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
-                                    ]
-                                }
-                            ],
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/python/54.teams-task-module/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/54.teams-task-module/deploymentTemplates/template-with-new-rg.json
@@ -233,42 +233,44 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
-                            "resources": [
-                                {
-                                    "name": "MsTeamsChannel",
-                                    "type": "channels",
-                                    "location": "global",
-                                    "apiVersion": "2018-07-12",
-                                    "kind": "bot",
-                                    "properties": {
-                                        "channelName": "MsTeamsChannel"
-                                    },
-                                    "dependsOn": [
-                                        "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
-                                    ]
-                                }
-                            ],
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/python/55.teams-link-unfurling/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/55.teams-link-unfurling/deploymentTemplates/template-with-new-rg.json
@@ -233,42 +233,44 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
-                            "resources": [
-                                {
-                                    "name": "MsTeamsChannel",
-                                    "type": "channels",
-                                    "location": "global",
-                                    "apiVersion": "2018-07-12",
-                                    "kind": "bot",
-                                    "properties": {
-                                        "channelName": "MsTeamsChannel"
-                                    },
-                                    "dependsOn": [
-                                        "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
-                                    ]
-                                }
-                            ],
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/python/56.teams-file-upload/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/56.teams-file-upload/deploymentTemplates/template-with-new-rg.json
@@ -233,42 +233,44 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
-                            "resources": [
-                                {
-                                    "name": "MsTeamsChannel",
-                                    "type": "channels",
-                                    "location": "global",
-                                    "apiVersion": "2018-07-12",
-                                    "kind": "bot",
-                                    "properties": {
-                                        "channelName": "MsTeamsChannel"
-                                    },
-                                    "dependsOn": [
-                                        "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
-                                    ]
-                                }
-                            ],
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/python/57.teams-conversation-bot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/57.teams-conversation-bot/deploymentTemplates/template-with-new-rg.json
@@ -233,42 +233,44 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
-                            "resources": [
-                                {
-                                    "name": "MsTeamsChannel",
-                                    "type": "channels",
-                                    "location": "global",
-                                    "apiVersion": "2018-07-12",
-                                    "kind": "bot",
-                                    "properties": {
-                                        "channelName": "MsTeamsChannel"
-                                    },
-                                    "dependsOn": [
-                                        "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
-                                    ]
-                                }
-                            ],
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/python/58.teams-start-thread-in-channel/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/58.teams-start-thread-in-channel/deploymentTemplates/template-with-new-rg.json
@@ -233,42 +233,44 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
-                            "resources": [
-                                {
-                                    "name": "MsTeamsChannel",
-                                    "type": "channels",
-                                    "location": "global",
-                                    "apiVersion": "2018-07-12",
-                                    "kind": "bot",
-                                    "properties": {
-                                        "channelName": "MsTeamsChannel"
-                                    },
-                                    "dependsOn": [
-                                        "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
-                                    ]
-                                }
-                            ],
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', parameters('botId'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/python/60.slack-adapter/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/60.slack-adapter/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/81.skills-skilldialog/dialog-root-bot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/81.skills-skilldialog/dialog-root-bot/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/81.skills-skilldialog/dialog-skill-bot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/81.skills-skilldialog/dialog-skill-bot/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/wip/python_quart/02.echo-bot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/wip/python_quart/02.echo-bot/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/wip/python_quart/13.core-bot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/wip/python_quart/13.core-bot/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/wip/python_tornado/02.echo-bot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/wip/python_tornado/02.echo-bot/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/samples/python/wip/python_tornado/13.core-bot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/python/wip/python_tornado/13.core-bot/deploymentTemplates/template-with-new-rg.json
@@ -233,23 +233,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"


### PR DESCRIPTION
Addresses #3340

## Proposed Changes
This PR updates the deployment templates (`template-with-new-rg.json`) of the bots inside [samples/python](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/python) folder to use the new Azure resource `Azure Bot` instead of the Bot Channel Registration.

### Detailed Changes
Updated the ARM templates of the following samples:
- 02.echo-bot
- 03.welcome-user
- 05.multi-turn-prompt
- 06.using-cards
- 07.using-adaptive-cards
- 08.suggested-actions
- 11.qnamaker
- 13.core-bot
- 14.nlp-with-dispatch
- 15.handling-attachments
- 16.proactive-messages
- 17.multilingual-bot
- 18.bot-authentication
- 19.custom-dialogs
- 21.corebot-app-insights
- 23.facebook-events
- 24.bot-authentication-msgraph
- 42.scaleout
- 43.complex-dialog
- 44.prompt-for-user-input
- 45.state-management
- 46.teams-auth
- 47.inspection
- 49.qnamaker-all-features
- 50.teams-messaging-extension-search
- 51.teams-messaging-extensions-action
- 52.teams-messaging-extensions-search-auth-config
- 53.teams-messaging-extensions-action-preview
- 54.teams-task-module
- 55.teams-link-unfurling
- 56.teams-file-upload
- 57.teams-conversation-bot
- 58.teams-start-thread-in-channel
- 60.slack-adapter
- 80.skills-simple-bot-to-bot/echo-skill-bot
- 80.skills-simple-bot-to-bot/simple-root-bot
- 81.skills-skilldialog/dialog-root-bot
- 81.skills-skilldialog/dialog-skill-bot
- wip/python_quart/02.echo-bot
- wip/python_quart/13.core-bot
- wip/python_tornado/02.echo-bot
- wip/python_tornado/13.core-bot

## Testing
The following images show two bot samples working on azure, the first being the `55.teams-link-unfurling` and the second the `42.scaleout`.
![imagen](https://user-images.githubusercontent.com/62260472/130279342-9eef7716-efbb-490f-a150-7f1f8d8acb51.png)
