### PR TITLE
[#3526] Add support for MSI to JS samples and generators - teams samples (part 1/2)

### DIFF
--- a/samples/javascript_nodejs/25.message-reaction/.env
+++ b/samples/javascript_nodejs/25.message-reaction/.env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/javascript_nodejs/25.message-reaction/index.js
+++ b/samples/javascript_nodejs/25.message-reaction/index.js
@@ -26,7 +26,9 @@ const { MessageReactionBot } = require('./bots/messageReactionBot');
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/25.message-reaction/package.json
+++ b/samples/javascript_nodejs/25.message-reaction/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/50.teams-messaging-extensions-search/.env
+++ b/samples/javascript_nodejs/50.teams-messaging-extensions-search/.env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/javascript_nodejs/50.teams-messaging-extensions-search/index.js
+++ b/samples/javascript_nodejs/50.teams-messaging-extensions-search/index.js
@@ -24,7 +24,9 @@ const { TeamsMessagingExtensionsSearchBot } = require('./bots/teamsMessagingExte
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/50.teams-messaging-extensions-search/package.json
+++ b/samples/javascript_nodejs/50.teams-messaging-extensions-search/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "axios": "^0.21.2",
-    "botbuilder": "~4.14.0",
+    "botbuilder": "~4.15.0-rc0",
     "dotenv": "^8.2.0",
     "restify": "~8.5.1"
   },

--- a/samples/javascript_nodejs/51.teams-messaging-extensions-action/.env
+++ b/samples/javascript_nodejs/51.teams-messaging-extensions-action/.env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/javascript_nodejs/51.teams-messaging-extensions-action/index.js
+++ b/samples/javascript_nodejs/51.teams-messaging-extensions-action/index.js
@@ -23,7 +23,9 @@ const { TeamsMessagingExtensionsActionBot } = require('./bots/teamsMessagingExte
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/51.teams-messaging-extensions-action/package.json
+++ b/samples/javascript_nodejs/51.teams-messaging-extensions-action/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/.env
+++ b/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/.env
@@ -1,4 +1,6 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=
 ConnectionName=
 SiteUrl=

--- a/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/index.js
+++ b/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/index.js
@@ -25,7 +25,9 @@ const { TeamsMessagingExtensionsSearchAuthConfigBot } = require('./bots/teamsMes
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/package.json
+++ b/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@microsoft/microsoft-graph-client": "~2.0.0",
     "axios": "^0.21.2",
-    "botbuilder": "~4.14.0",
+    "botbuilder": "~4.15.0-rc0",
     "dotenv": "^8.2.0",
     "restify": "~8.5.1"
   },

--- a/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/.env
+++ b/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/.env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/index.js
+++ b/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/index.js
@@ -23,7 +23,9 @@ const { TeamsMessagingExtensionsActionPreviewBot } = require('./bots/teamsMessag
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/package.json
+++ b/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },


### PR DESCRIPTION
Addresses #3526

## Description
This PR updated the Teams' bot samples, adding support for MSI and SingleTenant App types.

### Detailed Changes
- Updated the **_botbuilder_** dependency to the RC0 version.
- Updated **_index.js_** to pass the new parameters AppType and AppTenantId to the _ConfigurationServiceClientCredentialFactory_ instance.
- Added the new settings _MicrosoftAppType_ and _MicrosoftAppTenantId_ to the **_env_** file.

This PR updates the following samples:
- 25.message-reaction
- 50.teams-messaging-extensions-search
- 51.teams-messaging-extensions-action
- 52.teams-messaging-extensions-search-auth-config
- 53.teams-messaging-extensions-action-preview 

## Testing
The following images show the three bots working with the three app types: MultiTenant, SingleTenant, and MSI.
![image](https://user-images.githubusercontent.com/62260472/138343173-982471d7-fdd9-414f-a560-be24d73e927c.png)