### PR TITLE
[#3340] Deployment ARM templates update - Migration folder

### DIFF
--- a/Migration/Dispatch/csharp/14.nlp-with-dispatch/DeploymentTemplates/template-with-new-rg.json
+++ b/Migration/Dispatch/csharp/14.nlp-with-dispatch/DeploymentTemplates/template-with-new-rg.json
@@ -163,13 +163,13 @@
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
-								"iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
                                 "luisAppIds": [],
-								"schemaTransformationVersion": "1.3",
-								"isCmekEnabled": false,
-								"isIsolated": false
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/Migration/Dispatch/csharp/14.nlp-with-dispatch/DeploymentTemplates/template-with-new-rg.json
+++ b/Migration/Dispatch/csharp/14.nlp-with-dispatch/DeploymentTemplates/template-with-new-rg.json
@@ -152,23 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+								"iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+								"schemaTransformationVersion": "1.3",
+								"isCmekEnabled": false,
+								"isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/Migration/Dispatch/csharp/14.nlp-with-dispatch/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/Migration/Dispatch/csharp/14.nlp-with-dispatch/DeploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+				"iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+				"schemaTransformationVersion": "1.3",
+				"isCmekEnabled": false,
+				"isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/Migration/Dispatch/csharp/14.nlp-with-dispatch/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/Migration/Dispatch/csharp/14.nlp-with-dispatch/DeploymentTemplates/template-with-preexisting-rg.json
@@ -139,13 +139,13 @@
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
-				"iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
                 "luisAppIds": [],
-				"schemaTransformationVersion": "1.3",
-				"isCmekEnabled": false,
-				"isIsolated": false
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/Migration/Dispatch/javascript/14.nlp-with-dispatch/deploymentTemplates/template-with-new-rg.json
+++ b/Migration/Dispatch/javascript/14.nlp-with-dispatch/deploymentTemplates/template-with-new-rg.json
@@ -163,13 +163,13 @@
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
-								"iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
                                 "luisAppIds": [],
-								"schemaTransformationVersion": "1.3",
-								"isCmekEnabled": false,
-								"isIsolated": false
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/Migration/Dispatch/javascript/14.nlp-with-dispatch/deploymentTemplates/template-with-new-rg.json
+++ b/Migration/Dispatch/javascript/14.nlp-with-dispatch/deploymentTemplates/template-with-new-rg.json
@@ -152,23 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+								"iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+								"schemaTransformationVersion": "1.3",
+								"isCmekEnabled": false,
+								"isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/Migration/Dispatch/javascript/14.nlp-with-dispatch/deploymentTemplates/template-with-preexisting-rg.json
+++ b/Migration/Dispatch/javascript/14.nlp-with-dispatch/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+				"iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+				"schemaTransformationVersion": "1.3",
+				"isCmekEnabled": false,
+				"isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/Migration/Dispatch/javascript/14.nlp-with-dispatch/deploymentTemplates/template-with-preexisting-rg.json
+++ b/Migration/Dispatch/javascript/14.nlp-with-dispatch/deploymentTemplates/template-with-preexisting-rg.json
@@ -139,13 +139,13 @@
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
-				"iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
                 "luisAppIds": [],
-				"schemaTransformationVersion": "1.3",
-				"isCmekEnabled": false,
-				"isIsolated": false
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/Migration/MigrationV3V4/Node/Skills/v4-root-bot/deploymentTemplates/template-with-new-rg.json
+++ b/Migration/MigrationV3V4/Node/Skills/v4-root-bot/deploymentTemplates/template-with-new-rg.json
@@ -163,13 +163,13 @@
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
-								"iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
                                 "luisAppIds": [],
-								"schemaTransformationVersion": "1.3",
-								"isCmekEnabled": false,
-								"isIsolated": false
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/Migration/MigrationV3V4/Node/Skills/v4-root-bot/deploymentTemplates/template-with-new-rg.json
+++ b/Migration/MigrationV3V4/Node/Skills/v4-root-bot/deploymentTemplates/template-with-new-rg.json
@@ -152,23 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+								"iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+								"schemaTransformationVersion": "1.3",
+								"isCmekEnabled": false,
+								"isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/Migration/MigrationV3V4/Node/Skills/v4-root-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/Migration/MigrationV3V4/Node/Skills/v4-root-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+				"iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+				"schemaTransformationVersion": "1.3",
+				"isCmekEnabled": false,
+				"isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/Migration/MigrationV3V4/Node/Skills/v4-root-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/Migration/MigrationV3V4/Node/Skills/v4-root-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -139,13 +139,13 @@
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
-				"iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
                 "luisAppIds": [],
-				"schemaTransformationVersion": "1.3",
-				"isCmekEnabled": false,
-				"isIsolated": false
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/Migration/MigrationV3V4/Node/core-MultiDialogs-v4/deploymentTemplates/template-with-new-rg.json
+++ b/Migration/MigrationV3V4/Node/core-MultiDialogs-v4/deploymentTemplates/template-with-new-rg.json
@@ -163,13 +163,13 @@
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
-								"iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
                                 "luisAppIds": [],
-								"schemaTransformationVersion": "1.3",
-								"isCmekEnabled": false,
-								"isIsolated": false
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/Migration/MigrationV3V4/Node/core-MultiDialogs-v4/deploymentTemplates/template-with-new-rg.json
+++ b/Migration/MigrationV3V4/Node/core-MultiDialogs-v4/deploymentTemplates/template-with-new-rg.json
@@ -152,23 +152,24 @@
                             }
                         },
                         {
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2021-03-01",
                             "type": "Microsoft.BotService/botServices",
                             "name": "[parameters('botId')]",
                             "location": "global",
-                            "kind": "bot",
+                            "kind": "azurebot",
                             "sku": {
                                 "name": "[parameters('botSku')]"
                             },
                             "properties": {
                                 "name": "[parameters('botId')]",
                                 "displayName": "[parameters('botId')]",
+								"iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                                 "endpoint": "[variables('botEndpoint')]",
                                 "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
+                                "luisAppIds": [],
+								"schemaTransformationVersion": "1.3",
+								"isCmekEnabled": false,
+								"isIsolated": false
                             },
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"

--- a/Migration/MigrationV3V4/Node/core-MultiDialogs-v4/deploymentTemplates/template-with-preexisting-rg.json
+++ b/Migration/MigrationV3V4/Node/core-MultiDialogs-v4/deploymentTemplates/template-with-preexisting-rg.json
@@ -128,23 +128,24 @@
             }
         },
         {
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2021-03-01",
             "type": "Microsoft.BotService/botServices",
             "name": "[parameters('botId')]",
             "location": "global",
-            "kind": "bot",
+            "kind": "azurebot",
             "sku": {
                 "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
+				"iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+                "luisAppIds": [],
+				"schemaTransformationVersion": "1.3",
+				"isCmekEnabled": false,
+				"isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"

--- a/Migration/MigrationV3V4/Node/core-MultiDialogs-v4/deploymentTemplates/template-with-preexisting-rg.json
+++ b/Migration/MigrationV3V4/Node/core-MultiDialogs-v4/deploymentTemplates/template-with-preexisting-rg.json
@@ -139,13 +139,13 @@
             "properties": {
                 "name": "[parameters('botId')]",
                 "displayName": "[parameters('botId')]",
-				"iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
                 "luisAppIds": [],
-				"schemaTransformationVersion": "1.3",
-				"isCmekEnabled": false,
-				"isIsolated": false
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"


### PR DESCRIPTION
Addresses #3340

## Proposed Changes
This PR updates the deployment templates of the bots inside [Migration](https://github.com/microsoft/BotBuilder-Samples/tree/main/Migration) folder to use the new Azure resource `Azure Bot` instead of the Bot Channel Registration.

### Detailed Changes
Updated the ARM templates of the following samples:
- Dispatch\csharp\14.nlp-with-dispatch
- Dispatch\javascript\14.nlp-with-dispatch
- MigrationV3V4\Node\Skills\v4-root-bot
- MigrationV3V4\Node\core-MultiDialogs-v4

## Testing
These images show some of the java_springboot samples deployed in Azure and working as expected.
![image](https://user-images.githubusercontent.com/44245136/130465570-ded17dff-b8b0-4797-aa97-c7f0a48c385b.png)
![image](https://user-images.githubusercontent.com/44245136/130465594-925b7075-37a0-4918-9187-1753e4baa408.png)