### PR TITLE
Match the icon names to the real file names

### DIFF
--- a/samples/csharp_dotnetcore/54.teams-task-module/TeamsAppManifest/manifest.json
+++ b/samples/csharp_dotnetcore/54.teams-task-module/TeamsAppManifest/manifest.json
@@ -11,8 +11,8 @@
     "termsOfUseUrl": "https://example.azurewebsites.net/termsofuse"
   },
   "icons": {
-    "color": "color.png",
-    "outline": "outline.png"
+    "color": "icon-color.png",
+    "outline": "icon-outline.png"
   },
   "name": {
     "short": "Task Module",


### PR DESCRIPTION
The icons should have a different size too. "color" should be in 192x192 px and outline in 32x32 px. See here: https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/build-and-test/apps-package#color

Fixes # no issue since its just a simple typo

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->
<!-- If you are introducing a new sample, make sure that the sample adheres to sample guidelines -->

  - 
  -
  -


## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->