### PR TITLE
Fix django vulnerability

### DIFF
--- a/samples/python/wip/python_django/13.core-bot/requirements.txt
+++ b/samples/python/wip/python_django/13.core-bot/requirements.txt
@@ -1,5 +1,5 @@
 # Django 2.2 before 2.2.10 has a security vulnerability.
-Django~=2.2.10
+Django~=2.2.24
 requests==2.23.0
 botframework-connector>=4.4.0.b1
 botbuilder-schema>=4.4.0.b1


### PR DESCRIPTION
Fixes #minor

## Description

Component Governance: CVE-2021-33571, severity high
https://dev.azure.com/FuseLabs/SDK_v4/_componentGovernance/112465/alert/5974475?typeId=4354877 
In Django 2.2 before 2.2.24, 3.x before 3.1.12, and 3.2 before 3.2.4, URLValidator, validate_ipv4_address, and validate_ipv46_address do not prohibit leading zero characters in octal literals. This may allow a bypass of access control that is based on IP addresses.

**Same fix also covers:**
Component Governance: CVE-2021-31542, severity high
https://dev.azure.com/FuseLabs/SDK_v4/_componentGovernance/112465/alert/4935093?typeId=4354877

Component Governance: CVE-2021-33203, severity high
https://dev.azure.com/FuseLabs/SDK_v4/_componentGovernance/112465/alert/5199196?typeId=4354877

## Proposed Changes
Upgrade django to 2.2.24
