### PR TITLE
[#3503] Add support for MSI to DotNet's samples and generators - custom adapter samples

### DIFF
--- a/samples/csharp_dotnetcore/60.slack-adapter/Adapters/BotFrameworkAdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/60.slack-adapter/Adapters/BotFrameworkAdapterWithErrorHandler.cs
@@ -1,18 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Net.Http;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples.Adapters
 {
     public class BotFrameworkAdapterWithErrorHandler : CloudAdapter
     {
-        public BotFrameworkAdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger)
-            : base(configuration, httpClientFactory, logger)
+        public BotFrameworkAdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<IBotFrameworkHttpAdapter> logger)
+            : base(auth, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/samples/csharp_dotnetcore/60.slack-adapter/SlackAdapterBot.csproj
+++ b/samples/csharp_dotnetcore/60.slack-adapter/SlackAdapterBot.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Adapters.Slack" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Adapters.Slack" Version="4.15.0-daily.20211006.271232.c20cc39" />
   </ItemGroup>
 
     <ItemGroup>

--- a/samples/csharp_dotnetcore/60.slack-adapter/SlackAdapterBot.csproj
+++ b/samples/csharp_dotnetcore/60.slack-adapter/SlackAdapterBot.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Adapters.Slack" Version="4.15.0-daily.20211006.271232.c20cc39" />
+    <PackageReference Include="Microsoft.Bot.Builder.Adapters.Slack" Version="4.15.0" />
   </ItemGroup>
 
     <ItemGroup>

--- a/samples/csharp_dotnetcore/60.slack-adapter/Startup.cs
+++ b/samples/csharp_dotnetcore/60.slack-adapter/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.BotBuilderSamples.Adapters;
 using Microsoft.BotBuilderSamples.Bots;
+using Microsoft.Bot.Connector.Authentication;
 
 namespace Microsoft.BotBuilderSamples
 {
@@ -20,10 +21,13 @@ namespace Microsoft.BotBuilderSamples
         {
             services.AddHttpClient().AddControllers().AddNewtonsoftJson();
 
-            // Create the default Bot Framework Adapter (used for Azure Bot Service channels and emulator).
+            // Create the Bot Framework Authentication to be used with the Bot Adapter.
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+
+            // Create the default Bot Adapter (used for Azure Bot Service channels and emulator).
             services.AddSingleton<IBotFrameworkHttpAdapter, BotFrameworkAdapterWithErrorHandler>();
 
-            // Create the Facebook Adapter
+            // Create the Slack Adapter
             services.AddSingleton<SlackAdapter, SlackAdapterWithErrorHandler>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.

--- a/samples/csharp_dotnetcore/60.slack-adapter/appsettings.json
+++ b/samples/csharp_dotnetcore/60.slack-adapter/appsettings.json
@@ -1,5 +1,9 @@
 {
   "SlackVerificationToken": "",
   "SlackBotToken": "",
-  "SlackClientSigningSecret": ""
+  "SlackClientSigningSecret": "",
+  "MicrosoftAppType": "",
+  "MicrosoftAppId": "",
+  "MicrosoftAppPassword": "",
+  "MicrosoftAppTenantId": ""
 }

--- a/samples/csharp_dotnetcore/60.slack-adapter/appsettings.json
+++ b/samples/csharp_dotnetcore/60.slack-adapter/appsettings.json
@@ -1,9 +1,9 @@
 {
-  "SlackVerificationToken": "",
-  "SlackBotToken": "",
-  "SlackClientSigningSecret": "",
   "MicrosoftAppType": "",
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
-  "MicrosoftAppTenantId": ""
+  "MicrosoftAppTenantId": "",
+  "SlackVerificationToken": "",
+  "SlackBotToken": "",
+  "SlackClientSigningSecret": ""
 }

--- a/samples/csharp_dotnetcore/61.facebook-adapter/Adapters/BotFrameworkAdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/61.facebook-adapter/Adapters/BotFrameworkAdapterWithErrorHandler.cs
@@ -1,18 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Net.Http;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples.Adapters
 {
     public class BotFrameworkAdapterWithErrorHandler : CloudAdapter
     {
-        public BotFrameworkAdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger)
-            : base(configuration, httpClientFactory, logger)
+        public BotFrameworkAdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<IBotFrameworkHttpAdapter> logger)
+            : base(auth, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/samples/csharp_dotnetcore/61.facebook-adapter/FacebookAdapterBot.csproj
+++ b/samples/csharp_dotnetcore/61.facebook-adapter/FacebookAdapterBot.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Adapters.Facebook" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Adapters.Facebook" Version="4.15.0-daily.20211006.271232.c20cc39" />
   </ItemGroup>
 
     <ItemGroup>

--- a/samples/csharp_dotnetcore/61.facebook-adapter/FacebookAdapterBot.csproj
+++ b/samples/csharp_dotnetcore/61.facebook-adapter/FacebookAdapterBot.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Adapters.Facebook" Version="4.15.0-daily.20211006.271232.c20cc39" />
+    <PackageReference Include="Microsoft.Bot.Builder.Adapters.Facebook" Version="4.15.0" />
   </ItemGroup>
 
     <ItemGroup>

--- a/samples/csharp_dotnetcore/61.facebook-adapter/Startup.cs
+++ b/samples/csharp_dotnetcore/61.facebook-adapter/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Bot.Builder.Adapters.Facebook;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Bot.Connector.Authentication;
 
 namespace Microsoft.BotBuilderSamples
 {
@@ -20,7 +21,10 @@ namespace Microsoft.BotBuilderSamples
         {
             services.AddHttpClient().AddControllers().AddNewtonsoftJson();
 
-            // Create the default Bot Framework Adapter (used for Azure Bot Service channels and emulator).
+            // Create the Bot Framework Authentication to be used with the Bot Adapter.
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+
+            // Create the default Bot Adapter (used for Azure Bot Service channels and emulator).
             services.AddSingleton<IBotFrameworkHttpAdapter, BotFrameworkAdapterWithErrorHandler>();
 
             // Create the Facebook Adapter

--- a/samples/csharp_dotnetcore/61.facebook-adapter/appsettings.json
+++ b/samples/csharp_dotnetcore/61.facebook-adapter/appsettings.json
@@ -1,5 +1,9 @@
 {
   "FacebookVerifyToken": "",
   "FacebookAppSecret": "",
-  "FacebookAccessToken": ""
+  "FacebookAccessToken": "",
+  "MicrosoftAppType": "",
+  "MicrosoftAppId": "",
+  "MicrosoftAppPassword": "",
+  "MicrosoftAppTenantId": ""
 }

--- a/samples/csharp_dotnetcore/61.facebook-adapter/appsettings.json
+++ b/samples/csharp_dotnetcore/61.facebook-adapter/appsettings.json
@@ -1,9 +1,9 @@
 {
-  "FacebookVerifyToken": "",
-  "FacebookAppSecret": "",
-  "FacebookAccessToken": "",
   "MicrosoftAppType": "",
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
-  "MicrosoftAppTenantId": ""
+  "MicrosoftAppTenantId": "",
+  "FacebookVerifyToken": "",
+  "FacebookAppSecret": "",
+  "FacebookAccessToken": ""
 }

--- a/samples/csharp_dotnetcore/62.webex-adapter/Adapters/BotFrameworkAdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/62.webex-adapter/Adapters/BotFrameworkAdapterWithErrorHandler.cs
@@ -1,18 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Net.Http;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples.Adapters
 {
     public class BotFrameworkAdapterWithErrorHandler : CloudAdapter
     {
-        public BotFrameworkAdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger)
-            : base(configuration, httpClientFactory, logger)
+        public BotFrameworkAdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<IBotFrameworkHttpAdapter> logger)
+            : base(auth, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/samples/csharp_dotnetcore/62.webex-adapter/Startup.cs
+++ b/samples/csharp_dotnetcore/62.webex-adapter/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.BotBuilderSamples.Adapters;
 using Microsoft.BotBuilderSamples.Bots;
+using Microsoft.Bot.Connector.Authentication;
 
 namespace Microsoft.BotBuilderSamples
 {
@@ -20,7 +21,10 @@ namespace Microsoft.BotBuilderSamples
         {
             services.AddHttpClient().AddControllers().AddNewtonsoftJson();
 
-            // Create the default Bot Framework Adapter.
+            // Create the Bot Framework Authentication to be used with the Bot Adapter.
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+
+            // Create the default Bot Adapter (used for Azure Bot Service channels and emulator).
             services.AddSingleton<IBotFrameworkHttpAdapter, BotFrameworkAdapterWithErrorHandler>();
 
             // Create the default Bot Framework Adapter.

--- a/samples/csharp_dotnetcore/62.webex-adapter/WebexAdapterBot.csproj
+++ b/samples/csharp_dotnetcore/62.webex-adapter/WebexAdapterBot.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Adapters.Webex" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Adapters.Webex" Version="4.15.0-daily.20211006.271232.c20cc39" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/62.webex-adapter/WebexAdapterBot.csproj
+++ b/samples/csharp_dotnetcore/62.webex-adapter/WebexAdapterBot.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Adapters.Webex" Version="4.15.0-daily.20211006.271232.c20cc39" />
+    <PackageReference Include="Microsoft.Bot.Builder.Adapters.Webex" Version="4.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/62.webex-adapter/appsettings.json
+++ b/samples/csharp_dotnetcore/62.webex-adapter/appsettings.json
@@ -1,4 +1,8 @@
 {
+  "MicrosoftAppType": "",
+  "MicrosoftAppId": "",
+  "MicrosoftAppPassword": "",
+  "MicrosoftAppTenantId": "",
   "WebexPublicAddress": "",
   "WebexAccessToken": "",
   "WebexSecret": "",

--- a/samples/csharp_dotnetcore/63.twilio-adapter/Adapters/BotFrameworkAdapterWithErrorHandler.cs
+++ b/samples/csharp_dotnetcore/63.twilio-adapter/Adapters/BotFrameworkAdapterWithErrorHandler.cs
@@ -1,18 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Net.Http;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples.Adapters
 {
     public class BotFrameworkAdapterWithErrorHandler : CloudAdapter
     {
-        public BotFrameworkAdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger)
-            : base(configuration, httpClientFactory, logger)
+        public BotFrameworkAdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<IBotFrameworkHttpAdapter> logger)
+            : base(auth, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/samples/csharp_dotnetcore/63.twilio-adapter/Startup.cs
+++ b/samples/csharp_dotnetcore/63.twilio-adapter/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.BotBuilderSamples.Adapters;
 using Microsoft.BotBuilderSamples.Bots;
+using Microsoft.Bot.Connector.Authentication;
 
 namespace Microsoft.BotBuilderSamples
 {
@@ -20,7 +21,10 @@ namespace Microsoft.BotBuilderSamples
         {
             services.AddHttpClient().AddControllers().AddNewtonsoftJson();
 
-            // Create the default Bot Framework Adapter (used for Azure Bot Service channels and emulator).
+            // Create the Bot Framework Authentication to be used with the Bot Adapter.
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+
+            // Create the default Bot Adapter (used for Azure Bot Service channels and emulator).
             services.AddSingleton<IBotFrameworkHttpAdapter, BotFrameworkAdapterWithErrorHandler>();
 
             // Create the Twilio Adapter

--- a/samples/csharp_dotnetcore/63.twilio-adapter/TwilioAdapterBot.csproj
+++ b/samples/csharp_dotnetcore/63.twilio-adapter/TwilioAdapterBot.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Adapters.Twilio" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Adapters.Twilio" Version="4.15.0-daily.20211006.271232.c20cc39" />
   </ItemGroup>
   
   <ItemGroup>

--- a/samples/csharp_dotnetcore/63.twilio-adapter/TwilioAdapterBot.csproj
+++ b/samples/csharp_dotnetcore/63.twilio-adapter/TwilioAdapterBot.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Adapters.Twilio" Version="4.15.0-daily.20211006.271232.c20cc39" />
+    <PackageReference Include="Microsoft.Bot.Builder.Adapters.Twilio" Version="4.15.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/samples/csharp_dotnetcore/63.twilio-adapter/appsettings.json
+++ b/samples/csharp_dotnetcore/63.twilio-adapter/appsettings.json
@@ -1,4 +1,8 @@
 {
+  "MicrosoftAppType": "",
+  "MicrosoftAppId": "",
+  "MicrosoftAppPassword": "",
+  "MicrosoftAppTenantId": "",
   "TwilioNumber": "",
   "TwilioAccountSid": "",
   "TwilioAuthToken": "",


### PR DESCRIPTION
Addresses #3503

> **Note:** The pipeline `Samples-CI-PR-Pipelines-Runner` is failing due to not finding the `4.15.0-daily.20211006.271232.c20cc39` version in NuGet, whereas this is only available in Artifacts or MyGet.

> **Note:** Currently, MSI and SingleTenant support needs the version `4.15.x` that's under development, therefore these PR changes will use the `4.15.0-daily.20211006.271232.c20cc39` version instead. Once the `4.15.x` version is released, this will be updated.

## Description
This PR updates the Custom adapter bots' samples, adding support for MSI and SingleTenant App types.

### Detailed Changes
- Updated **_AdapterWithErrorHandler_** class to receive the _BotFrameworkAuthentication_ in the constructor.
- Updated the **_Microsoft.Bot.Builder.Integration.AspNet.Core_** dependency to the latest preview version.
- Updated **_Startup_** class to create the _BotFrameworkAuthentication_.
- Added the new settings _MicrosoftAppType_ and _MicrosoftAppTenantId_ to the **_appsettings.json_** file.

This PR updates the following samples:
- 60.slack-adapter bot
- 61.facebook-adapter bot
- 62.webex-adapter
- 63.twilio-adapter 

## Testing
The following images show the `63.twilio-adapter `, `62.webex-adapter` and `61.facebook-adapter bot` bots working with the three app types: MultiTenant, SingleTenant, and MSI.
![imagen](https://user-images.githubusercontent.com/62260472/137528249-ab5adc90-e51e-454c-9010-0d9ae0423095.png)