### PR TITLE
[#3526] Add support for MSI to JS samples and generators - ARM preexisting RG templates (1/2)

### DIFF
--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/06.using-cards/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/06.using-cards/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/11.qnamaker/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/11.qnamaker/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/14.nlp-with-orchestrator/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/14.nlp-with-orchestrator/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/25.message-reaction/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/25.message-reaction/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/45.state-management/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/45.state-management/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/46.teams-auth/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/46.teams-auth/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/47.inspection/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/47.inspection/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,17 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "appId": {
             "type": "string",
             "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
             }
         },
         "appSecret": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
             }
         },
         "botId": {
@@ -66,6 +79,27 @@
             "metadata": {
                 "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
             }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
         }
     },
     "variables": {
@@ -75,7 +109,35 @@
         "resourcesLocation": "[parameters('appServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -100,6 +162,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
             ],
             "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "name": "[variables('webAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -110,12 +173,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ],
                     "cors": {
@@ -142,6 +213,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,


### PR DESCRIPTION
Addresses #3526

## Description
This PR updates the JS samples' ARM `template-with-preexisting-rg.json` files to include the parameters and resources required to support MSI.

### Detailed Changes
- Added _appType_, _tenantId_, _existingUserAssignedMSIName_, and _existingUserAssignedMSIResourceGroupName_ parameters.
- Added the connection with the provided identity in case MSI app type is selected.

## Testing
This image shows the bots being deployed and tested successfully after the changes.
![image](https://user-images.githubusercontent.com/44245136/139274045-57030551-9995-444b-8df3-bd99888a54c1.png)
