### PR TITLE
[#3447] Samples are missing required MsTeamsChannel in Deployment templates - preexisting RG templates

### DIFF
--- a/experimental/composer-samples/csharp_dotnetcore/projects/51.teams-messaging-extensions-action/teamsmessagingextensionsaction/Scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/experimental/composer-samples/csharp_dotnetcore/projects/51.teams-messaging-extensions-action/teamsmessagingextensionsaction/Scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -306,6 +306,22 @@
       ]
     },
     {
+      "type": "Microsoft.BotService/botServices/channels",
+      "apiVersion": "2021-03-01",
+      "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+      "location": "global",
+      "dependsOn": [
+          "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+      ],
+      "properties": {
+          "properties": {
+              "enableCalling": false,
+              "isEnabled": true
+          },
+          "channelName": "MsTeamsChannel"
+      }
+    },
+    {
       "comments": "app insights",
       "type": "Microsoft.Insights/components",
       "kind": "web",

--- a/experimental/composer-samples/csharp_dotnetcore/projects/57.teams-conversation-bot/teams-conversation-bot/Scripts/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/experimental/composer-samples/csharp_dotnetcore/projects/57.teams-conversation-bot/teams-conversation-bot/Scripts/DeploymentTemplates/template-with-preexisting-rg.json
@@ -306,6 +306,22 @@
       ]
     },
     {
+      "type": "Microsoft.BotService/botServices/channels",
+      "apiVersion": "2021-03-01",
+      "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+      "location": "global",
+      "dependsOn": [
+          "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+      ],
+      "properties": {
+          "properties": {
+              "enableCalling": false,
+              "isEnabled": true
+          },
+          "channelName": "MsTeamsChannel"
+      }
+    },
+    {
       "comments": "app insights",
       "type": "Microsoft.Insights/components",
       "kind": "web",

--- a/experimental/teams-sso/csharp_dotnetcore/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/experimental/teams-sso/csharp_dotnetcore/DeploymentTemplates/template-with-preexisting-rg.json
@@ -150,6 +150,22 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
             ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
         }
     ]
 }

--- a/samples/csharp_dotnetcore/46.teams-auth/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/46.teams-auth/DeploymentTemplates/template-with-preexisting-rg.json
@@ -150,6 +150,22 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
             ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
         }
     ]
 }

--- a/samples/java_springboot/46.teams-auth/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/46.teams-auth/deploymentTemplates/template-with-preexisting-rg.json
@@ -255,6 +255,22 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
             ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
         }
     ]
 }

--- a/samples/java_springboot/50.teams-messaging-extensions-search/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/50.teams-messaging-extensions-search/deploymentTemplates/template-with-preexisting-rg.json
@@ -255,6 +255,22 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
             ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
         }
     ]
 }

--- a/samples/java_springboot/51.teams-messaging-extensions-action/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/51.teams-messaging-extensions-action/deploymentTemplates/template-with-preexisting-rg.json
@@ -255,6 +255,22 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
             ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
         }
     ]
 }

--- a/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/deploymentTemplates/template-with-preexisting-rg.json
@@ -255,6 +255,22 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
             ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
         }
     ]
 }

--- a/samples/java_springboot/53.teams-messaging-extensions-action-preview/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/53.teams-messaging-extensions-action-preview/deploymentTemplates/template-with-preexisting-rg.json
@@ -255,6 +255,22 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
             ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
         }
     ]
 }

--- a/samples/java_springboot/54.teams-task-module/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/54.teams-task-module/deploymentTemplates/template-with-preexisting-rg.json
@@ -255,6 +255,22 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
             ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
         }
     ]
 }

--- a/samples/java_springboot/55.teams-link-unfurling/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/55.teams-link-unfurling/deploymentTemplates/template-with-preexisting-rg.json
@@ -255,6 +255,22 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
             ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
         }
     ]
 }

--- a/samples/java_springboot/56.teams-file-upload/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/56.teams-file-upload/deploymentTemplates/template-with-preexisting-rg.json
@@ -255,6 +255,22 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
             ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
         }
     ]
 }

--- a/samples/java_springboot/57.teams-conversation-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/57.teams-conversation-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -255,6 +255,22 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
             ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
         }
     ]
 }

--- a/samples/java_springboot/58.teams-start-new-thread-in-channel/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/java_springboot/58.teams-start-new-thread-in-channel/deploymentTemplates/template-with-preexisting-rg.json
@@ -255,6 +255,22 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
             ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
         }
     ]
 }

--- a/samples/javascript_nodejs/46.teams-auth/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/46.teams-auth/deploymentTemplates/template-with-preexisting-rg.json
@@ -150,6 +150,22 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
             ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
         }
     ]
 }

--- a/samples/typescript_nodejs/50.teams-messaging-extensions-search/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/typescript_nodejs/50.teams-messaging-extensions-search/deploymentTemplates/template-with-preexisting-rg.json
@@ -150,6 +150,22 @@
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
       ]
+    },
+    {
+      "type": "Microsoft.BotService/botServices/channels",
+      "apiVersion": "2021-03-01",
+      "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+      "location": "global",
+      "dependsOn": [
+          "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+      ],
+      "properties": {
+          "properties": {
+              "enableCalling": false,
+              "isEnabled": true
+          },
+          "channelName": "MsTeamsChannel"
+      }
     }
   ]
 }

--- a/samples/typescript_nodejs/51.teams-messaging-extensions-action/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/typescript_nodejs/51.teams-messaging-extensions-action/deploymentTemplates/template-with-preexisting-rg.json
@@ -150,6 +150,22 @@
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
       ]
+    },
+    {
+      "type": "Microsoft.BotService/botServices/channels",
+      "apiVersion": "2021-03-01",
+      "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+      "location": "global",
+      "dependsOn": [
+          "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+      ],
+      "properties": {
+          "properties": {
+              "enableCalling": false,
+              "isEnabled": true
+          },
+          "channelName": "MsTeamsChannel"
+      }
     }
   ]
 }

--- a/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/deploymentTemplates/template-with-preexisting-rg.json
@@ -150,6 +150,22 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
             ]
+        },
+        {
+            "type": "Microsoft.BotService/botServices/channels",
+            "apiVersion": "2021-03-01",
+            "name": "[concat(parameters('botId'), '/MsTeamsChannel')]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.BotService/botServices', parameters('botId'))]"
+            ],
+            "properties": {
+                "properties": {
+                    "enableCalling": false,
+                    "isEnabled": true
+                },
+                "channelName": "MsTeamsChannel"
+            }
         }
     ]
 }


### PR DESCRIPTION
Fixes #3447

## Description
This PR updates the ARM templates of Teams bots to include the connection with the MSTeamsChannel as part of the deployment.

### Detailed Changes
Updated the `template-with-preexisting-rg.json` of the following samples:

**samples folder**
- csharp_dotnetcore/46.teams-auth
- java_springboot/46.teams-auth
- java_springboot/50.teams-messaging-extensions-search
- java_springboot/51.teams-messaging-extensions-action
- java_springboot/52.teams-messaging-extensions-search-auth-config
- java_springboot/53.teams-messaging-extensions-action-preview
- java_springboot/54.teams-task-module
- java_springboot/55.teams-link-unfurling
- java_springboot/56.teams-file-upload
- java_springboot/57.teams-conversation-bot
- java_springboot/58.teams-start-new-thread-in-channel
- javascript_nodejs/46.teams-auth/deploymentTemplates
- typescript_nodejs/50.teams-messaging-extensions-search
- typescript_nodejs/51.teams-messaging-extensions-action
- typescript_nodejs/58.teams-start-new-thread-in-channel

**experimental folder**
- composer-samples/csharp_dotnetcore/projects/51.teams-messaging-extensions-action
- composer-samples/csharp_dotnetcore/projects/57.teams-conversation-bot
- experimental/teams-sso

## Testing
These images show some of the tested bots after deploying them to Azure.
![image](https://user-images.githubusercontent.com/44245136/135496956-34f8c7fa-e34e-4e96-aaa8-04170c2c0f7f.png)