### PR TITLE
[#3307] Migrate C# samples to Cloud Adapter - Samples folder

### DIFF
--- a/samples/csharp_dotnetcore/14.nlp-with-orchestrator/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/14.nlp-with-orchestrator/AdapterWithErrorHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Net.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
@@ -10,10 +11,10 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger, ConversationState conversationState = null)
-            : base(configuration, logger)
+        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState = null)
+            : base(configuration, httpClientFactory, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/samples/csharp_dotnetcore/14.nlp-with-orchestrator/Startup.cs
+++ b/samples/csharp_dotnetcore/14.nlp-with-orchestrator/Startup.cs
@@ -26,7 +26,7 @@ namespace Microsoft.BotBuilderSamples
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Latest);
+            services.AddHttpClient().AddMvc().SetCompatibilityVersion(CompatibilityVersion.Latest);
 
             // Create the Bot Framework Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();

--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/AdapterWithErrorHandler.cs
@@ -9,10 +9,10 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger)
-            : base(configuration, logger)
+        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger)
+            : base(configuration, httpClientFactory, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/Bots/TeamsConversationBot.cs
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/Bots/TeamsConversationBot.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.Teams;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
@@ -147,15 +148,16 @@ namespace Microsoft.BotBuilderSamples.Bots
                     TenantId = turnContext.Activity.Conversation.TenantId,
                 };
 
-                await ((BotFrameworkAdapter)turnContext.Adapter).CreateConversationAsync(
+                await ((CloudAdapter)turnContext.Adapter).CreateConversationAsync(
+                    credentials.MicrosoftAppId,
                     teamsChannelId,
                     serviceUrl,
-                    credentials,
+                    credentials.OAuthScope,
                     conversationParameters,
                     async (t1, c1) =>
                     {
                         conversationReference = t1.Activity.GetConversationReference();
-                        await ((BotFrameworkAdapter)turnContext.Adapter).ContinueConversationAsync(
+                        await ((CloudAdapter)turnContext.Adapter).ContinueConversationAsync(
                             _appId,
                             conversationReference,
                             async (t2, c2) =>

--- a/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/AdapterWithErrorHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Net.Http;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Extensions.Configuration;
@@ -8,10 +9,10 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger)
-            : base(configuration, logger)
+        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger)
+            : base(configuration, httpClientFactory, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/Bots/TeamsStartNewThreadInTeam.cs
+++ b/samples/csharp_dotnetcore/58.teams-start-new-thread-in-channel/Bots/TeamsStartNewThreadInTeam.cs
@@ -4,6 +4,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.Teams;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
@@ -39,10 +40,11 @@ namespace Microsoft.BotBuilderSamples.Bots
 
             ConversationReference conversationReference = null;
 
-            await ((BotFrameworkAdapter)turnContext.Adapter).CreateConversationAsync(
+            await ((CloudAdapter)turnContext.Adapter).CreateConversationAsync(
+                credentials.MicrosoftAppId,
                 teamsChannelId,
                 serviceUrl,
-                credentials,
+                credentials.OAuthScope,
                 conversationParameters,
                 (t, ct) =>
                 {
@@ -52,7 +54,7 @@ namespace Microsoft.BotBuilderSamples.Bots
                 cancellationToken);
 
 
-            await ((BotFrameworkAdapter)turnContext.Adapter).ContinueConversationAsync(
+            await ((CloudAdapter)turnContext.Adapter).ContinueConversationAsync(
                 _appId,
                 conversationReference,
                 async (t, ct) =>

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/SkillAdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/SkillAdapterWithErrorHandler.cs
@@ -8,17 +8,16 @@ using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples.EchoSkillBot
 {
-    public class SkillAdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class SkillAdapterWithErrorHandler : CloudAdapter
     {
         private readonly ILogger _logger;
 
-        public SkillAdapterWithErrorHandler(IConfiguration configuration, ICredentialProvider credentialProvider, AuthenticationConfiguration authConfig, ILogger<BotFrameworkHttpAdapter> logger)
-            : base(configuration, credentialProvider, authConfig, logger: logger)
+        public SkillAdapterWithErrorHandler(BotFrameworkAuthentication botFrameworkAuthentication, ILogger<IBotFrameworkHttpAdapter> logger)
+            : base(botFrameworkAuthentication, logger)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             OnTurnError = HandleTurnError;

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/Startup.cs
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/EchoSkillBot/Startup.cs
@@ -31,6 +31,8 @@ namespace Microsoft.BotBuilderSamples.EchoSkillBot
                 ClaimsValidator = new AllowedCallersClaimsValidator(new List<string>(sp.GetService<IConfiguration>().GetSection("AllowedCallers").Get<string[]>()))
             });
 
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+
             // Create the Bot Framework Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, SkillAdapterWithErrorHandler>();
 

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/AdapterWithErrorHandler.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
@@ -17,21 +16,21 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples.SimpleRootBot
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
         private readonly IConfiguration _configuration;
         private readonly ConversationState _conversationState;
         private readonly ILogger _logger;
-        private readonly SkillHttpClient _skillClient;
+        private readonly BotFrameworkClient _botFrameworkClient;
         private readonly SkillsConfiguration _skillsConfig;
 
-        public AdapterWithErrorHandler(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger, ConversationState conversationState, SkillHttpClient skillClient = null, SkillsConfiguration skillsConfig = null)
-            : base(configuration, logger)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication botFrameworkAuthentication, IConfiguration configuration, ILogger<CloudAdapter> logger, ConversationState conversationState, SkillsConfiguration skillsConfig = null)
+            : base(botFrameworkAuthentication, logger)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _skillClient = skillClient;
+            _botFrameworkClient = botFrameworkAuthentication.CreateBotFrameworkClient();
             _skillsConfig = skillsConfig;
 
             OnTurnError = HandleTurnError;
@@ -74,7 +73,7 @@ namespace Microsoft.BotBuilderSamples.SimpleRootBot
 
         private async Task EndSkillConversationAsync(ITurnContext turnContext)
         {
-            if (_skillClient == null || _skillsConfig == null)
+            if (_botFrameworkClient == null || _skillsConfig == null)
             {
                 return;
             }
@@ -95,7 +94,7 @@ namespace Microsoft.BotBuilderSamples.SimpleRootBot
                     endOfConversation.ApplyConversationReference(turnContext.Activity.GetConversationReference(), true);
 
                     await _conversationState.SaveChangesAsync(turnContext, true);
-                    await _skillClient.PostActivityAsync(botId, activeSkill, _skillsConfig.SkillHostEndpoint, (Activity)endOfConversation, CancellationToken.None);
+                    await _botFrameworkClient.PostActivityAsync(botId, activeSkill.AppId, activeSkill.SkillEndpoint, _skillsConfig.SkillHostEndpoint, endOfConversation.Conversation.Id, (Activity)endOfConversation, CancellationToken.None);
                 }
             }
             catch (Exception ex)

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/AdapterWithErrorHandler.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples.SimpleRootBot
         private readonly BotFrameworkClient _botFrameworkClient;
         private readonly SkillsConfiguration _skillsConfig;
 
-        public AdapterWithErrorHandler(BotFrameworkAuthentication botFrameworkAuthentication, IConfiguration configuration, ILogger<CloudAdapter> logger, ConversationState conversationState, SkillsConfiguration skillsConfig = null)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication botFrameworkAuthentication, IConfiguration configuration, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState, SkillsConfiguration skillsConfig = null)
             : base(botFrameworkAuthentication, logger)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/Controllers/BotController.cs
@@ -15,10 +15,10 @@ namespace Microsoft.BotBuilderSamples.SimpleRootBot.Controllers
     [ApiController]
     public class BotController : ControllerBase
     {
-        private readonly BotFrameworkHttpAdapter _adapter;
+        private readonly IBotFrameworkHttpAdapter _adapter;
         private readonly IBot _bot;
 
-        public BotController(BotFrameworkHttpAdapter adapter, IBot bot)
+        public BotController(IBotFrameworkHttpAdapter adapter, IBot bot)
         {
             _adapter = adapter;
             _bot = bot;

--- a/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/Startup.cs
+++ b/samples/csharp_dotnetcore/80.skills-simple-bot-to-bot/SimpleRootBot/Startup.cs
@@ -29,12 +29,15 @@ namespace Microsoft.BotBuilderSamples.SimpleRootBot
             services.AddSingleton<SkillsConfiguration>();
 
             // Register AuthConfiguration to enable custom claim validation.
-            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new Microsoft.BotBuilderSamples.SimpleRootBot.Authentication.AllowedSkillsClaimsValidator(sp.GetService<SkillsConfiguration>()) });
+            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new Authentication.AllowedSkillsClaimsValidator(sp.GetService<SkillsConfiguration>()) });
+
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
 
             // Register the Bot Framework Adapter with error handling enabled.
             // Note: some classes use the base BotAdapter so we add an extra registration that pulls the same instance.
-            services.AddSingleton<BotFrameworkHttpAdapter, AdapterWithErrorHandler>();
-            services.AddSingleton<BotAdapter>(sp => sp.GetService<BotFrameworkHttpAdapter>());
+            services.AddSingleton<CloudAdapter, AdapterWithErrorHandler>();
+            services.AddSingleton<IBotFrameworkHttpAdapter>(sp => sp.GetService<CloudAdapter>());
+            services.AddSingleton<BotAdapter>(sp => sp.GetService<CloudAdapter>());
 
             // Register the skills client and skills request handler.
             services.AddSingleton<SkillConversationIdFactoryBase, SkillConversationIdFactory>();

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/AdapterWithErrorHandler.cs
@@ -26,7 +26,7 @@ namespace Microsoft.BotBuilderSamples.DialogRootBot
         private readonly BotFrameworkClient _botFrameworkClient;
         private readonly SkillsConfiguration _skillsConfig;
 
-        public AdapterWithErrorHandler(BotFrameworkAuthentication botFrameworkAuthentication, IConfiguration configuration, ILogger<CloudAdapter> logger, ConversationState conversationState, SkillsConfiguration skillsConfig = null)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication botFrameworkAuthentication, IConfiguration configuration, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState, SkillsConfiguration skillsConfig = null)
             : base(botFrameworkAuthentication, logger)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/AdapterWithErrorHandler.cs
@@ -18,21 +18,21 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples.DialogRootBot
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
         private readonly IConfiguration _configuration;
         private readonly ConversationState _conversationState;
         private readonly ILogger _logger;
-        private readonly SkillHttpClient _skillClient;
+        private readonly BotFrameworkClient _botFrameworkClient;
         private readonly SkillsConfiguration _skillsConfig;
 
-        public AdapterWithErrorHandler(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger, ConversationState conversationState, SkillHttpClient skillClient = null, SkillsConfiguration skillsConfig = null)
-            : base(configuration, logger)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication botFrameworkAuthentication, IConfiguration configuration, ILogger<CloudAdapter> logger, ConversationState conversationState, SkillsConfiguration skillsConfig = null)
+            : base(botFrameworkAuthentication, logger)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _skillClient = skillClient;
+            _botFrameworkClient = botFrameworkAuthentication.CreateBotFrameworkClient();
             _skillsConfig = skillsConfig;
 
             OnTurnError = HandleTurnError;
@@ -76,7 +76,7 @@ namespace Microsoft.BotBuilderSamples.DialogRootBot
 
         private async Task EndSkillConversationAsync(ITurnContext turnContext)
         {
-            if (_skillClient == null || _skillsConfig == null)
+            if (_botFrameworkClient == null || _skillsConfig == null)
             {
                 return;
             }
@@ -96,7 +96,7 @@ namespace Microsoft.BotBuilderSamples.DialogRootBot
                     endOfConversation.ApplyConversationReference(turnContext.Activity.GetConversationReference(), true);
 
                     await _conversationState.SaveChangesAsync(turnContext, true);
-                    await _skillClient.PostActivityAsync(botId, activeSkill, _skillsConfig.SkillHostEndpoint, (Activity)endOfConversation, CancellationToken.None);
+                    await _botFrameworkClient.PostActivityAsync(botId, activeSkill.AppId, activeSkill.SkillEndpoint, _skillsConfig.SkillHostEndpoint, endOfConversation.Conversation.Id, (Activity)endOfConversation, CancellationToken.None);
                 }
             }
             catch (Exception ex)

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/Controllers/BotController.cs
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/Controllers/BotController.cs
@@ -18,7 +18,7 @@ namespace Microsoft.BotBuilderSamples.DialogRootBot.Controllers
         private readonly IBotFrameworkHttpAdapter _adapter;
         private readonly IBot _bot;
 
-        public BotController(BotFrameworkHttpAdapter adapter, IBot bot)
+        public BotController(IBotFrameworkHttpAdapter adapter, IBot bot)
         {
             _adapter = adapter;
             _bot = bot;

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/Middleware/LoggerMiddleware.cs
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/Middleware/LoggerMiddleware.cs
@@ -17,9 +17,9 @@ namespace Microsoft.BotBuilderSamples.DialogRootBot.Middleware
     /// </summary>
     public class LoggerMiddleware : IMiddleware
     {
-        private readonly ILogger<BotFrameworkHttpAdapter> _logger;
+        private readonly ILogger<IBotFrameworkHttpAdapter> _logger;
 
-        public LoggerMiddleware(ILogger<BotFrameworkHttpAdapter> logger)
+        public LoggerMiddleware(ILogger<IBotFrameworkHttpAdapter> logger)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/Startup.cs
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogRootBot/Startup.cs
@@ -39,13 +39,16 @@ namespace Microsoft.BotBuilderSamples.DialogRootBot
             services.AddSingleton<SkillsConfiguration>();
 
             // Register AuthConfiguration to enable custom claim validation.
-            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new Microsoft.BotBuilderSamples.DialogRootBot.Authentication.AllowedSkillsClaimsValidator(sp.GetService<SkillsConfiguration>()) });
+            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new Authentication.AllowedSkillsClaimsValidator(sp.GetService<SkillsConfiguration>()) });
+
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
 
             // Register the Bot Framework Adapter with error handling enabled.
             // Note: some classes expect a BotAdapter and some expect a BotFrameworkHttpAdapter, so
             // register the same adapter instance for both types.
-            services.AddSingleton<BotFrameworkHttpAdapter, AdapterWithErrorHandler>();
-            services.AddSingleton<BotAdapter>(sp => sp.GetService<BotFrameworkHttpAdapter>());
+            services.AddSingleton<CloudAdapter, AdapterWithErrorHandler>();
+            services.AddSingleton<IBotFrameworkHttpAdapter>(sp => sp.GetService<CloudAdapter>());
+            services.AddSingleton<BotAdapter>(sp => sp.GetService<CloudAdapter>());
 
             // Register the skills conversation ID factory, the client and the request handler.
             services.AddSingleton<SkillConversationIdFactoryBase, SkillConversationIdFactory>();

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/SkillAdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/SkillAdapterWithErrorHandler.cs
@@ -13,13 +13,13 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples.DialogSkillBot
 {
-    public class SkillAdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class SkillAdapterWithErrorHandler : CloudAdapter
     {
         private readonly ConversationState _conversationState;
         private readonly ILogger _logger;
 
-        public SkillAdapterWithErrorHandler(IConfiguration configuration, ICredentialProvider credentialProvider, AuthenticationConfiguration authConfig, ILogger<BotFrameworkHttpAdapter> logger, ConversationState conversationState = default)
-            : base(configuration, credentialProvider, authConfig, logger: logger)
+        public SkillAdapterWithErrorHandler(BotFrameworkAuthentication botFrameworkAuthentication, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState = default)
+            : base(botFrameworkAuthentication, logger)
         {
             _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));

--- a/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/Startup.cs
+++ b/samples/csharp_dotnetcore/81.skills-skilldialog/DialogSkillBot/Startup.cs
@@ -39,7 +39,9 @@ namespace Microsoft.BotBuilderSamples.DialogSkillBot
             {
                 ClaimsValidator = new AllowedCallersClaimsValidator(new List<string>(sp.GetService<IConfiguration>().GetSection("AllowedCallers").Get<string[]>()))
             });
-            
+
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+
             // Create the Bot Framework Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, SkillAdapterWithErrorHandler>();
 


### PR DESCRIPTION
Addresses #3307

## Description
This PR migrates the remaining C# bots in the samples folder from _BotFrameworkAdapter_ to _CloudAdapter_.

### Detailed Changes
Updated the following samples to use Cloud Adapter:
- 14.nlp-with-orchestrator
- 58.teams-start-new-thread-in-channel
- 57.teams-conversation-bot
- 80.skills-simple-bot-to-bot/EchoSkillBot
- 80.skills-simple-bot-to-bot/SimpleRootBot
- 81.skills-skilldialog/DialogRootBot
- 81.skills-skilldialog/DialogSkillBot

## Testing
These images show some of the migrated bots working as expected.
![image](https://user-images.githubusercontent.com/44245136/133830350-46bd7094-b10d-4133-a3c4-4c8cb251ef59.png)