### PR TITLE
[#3447] Samples are missing required MsTeamsChannel in Deployment templates - new RG templates

### DIFF
--- a/experimental/composer-samples/csharp_dotnetcore/projects/51.teams-messaging-extensions-action/teamsmessagingextensionsaction/Scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/experimental/composer-samples/csharp_dotnetcore/projects/51.teams-messaging-extensions-action/teamsmessagingextensionsaction/Scripts/DeploymentTemplates/template-with-new-rg.json
@@ -174,6 +174,22 @@
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/experimental/composer-samples/csharp_dotnetcore/projects/57.teams-conversation-bot/teams-conversation-bot/Scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/experimental/composer-samples/csharp_dotnetcore/projects/57.teams-conversation-bot/teams-conversation-bot/Scripts/DeploymentTemplates/template-with-new-rg.json
@@ -174,6 +174,22 @@
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/experimental/teams-sso/csharp_dotnetcore/DeploymentTemplates/template-with-new-rg.json
+++ b/experimental/teams-sso/csharp_dotnetcore/DeploymentTemplates/template-with-new-rg.json
@@ -174,6 +174,22 @@
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/csharp_dotnetcore/46.teams-auth/DeploymentTemplates/template-with-new-rg.json
+++ b/samples/csharp_dotnetcore/46.teams-auth/DeploymentTemplates/template-with-new-rg.json
@@ -174,6 +174,22 @@
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/java_springboot/46.teams-auth/deploymentTemplates/template-with-new-rg.json
+++ b/samples/java_springboot/46.teams-auth/deploymentTemplates/template-with-new-rg.json
@@ -282,6 +282,22 @@
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/java_springboot/50.teams-messaging-extensions-search/deploymentTemplates/template-with-new-rg.json
+++ b/samples/java_springboot/50.teams-messaging-extensions-search/deploymentTemplates/template-with-new-rg.json
@@ -282,6 +282,22 @@
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/java_springboot/51.teams-messaging-extensions-action/deploymentTemplates/template-with-new-rg.json
+++ b/samples/java_springboot/51.teams-messaging-extensions-action/deploymentTemplates/template-with-new-rg.json
@@ -282,6 +282,22 @@
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/deploymentTemplates/template-with-new-rg.json
+++ b/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/deploymentTemplates/template-with-new-rg.json
@@ -282,6 +282,22 @@
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/java_springboot/53.teams-messaging-extensions-action-preview/deploymentTemplates/template-with-new-rg.json
+++ b/samples/java_springboot/53.teams-messaging-extensions-action-preview/deploymentTemplates/template-with-new-rg.json
@@ -282,6 +282,22 @@
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/java_springboot/54.teams-task-module/deploymentTemplates/template-with-new-rg.json
+++ b/samples/java_springboot/54.teams-task-module/deploymentTemplates/template-with-new-rg.json
@@ -282,6 +282,22 @@
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/java_springboot/55.teams-link-unfurling/deploymentTemplates/template-with-new-rg.json
+++ b/samples/java_springboot/55.teams-link-unfurling/deploymentTemplates/template-with-new-rg.json
@@ -282,6 +282,22 @@
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/java_springboot/56.teams-file-upload/deploymentTemplates/template-with-new-rg.json
+++ b/samples/java_springboot/56.teams-file-upload/deploymentTemplates/template-with-new-rg.json
@@ -282,6 +282,22 @@
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/java_springboot/57.teams-conversation-bot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/java_springboot/57.teams-conversation-bot/deploymentTemplates/template-with-new-rg.json
@@ -282,6 +282,22 @@
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/java_springboot/58.teams-start-new-thread-in-channel/deploymentTemplates/template-with-new-rg.json
+++ b/samples/java_springboot/58.teams-start-new-thread-in-channel/deploymentTemplates/template-with-new-rg.json
@@ -282,6 +282,22 @@
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/javascript_nodejs/46.teams-auth/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/46.teams-auth/deploymentTemplates/template-with-new-rg.json
@@ -174,6 +174,22 @@
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/typescript_nodejs/50.teams-messaging-extensions-search/deploymentTemplates/template-with-new-rg.json
+++ b/samples/typescript_nodejs/50.teams-messaging-extensions-search/deploymentTemplates/template-with-new-rg.json
@@ -174,6 +174,22 @@
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/typescript_nodejs/51.teams-messaging-extensions-action/deploymentTemplates/template-with-new-rg.json
+++ b/samples/typescript_nodejs/51.teams-messaging-extensions-action/deploymentTemplates/template-with-new-rg.json
@@ -174,6 +174,22 @@
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}

--- a/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/deploymentTemplates/template-with-new-rg.json
+++ b/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/deploymentTemplates/template-with-new-rg.json
@@ -174,6 +174,22 @@
                             "dependsOn": [
                                 "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
+                        },
+                        {
+                            "type": "Microsoft.BotService/botServices/channels",
+                            "apiVersion": "2021-03-01",
+                            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.BotService/botServices/', variables('webAppName'))]"
+                            ],
+                            "properties": {
+                                "properties": {
+                                    "enableCalling": false,
+                                    "isEnabled": true
+                                },
+                                "channelName": "MsTeamsChannel"
+                            }
                         }
                     ],
                     "outputs": {}


### PR DESCRIPTION
Addresses #3447

## Description
This PR updates the ARM templates of Teams bots to include the connection with the MSTeamsChannel as part of the deployment.

### Detailed Changes
Updated the `template-with-new-rg.json` of the following samples:

**samples folder**
- csharp_dotnetcore/46.teams-auth
- java_springboot/46.teams-auth
- java_springboot/50.teams-messaging-extensions-search
- java_springboot/51.teams-messaging-extensions-action
- java_springboot/52.teams-messaging-extensions-search-auth-config
- java_springboot/53.teams-messaging-extensions-action-preview
- java_springboot/54.teams-task-module
- java_springboot/55.teams-link-unfurling
- java_springboot/56.teams-file-upload
- java_springboot/57.teams-conversation-bot
- java_springboot/58.teams-start-new-thread-in-channel
- javascript_nodejs/46.teams-auth/deploymentTemplates
- typescript_nodejs/50.teams-messaging-extensions-search
- typescript_nodejs/51.teams-messaging-extensions-action
- typescript_nodejs/58.teams-start-new-thread-in-channel

**experimental folder**
- composer-samples/csharp_dotnetcore/projects/51.teams-messaging-extensions-action
- composer-samples/csharp_dotnetcore/projects/57.teams-conversation-bot
- experimental/teams-sso

## Testing
These images show some of the tested bots after deploying them to Azure.
![image](https://user-images.githubusercontent.com/44245136/135496152-1ca3ed45-a824-4221-b7ca-b0a65d6320b6.png)
![image](https://user-images.githubusercontent.com/44245136/135496227-2804471b-ff50-469e-ae69-359b7a5dfa55.png)

