### PR TITLE
[#3503] Add support for MSI to DotNet's samples and generators - VSIX templates

### DIFF
--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/AdapterWithErrorHandler.cs
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/AdapterWithErrorHandler.cs
@@ -4,20 +4,19 @@
 // Generated with CoreBot .NET Template version __vX.X.X__
 
 using System;
-using System.Net.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace CoreBot
 {
     public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState = default)
-            : base(configuration, httpClientFactory, logger)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState = default)
+            : base(auth, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/CoreBot.csproj
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/CoreBot.csproj
@@ -15,9 +15,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.14.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.14.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.15.0-daily.20211006.271232.c20cc39" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.15.0-daily.20211006.271232.c20cc39" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0-daily.20211006.271232.c20cc39" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.3.2" />
   </ItemGroup>
 

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/Startup.cs
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/Startup.cs
@@ -9,6 +9,7 @@ using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Bot.Connector.Authentication;
 
 using CoreBot.Bots;
 using CoreBot.Dialogs;
@@ -22,7 +23,10 @@ namespace CoreBot
         {
             services.AddHttpClient().AddControllers().AddNewtonsoftJson();
 
-            // Create the Bot Framework Adapter with error handling enabled.
+            // Create the Bot Framework Authentication to be used with the Bot Adapter.
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+
+            // Create the Bot Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 
             // Create the storage we'll be using for User and Conversation state. (Memory is great for testing purposes.)

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/appsettings.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/appsettings.json
@@ -1,6 +1,8 @@
 {
+  "MicrosoftAppType": "",
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
+  "MicrosoftAppTenantId": "",
   "LuisAppId": "",
   "LuisAPIKey": "",
   "LuisAPIHostName": ""

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/AdapterWithErrorHandler.cs
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/AdapterWithErrorHandler.cs
@@ -3,18 +3,17 @@
 //
 // Generated with EchoBot .NET Template version __vX.X.X__
 
-using System.Net.Http;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
 
 namespace EchoBot
 {
     public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger)
-            : base(configuration, httpClientFactory, logger)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<IBotFrameworkHttpAdapter> logger)
+            : base(auth, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/Microsoft.BotFramework.EchoBot.csproj
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/Microsoft.BotFramework.EchoBot.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0-daily.20211006.271232.c20cc39" />
   </ItemGroup>
 
   <ItemGroup>

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/Startup.cs
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/Startup.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -27,7 +28,10 @@ namespace EchoBot
         {
             services.AddHttpClient().AddControllers().AddNewtonsoftJson();
 
-            // Create the Bot Framework Adapter with error handling enabled.
+            // Create the Bot Framework Authentication to be used with the Bot Adapter.
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+
+            // Create the Bot Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/appsettings.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/appsettings.json
@@ -1,4 +1,6 @@
 {
+  "MicrosoftAppType": "",
   "MicrosoftAppId": "",
-  "MicrosoftAppPassword": ""
+  "MicrosoftAppPassword": "",
+  "MicrosoftAppTenantId": ""
 }

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/AdapterWithErrorHandler.cs
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/AdapterWithErrorHandler.cs
@@ -3,18 +3,17 @@
 //
 // Generated with EmptyBot .NET Template version __vX.X.X__
 
-using System.Net.Http;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
 
 namespace EmptyBot
 {
     public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger)
-            : base(configuration, httpClientFactory, logger)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<IBotFrameworkHttpAdapter> logger)
+            : base(auth, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/Microsoft.BotFramework.EmptyBot.csproj
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/Microsoft.BotFramework.EmptyBot.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0-daily.20211006.271232.c20cc39" />
   </ItemGroup>
 
   <ItemGroup>

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/Startup.cs
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Bot.Connector.Authentication;
 
 namespace EmptyBot
 {
@@ -27,7 +28,10 @@ namespace EmptyBot
         {
             services.AddHttpClient().AddControllers().AddNewtonsoftJson();
 
-            // Create the Bot Framework Adapter with error handling enabled.
+            // Create the Bot Framework Authentication to be used with the Bot Adapter.
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+
+            // Create the Bot Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/appsettings.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/appsettings.json
@@ -1,4 +1,6 @@
 {
+  "MicrosoftAppType": "",
   "MicrosoftAppId": "",
-  "MicrosoftAppPassword": ""
+  "MicrosoftAppPassword": "",
+  "MicrosoftAppTenantId": ""
   }

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/AdapterWithErrorHandler.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/AdapterWithErrorHandler.cs
@@ -4,20 +4,19 @@
 // Generated with Bot Builder V4 SDK Template for Visual Studio CoreBot v$templateversion$
 
 using System;
-using System.Net.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace $safeprojectname$
 {
     public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState = default)
-            : base(configuration, httpClientFactory, logger)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState = default)
+            : base(auth, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/CoreBot.csproj
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/CoreBot.csproj
@@ -15,9 +15,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.14.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.14.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.15.0-daily.20211006.271232.c20cc39" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.15.0-daily.20211006.271232.c20cc39" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0-daily.20211006.271232.c20cc39" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.4.0" />
   </ItemGroup>
 

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/Startup.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/Startup.cs
@@ -9,6 +9,7 @@ using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Bot.Connector.Authentication;
 
 using $safeprojectname$.Bots;
 using $safeprojectname$.Dialogs;
@@ -22,7 +23,10 @@ namespace $safeprojectname$
         {
             services.AddHttpClient().AddControllers().AddNewtonsoftJson();
 
-            // Create the Bot Framework Adapter with error handling enabled.
+            // Create the Bot Framework Authentication to be used with the Bot Adapter.
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+
+            // Create the Bot Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 
             // Create the storage we'll be using for User and Conversation state. (Memory is great for testing purposes.)

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/appsettings.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/appsettings.json
@@ -1,6 +1,8 @@
 {
+  "MicrosoftAppType": "",
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
+  "MicrosoftAppTenantId": "",
   "LuisAppId": "",
   "LuisAPIKey": "",
   "LuisAPIHostName": ""

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/AdapterWithErrorHandler.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/AdapterWithErrorHandler.cs
@@ -4,20 +4,19 @@
 // Generated with Bot Builder V4 SDK Template for Visual Studio CoreBot v$templateversion$
 
 using System;
-using System.Net.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace $safeprojectname$
 {
     public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState = default)
-            : base(configuration, httpClientFactory, logger)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<IBotFrameworkHttpAdapter> logger, ConversationState conversationState = default)
+            : base(auth, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/CoreBot.csproj
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/CoreBot.csproj
@@ -15,9 +15,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.14.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.14.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.15.0-daily.20211006.271232.c20cc39" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.15.0-daily.20211006.271232.c20cc39" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0-daily.20211006.271232.c20cc39" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.4.0" />
   </ItemGroup>
 

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/Startup.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/Startup.cs
@@ -9,6 +9,7 @@ using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Bot.Connector.Authentication;
 
 using $safeprojectname$.Bots;
 using $safeprojectname$.Dialogs;
@@ -22,7 +23,10 @@ namespace $safeprojectname$
         {
             services.AddHttpClient().AddControllers().AddNewtonsoftJson();
 
-            // Create the Bot Framework Adapter with error handling enabled.
+            // Create the Bot Framework Authentication to be used with the Bot Adapter.
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+
+            // Create the Bot Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 
             // Create the storage we'll be using for User and Conversation state. (Memory is great for testing purposes.)

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/appsettings.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/appsettings.json
@@ -1,6 +1,8 @@
 {
+  "MicrosoftAppType": "",
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
+  "MicrosoftAppTenantId": "",
   "LuisAppId": "",
   "LuisAPIKey": "",
   "LuisAPIHostName": ""

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/AdapterWithErrorHandler.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/AdapterWithErrorHandler.cs
@@ -3,18 +3,17 @@
 //
 // Generated with Bot Builder V4 SDK Template for Visual Studio CoreBot v$templateversion$
 
-using System.Net.Http;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
 
 namespace $safeprojectname$
 {
     public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger)
-            : base(configuration, httpClientFactory, logger)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<IBotFrameworkHttpAdapter> logger)
+            : base(auth, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/EchoBot.csproj
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/EchoBot.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0-daily.20211006.271232.c20cc39" />
   </ItemGroup>
 
     <ItemGroup>

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/Startup.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/Startup.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -27,7 +28,10 @@ namespace $safeprojectname$
         {
             services.AddHttpClient().AddControllers().AddNewtonsoftJson();
 
-            // Create the Bot Framework Adapter with error handling enabled.
+            // Create the Bot Framework Authentication to be used with the Bot Adapter.
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+
+            // Create the Bot Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/appsettings.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/appsettings.json
@@ -1,4 +1,6 @@
 {
+  "MicrosoftAppType": "",
   "MicrosoftAppId": "",
-  "MicrosoftAppPassword": ""
+  "MicrosoftAppPassword": "",
+  "MicrosoftAppTenantId": ""
 }

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/AdapterWithErrorHandler.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/AdapterWithErrorHandler.cs
@@ -3,18 +3,17 @@
 //
 // Generated with Bot Builder V4 SDK Template for Visual Studio CoreBot v$templateversion$
 
-using System.Net.Http;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
 
 namespace $safeprojectname$
 {
     public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<IBotFrameworkHttpAdapter> logger)
-            : base(configuration, httpClientFactory, logger)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<IBotFrameworkHttpAdapter> logger)
+            : base(auth, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/EmptyBot.csproj
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/EmptyBot.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.14.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.15.0-daily.20211006.271232.c20cc39" />
   </ItemGroup>
 
     <ItemGroup>

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/Startup.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/Startup.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -26,6 +27,9 @@ namespace $safeprojectname$
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddHttpClient().AddControllers().AddNewtonsoftJson();
+
+            // Create the Bot Framework Authentication to be used with the Bot Adapter.
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
 
             // Create the Bot Framework Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/Startup.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/Startup.cs
@@ -31,7 +31,7 @@ namespace $safeprojectname$
             // Create the Bot Framework Authentication to be used with the Bot Adapter.
             services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
 
-            // Create the Bot Framework Adapter with error handling enabled.
+            // Create the Bot Adapter with error handling enabled.
             services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/appsettings.json
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/appsettings.json
@@ -1,4 +1,6 @@
 {
+    "MicrosoftAppType": "",
     "MicrosoftAppId": "",
-    "MicrosoftAppPassword": ""
+    "MicrosoftAppPassword": "",
+    "MicrosoftAppTenantId": ""
 }


### PR DESCRIPTION
Addresses #3503

> **Note:** Currently, MSI and SingleTenant support needs the version `4.15.x` that's under development, therefore these PR changes will use the `4.15.0-daily.20211006.271232.c20cc39` version instead. Once the `4.15.x` version is released, this will be updated.

## Description
This PR updated the dotnet generators (VSIX and dotnet templates), adding support for MSI and SingleTenant App types.

### Detailed Changes
- Updated **_AdapterWithErrorHandler_** class to receive the _BotFrameworkAuthentication_ in the constructor.
- Updated the **_Microsoft.Bot.Builder.Integration.AspNet.Core_** dependency to the latest preview version.
- Updated **_Startup_** class to create the _BotFrameworkAuthentication_.
- Added the new settings _MicrosoftAppType_ and _MicrosoftAppTenantId_ to the **_appsettings.json_** file.

This PR updates the following samples:
- dotnet-templates:
   - Microsoft.BotFramework.CSharp.CoreBot
   - Microsoft.BotFramework.CSharp.EchoBot
   - Microsoft.BotFramework.CSharp.EmptyBot
- VSIX:
   - CoreBot
   - CoreBotWithTests
   - EchoBot
   - EmptyBot

## Testing
These images show the core, echo and empty bots working with the three app types.
![image](https://user-images.githubusercontent.com/44245136/137772310-b837ed6a-c481-4ca3-a180-d812f347f234.png)