### PR TITLE
[#3526] Add support for MSI to JS samples and generators - teams samples (part 2/2)

### DIFF
--- a/samples/javascript_nodejs/54.teams-task-module/.env
+++ b/samples/javascript_nodejs/54.teams-task-module/.env
@@ -1,3 +1,5 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=
 BaseUrl=https://YourDeployedBotUrl.com

--- a/samples/javascript_nodejs/54.teams-task-module/index.js
+++ b/samples/javascript_nodejs/54.teams-task-module/index.js
@@ -23,7 +23,9 @@ const { TeamsTaskModuleBot } = require('./bots/teamsTaskModuleBot');
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/54.teams-task-module/package.json
+++ b/samples/javascript_nodejs/54.teams-task-module/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/55.teams-link-unfurling/.env
+++ b/samples/javascript_nodejs/55.teams-link-unfurling/.env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/javascript_nodejs/55.teams-link-unfurling/index.js
+++ b/samples/javascript_nodejs/55.teams-link-unfurling/index.js
@@ -24,7 +24,9 @@ const { TeamsLinkUnfurlingBot } = require('./bots/teamsLinkUnfurlingBot');
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/55.teams-link-unfurling/package.json
+++ b/samples/javascript_nodejs/55.teams-link-unfurling/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/56.teams-file-upload/.env
+++ b/samples/javascript_nodejs/56.teams-file-upload/.env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/javascript_nodejs/56.teams-file-upload/index.js
+++ b/samples/javascript_nodejs/56.teams-file-upload/index.js
@@ -24,7 +24,9 @@ const { TeamsFileUploadBot } = require('./bots/teamsFileUploadBot');
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/56.teams-file-upload/package.json
+++ b/samples/javascript_nodejs/56.teams-file-upload/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "axios": "^0.21.2",
-    "botbuilder": "~4.14.0",
+    "botbuilder": "~4.15.0-rc0",
     "dotenv": "^8.2.0",
     "restify": "~8.5.1"
   },

--- a/samples/javascript_nodejs/57.teams-conversation-bot/.env
+++ b/samples/javascript_nodejs/57.teams-conversation-bot/.env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/javascript_nodejs/57.teams-conversation-bot/index.js
+++ b/samples/javascript_nodejs/57.teams-conversation-bot/index.js
@@ -24,7 +24,9 @@ const { TeamsConversationBot } = require('./bots/teamsConversationBot');
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/57.teams-conversation-bot/package.json
+++ b/samples/javascript_nodejs/57.teams-conversation-bot/package.json
@@ -18,7 +18,7 @@
     "dependencies": {
         "adaptive-expressions": "^4.14.1",
         "adaptivecards-templating": "^2.1.0",
-        "botbuilder": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/.env
+++ b/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/.env
@@ -1,2 +1,4 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/index.js
+++ b/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/index.js
@@ -24,7 +24,9 @@ const { TeamsStartNewThreadInChannel } = require('./bots/TeamsStartNewThreadInCh
 
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
     MicrosoftAppId: process.env.MicrosoftAppId,
-    MicrosoftAppPassword: process.env.MicrosoftAppPassword
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
 
 const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);

--- a/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/package.json
+++ b/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },


### PR DESCRIPTION
Addresses #3526

## Description
This PR updated the Teams' bot samples, adding support for MSI and SingleTenant App types.

### Detailed Changes
- Updated the **_botbuilder_** dependency to the RC0 version.
- Updated **_index.js_** to pass the new parameters AppType and AppTenantId to the _ConfigurationServiceClientCredentialFactory_ instance.
- Added the new settings _MicrosoftAppType_ and _MicrosoftAppTenantId_ to the **_env_** file.

This PR updates the following samples:
- 54.teams-task-module
- 55.teams-link-unfurling
- 56.teams-file-upload
- 57.teams-conversation-bot
- 58.teams-start-new-thread-in-channel 

## Testing
The following images show the three bots working with the three app types: MultiTenant, SingleTenant, and MSI.
![image](https://user-images.githubusercontent.com/62260472/138343173-982471d7-fdd9-414f-a560-be24d73e927c.png)