### PR TITLE
[#3503] Add support for MSI to DotNet's samples and generators - teams samples (part 1/2)

### DIFF
--- a/samples/csharp_dotnetcore/25.message-reaction/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/25.message-reaction/AdapterWithErrorHandler.cs
@@ -1,17 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Net.Http;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
     public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger)
-            : base(configuration, httpClientFactory, logger)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<IBotFrameworkHttpAdapter> logger)
+            : base(auth, logger)
         { 
             OnTurnError = async (turnContext, exception) =>
             {

--- a/samples/csharp_dotnetcore/25.message-reaction/MessageReaction.csproj
+++ b/samples/csharp_dotnetcore/25.message-reaction/MessageReaction.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0-daily.20211006.271232.c20cc39" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/25.message-reaction/MessageReaction.csproj
+++ b/samples/csharp_dotnetcore/25.message-reaction/MessageReaction.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0-daily.20211006.271232.c20cc39" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/25.message-reaction/Startup.cs
+++ b/samples/csharp_dotnetcore/25.message-reaction/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.BotBuilderSamples.Bots;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -34,7 +35,10 @@ namespace Microsoft.BotBuilderSamples
             // the previously sent activity.
             services.AddSingleton<ActivityLog>();
 
-            // Create the Bot Framework Adapter with error handling enabled.
+            // Create the Bot Framework Authentication to be used with the Bot Adapter.
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+
+            // Create the Bot Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.

--- a/samples/csharp_dotnetcore/25.message-reaction/appsettings.json
+++ b/samples/csharp_dotnetcore/25.message-reaction/appsettings.json
@@ -1,4 +1,6 @@
 {
+  "MicrosoftAppType": "",
   "MicrosoftAppId": "",
-  "MicrosoftAppPassword": ""
+  "MicrosoftAppPassword": "",
+  "MicrosoftAppTenantId": ""
 }

--- a/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/AdapterWithErrorHandler.cs
@@ -1,18 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Net.Http;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
     public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger)
-            : base(configuration, httpClientFactory, logger)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<IBotFrameworkHttpAdapter> logger)
+            : base(auth, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/Startup.cs
+++ b/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 using Microsoft.BotBuilderSamples.Bots;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Bot.Connector.Authentication;
 
 namespace Microsoft.BotBuilderSamples
 {
@@ -27,7 +28,10 @@ namespace Microsoft.BotBuilderSamples
         {
             services.AddHttpClient().AddControllers().AddNewtonsoftJson();
 
-            // Create the Bot Framework Adapter with error handling enabled.
+            // Create the Bot Framework Authentication to be used with the Bot Adapter.
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+
+            // Create the Bot Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.

--- a/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/TeamsMessagingExtensionsSearch.csproj
+++ b/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/TeamsMessagingExtensionsSearch.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0-daily.20211006.271232.c20cc39" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/TeamsMessagingExtensionsSearch.csproj
+++ b/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/TeamsMessagingExtensionsSearch.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0-daily.20211006.271232.c20cc39" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/appsettings.json
+++ b/samples/csharp_dotnetcore/50.teams-messaging-extensions-search/appsettings.json
@@ -1,5 +1,7 @@
 {
+  "MicrosoftAppType": "",
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
-  "BaseURL":""
+  "MicrosoftAppTenantId": "",
+  "BaseUrl": ""
 }

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/AdapterWithErrorHandler.cs
@@ -1,18 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Net.Http;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
     public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger)
-            : base(configuration, httpClientFactory, logger)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<IBotFrameworkHttpAdapter> logger)
+            : base(auth, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Startup.cs
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 using Microsoft.BotBuilderSamples.Bots;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Bot.Connector.Authentication;
 
 namespace Microsoft.BotBuilderSamples
 {
@@ -31,7 +32,10 @@ namespace Microsoft.BotBuilderSamples
             services.AddControllers().AddNewtonsoftJson();
             services.AddRazorPages();
 
-            // Create the Bot Framework Adapter with error handling enabled.
+            // Create the Bot Framework Authentication to be used with the Bot Adapter.
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+
+            // Create the Bot Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/TeamsMessagingExtensionsAction.csproj
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/TeamsMessagingExtensionsAction.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="2.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0-daily.20211006.271232.c20cc39" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/TeamsMessagingExtensionsAction.csproj
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/TeamsMessagingExtensionsAction.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="2.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0-daily.20211006.271232.c20cc39" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/appsettings.json
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/appsettings.json
@@ -1,5 +1,7 @@
 {
+  "MicrosoftAppType": "<<YOUR-MICROSOFT-APP-TYPE>>",
   "MicrosoftAppId": "<<YOUR-MICROSOFT-APP-ID>>",
   "MicrosoftAppPassword": "<<YOUR-MICROSOFT-APP-SECRET>>",
-  "BaseUrl":"<<Your_Base_Url>>"
+  "MicrosoftAppTenantId": "<<YOUR-MICROSOFT-APP-TENANT-ID>>",
+  "BaseUrl": "<<Your_Base_Url>>"
 }

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/AdapterWithErrorHandler.cs
@@ -7,16 +7,15 @@ using Microsoft.Bot.Builder;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using System.Net.Http;
+using Microsoft.Bot.Connector.Authentication;
 
 namespace Microsoft.BotBuilderSamples
 {
     public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState = default)
-            : base(configuration, httpClientFactory, logger)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState = default)
+            : base(auth, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/Startup.cs
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 using Microsoft.BotBuilderSamples.Bots;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Bot.Connector.Authentication;
 
 namespace Microsoft.BotBuilderSamples
 {
@@ -31,7 +32,10 @@ namespace Microsoft.BotBuilderSamples
             services.AddSingleton<IStorage>(new MemoryStorage());
             services.AddSingleton<UserState>();
 
-            // Create the Bot Framework Adapter with error handling enabled.
+            // Create the Bot Framework Authentication to be used with the Bot Adapter.
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+
+            // Create the Bot Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/TeamsMessagingExtensionsSearchAuthConfig.csproj
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/TeamsMessagingExtensionsSearchAuthConfig.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="2.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0-daily.20211006.271232.c20cc39" />
     <PackageReference Include="Microsoft.Graph" Version="1.21.0" />
   </ItemGroup>
 

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/TeamsMessagingExtensionsSearchAuthConfig.csproj
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/TeamsMessagingExtensionsSearchAuthConfig.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="2.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0-daily.20211006.271232.c20cc39" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0" />
     <PackageReference Include="Microsoft.Graph" Version="1.21.0" />
   </ItemGroup>
 

--- a/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/appsettings.json
+++ b/samples/csharp_dotnetcore/52.teams-messaging-extensions-search-auth-config/appsettings.json
@@ -1,6 +1,8 @@
 {
+  "MicrosoftAppType": "<<YourMicrosoftAppType>>",
   "MicrosoftAppId": "<<YourMicrosoftAppId>>",
   "MicrosoftAppPassword": "<<YourMicrosoftAppPassword>>",
+  "MicrosoftAppTenantId": "<<YourMicrosoftAppTenantId>>",
   "ConnectionName": "<<YourAADV2BotServiceConnectionName>>",
   "SiteUrl": "<<https://YourSiteUrl.com>>"
 }

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/AdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/AdapterWithErrorHandler.cs
@@ -1,18 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Net.Http;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
     public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger)
-            : base(configuration, httpClientFactory, logger)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<IBotFrameworkHttpAdapter> logger)
+            : base(auth, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/Startup.cs
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.BotBuilderSamples.Bots;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -29,7 +30,10 @@ namespace Microsoft.BotBuilderSamples
             // Create the storage we'll be using for User and Conversation state. (Memory is great for testing purposes.)
             services.AddSingleton<IStorage, MemoryStorage>();
 
-            // Create the Bot Framework Adapter with error handling enabled.
+            // Create the Bot Framework Authentication to be used with the Bot Adapter.
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+
+            // Create the Bot Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/TeamsMessagingExtensionsActionPreview.csproj
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/TeamsMessagingExtensionsActionPreview.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0-daily.20211006.271232.c20cc39" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/TeamsMessagingExtensionsActionPreview.csproj
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/TeamsMessagingExtensionsActionPreview.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0-daily.20211006.271232.c20cc39" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/appsettings.json
+++ b/samples/csharp_dotnetcore/53.teams-messaging-extensions-action-preview/appsettings.json
@@ -1,4 +1,6 @@
 {
+  "MicrosoftAppType": "",
   "MicrosoftAppId": "",
-  "MicrosoftAppPassword": ""
+  "MicrosoftAppPassword": "",
+  "MicrosoftAppTenantId": ""
 }


### PR DESCRIPTION
Addresses #3503

> **Note:** The pipeline `Samples-CI-PR-Pipelines-Runner` is failing due to not finding the `4.15.0-daily.20211006.271232.c20cc39` version in NuGet, whereas this is only available in Artifacts or MyGet.

> **Note:** Currently, MSI and SingleTenant support needs the version `4.15.x` that's under development, therefore these PR changes will use the `4.15.0-daily.20211006.271232.c20cc39` version instead. Once the `4.15.x` version is released, this will be updated.

## Description
This PR updates the Teams bots' samples, adding support for MSI and SingleTenant App types.

### Detailed Changes
- Updated **_AdapterWithErrorHandler_** class to receive the _BotFrameworkAuthentication_ in the constructor.
- Updated the **_Microsoft.Bot.Builder.Integration.AspNet.Core_** dependency to the latest preview version.
- Updated **_Startup_** class to create the _BotFrameworkAuthentication_.
- Added the new settings _MicrosoftAppType_ and _MicrosoftAppTenantId_ to the **_appsettings.json_** file.

This PR updates the following samples:
- 25.message-reaction
- 50.teams-messaging-extensions-search
- 51.teams-messaging-extensions-action
- 52.teams-messaging-extensions-search-auth-config
- 53.teams-messaging-extensions-action-preview 

## Testing
The following images show the `51.teams-messaging-extensions-action`, `50.teams-messaging-extensions-search` and `52.teams-messaging-extensions-search-auth-config` bots working with the three app types: MultiTenant, SingleTenant, and MSI.
![imagen](https://user-images.githubusercontent.com/62260472/137503904-9b621ff5-2dfb-45df-a769-c41967b36296.png)