### PR TITLE
fix: Component Governance: CVE-2021-33623

### DIFF
--- a/experimental/generation/generator/package.json
+++ b/experimental/generation/generator/package.json
@@ -1,23 +1,23 @@
 {
-	"name": "root",
-	"private": true,
-	"scripts": {
-		"postinstall": "lerna bootstrap --hoist",
-		"build": "lerna run build",
-		"clean": "lerna run clean",
-		"test": "lerna run build && lerna run test --stream --concurrency 1"
-	},
-	"devDependencies": {
-		"lerna": "^3.22.1"
-	},
-	"dependencies": {
-		"adaptive-expressions": "next",
-		"botbuilder": "next",
-		"botbuilder-ai": "next",
-		"botbuilder-core": "next",
-		"botbuilder-dialogs-adaptive": "next",
-		"botbuilder-dialogs-adaptive-runtime-core": "next",
-		"botbuilder-dialogs-declarative": "next",
-		"botbuilder-lg": "next"
-	}
+  "name": "root",
+  "private": true,
+  "scripts": {
+    "postinstall": "lerna bootstrap --hoist",
+    "build": "lerna run build",
+    "clean": "lerna run clean",
+    "test": "lerna run build && lerna run test --stream --concurrency 1"
+  },
+  "devDependencies": {
+    "lerna": "^4.0.0"
+  },
+  "dependencies": {
+    "adaptive-expressions": "next",
+    "botbuilder": "next",
+    "botbuilder-ai": "next",
+    "botbuilder-core": "next",
+    "botbuilder-dialogs-adaptive": "next",
+    "botbuilder-dialogs-adaptive-runtime-core": "next",
+    "botbuilder-dialogs-declarative": "next",
+    "botbuilder-lg": "next"
+  }
 }


### PR DESCRIPTION
Fixes #minor

## Description
#1: Component Governance: CVE-2021-33623, severity high
https://dev.azure.com/FuseLabs/SDK_v4/_componentGovernance/112465/alert/5963096?typeId=4419273
"The trim-newlines package before 3.0.1 and 4.x before 4.0.1 for Node.js has an issue related to regular expression denial-of-service (ReDoS) for the .end() method."
BotBuilder-bf-generate-JS
"Upgrade trim-newlines from 2.0.0 to 3.0.1 to fix the vulnerability."

#2: Component Governance: CVE-2021-33623, severity high
https://dev.azure.com/FuseLabs/SDK_v4/_componentGovernance/112465/alert/5963097?typeId=4419273

## Proposed Changes
trim-newlines is a dependency of lerna. Upgrading lerna to 4.0.0 in package.json fixes both CVEs.