### PR TITLE
[#3526] Add support for MSI to JS samples and generators - bot essentials (part 2/2)

### DIFF
--- a/samples/javascript_nodejs/13.core-bot/.env
+++ b/samples/javascript_nodejs/13.core-bot/.env
@@ -1,5 +1,7 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=
 LuisAppId=
 LuisAPIKey=
 LuisAPIHostName=

--- a/samples/javascript_nodejs/13.core-bot/index.js
+++ b/samples/javascript_nodejs/13.core-bot/index.js
@@ -36,7 +36,9 @@ const BOOKING_DIALOG = 'bookingDialog';
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/13.core-bot/package.json
+++ b/samples/javascript_nodejs/13.core-bot/package.json
@@ -17,10 +17,10 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.14.0",
-        "botbuilder-ai": "~4.14.0",
-        "botbuilder-dialogs": "~4.14.0",
-        "botbuilder-testing": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
+        "botbuilder-ai": "~4.15.0-rc0",
+        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder-testing": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "moment-timezone": "~0.5.33",
         "restify": "~8.5.1"

--- a/samples/javascript_nodejs/14.nlp-with-orchestrator/.env
+++ b/samples/javascript_nodejs/14.nlp-with-orchestrator/.env
@@ -1,5 +1,7 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=
 
 QnAKnowledgebaseId=
 QnAEndpointKey=

--- a/samples/javascript_nodejs/14.nlp-with-orchestrator/index.js
+++ b/samples/javascript_nodejs/14.nlp-with-orchestrator/index.js
@@ -23,7 +23,9 @@ const { DispatchBot } = require('./bots/dispatchBot');
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/14.nlp-with-orchestrator/package.json
+++ b/samples/javascript_nodejs/14.nlp-with-orchestrator/package.json
@@ -16,11 +16,11 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
-        "botbuilder-ai": "~4.14.0",
-        "botbuilder-ai-orchestrator": "~4.14.0",
-        "botbuilder-azure": "~4.14.0",
-        "botbuilder-dialogs": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
+        "botbuilder-ai": "~4.15.0-rc0",
+        "botbuilder-ai-orchestrator": "~4.15.0-rc0",
+        "botbuilder-azure": "~4.15.0-rc0",
+        "botbuilder-dialogs": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/15.handling-attachments/.env
+++ b/samples/javascript_nodejs/15.handling-attachments/.env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/javascript_nodejs/15.handling-attachments/index.js
+++ b/samples/javascript_nodejs/15.handling-attachments/index.js
@@ -21,7 +21,9 @@ const { AttachmentsBot } = require('./bots/attachmentsBot');
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/15.handling-attachments/package.json
+++ b/samples/javascript_nodejs/15.handling-attachments/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "axios": "^0.21.2",
-    "botbuilder": "~4.14.0",
+    "botbuilder": "~4.15.0-rc0",
     "dotenv": "^8.2.0",
     "restify": "~8.5.1"
   },

--- a/samples/javascript_nodejs/43.complex-dialog/.env
+++ b/samples/javascript_nodejs/43.complex-dialog/.env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/javascript_nodejs/43.complex-dialog/index.js
+++ b/samples/javascript_nodejs/43.complex-dialog/index.js
@@ -35,7 +35,9 @@ server.listen(process.env.port || process.env.PORT || 3978, function() {
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/43.complex-dialog/package.json
+++ b/samples/javascript_nodejs/43.complex-dialog/package.json
@@ -12,8 +12,8 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
-        "botbuilder-dialogs": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
+        "botbuilder-dialogs": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/45.state-management/.env
+++ b/samples/javascript_nodejs/45.state-management/.env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/javascript_nodejs/45.state-management/index.js
+++ b/samples/javascript_nodejs/45.state-management/index.js
@@ -35,7 +35,9 @@ server.listen(process.env.port || process.env.PORT || 3978, function() {
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/45.state-management/package.json
+++ b/samples/javascript_nodejs/45.state-management/package.json
@@ -12,7 +12,7 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },


### PR DESCRIPTION
Addresses #3526

## Description
This PR updated the bot essentials samples adding support for MSI and SingleTenant App types.

### Detailed Changes
- Updated the **_botbuilder_** dependency to the RC0 version.
- Updated **_index.js_** to pass the new parameters AppType and AppTenantId to the _ConfigurationServiceClientCredentialFactory_ instance.
- Added the new settings _MicrosoftAppType_ and _MicrosoftAppTenantId_ to the **_env_** file.

This PR updates the following samples:
- 13.core-bot
- 14.nlp-with-orchestrator
- 15.handling-attachments
- 43.complex-dialog
- 45.state-management

## Testing
The following images show the _handling-attachments_ bot working with the three app types: MultiTenant, SingleTenant, and MSI.
![image](https://user-images.githubusercontent.com/44245136/138148286-ccecce04-e30b-4de7-b1a9-421cc5757bb7.png)
