### PR TITLE
[#3550] Port CloudAdapter & MSI to TypeScript samples (1/2)

### DIFF
--- a/samples/typescript_nodejs/00.empty-bot/.env
+++ b/samples/typescript_nodejs/00.empty-bot/.env
@@ -1,0 +1,4 @@
+MicrosoftAppType=
+MicrosoftAppId=
+MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/typescript_nodejs/00.empty-bot/package.json
+++ b/samples/typescript_nodejs/00.empty-bot/package.json
@@ -18,7 +18,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
         "replace": "~1.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/typescript_nodejs/00.empty-bot/src/index.ts
+++ b/samples/typescript_nodejs/00.empty-bot/src/index.ts
@@ -5,23 +5,34 @@ import * as restify from 'restify';
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-import { BotFrameworkAdapter } from 'botbuilder';
+import {
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    createBotFrameworkAuthenticationFromConfiguration
+} from 'botbuilder';
 
 // This bot's main dialog.
 import { EmptyBot } from './bot';
 
 // Create HTTP server.
 const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
 server.listen(process.env.port || process.env.PORT || 3978, () => {
     console.log(`\n${ server.name } listening to ${ server.url }`);
 });
 
-// Create adapter.
-// See https://aka.ms/about-bot-adapter to learn more about adapters.
-const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppId,
-    appPassword: process.env.MicrosoftAppPassword
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
+// Create adapter.
+// See https://aka.ms/about-bot-adapter to learn more about how bots work.
+const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 // Catch-all for errors.
 adapter.onTurnError = async (context, error) => {
@@ -47,9 +58,7 @@ adapter.onTurnError = async (context, error) => {
 const myBot = new EmptyBot();
 
 // Listen for incoming requests.
-server.post('/api/messages', (req, res) => {
-    adapter.processActivity(req, res, async (context) => {
-        // Route to main dialog.
-        await myBot.run(context);
-    });
+server.post('/api/messages', async (req, res) => {
+    // Route received a request to adapter for processing
+    await adapter.process(req, res, (context) => myBot.run(context))
 });

--- a/samples/typescript_nodejs/02.echo-bot/.env
+++ b/samples/typescript_nodejs/02.echo-bot/.env
@@ -1,0 +1,4 @@
+MicrosoftAppType=
+MicrosoftAppId=
+MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/typescript_nodejs/02.echo-bot/package.json
+++ b/samples/typescript_nodejs/02.echo-bot/package.json
@@ -18,14 +18,13 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "replace": "^1.2.0",
         "restify": "~8.5.1"
     },
     "devDependencies": {
         "@types/dotenv": "6.1.1",
-        "@types/node": "^10.17.27",
         "@types/restify": "8.4.2",
         "nodemon": "~2.0.4",
         "tslint": "~6.1.2",

--- a/samples/typescript_nodejs/02.echo-bot/package.json
+++ b/samples/typescript_nodejs/02.echo-bot/package.json
@@ -25,6 +25,7 @@
     },
     "devDependencies": {
         "@types/dotenv": "6.1.1",
+        "@types/node": "^16.11.6",
         "@types/restify": "8.4.2",
         "nodemon": "~2.0.4",
         "tslint": "~6.1.2",

--- a/samples/typescript_nodejs/02.echo-bot/src/index.ts
+++ b/samples/typescript_nodejs/02.echo-bot/src/index.ts
@@ -13,25 +13,36 @@ import { INodeSocket } from 'botframework-streaming';
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-import { BotFrameworkAdapter } from 'botbuilder';
+import { 
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    createBotFrameworkAuthenticationFromConfiguration
+} from 'botbuilder';
 
 // This bot's main dialog.
 import { EchoBot } from './bot';
 
 // Create HTTP server.
 const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
 server.listen(process.env.port || process.env.PORT || 3978, () => {
     console.log(`\n${server.name} listening to ${server.url}`);
     console.log('\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator');
     console.log('\nTo talk to your bot, open the emulator select "Open Bot"');
 });
 
-// Create adapter.
-// See https://aka.ms/about-bot-adapter to learn more about adapters.
-const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppId,
-    appPassword: process.env.MicrosoftAppPassword
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
 });
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
+// Create adapter.
+// See https://aka.ms/about-bot-adapter to learn more about how bots work.
+const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 // Catch-all for errors.
 const onTurnErrorHandler = async (context, error) => {
@@ -53,33 +64,25 @@ const onTurnErrorHandler = async (context, error) => {
     await context.sendActivity('To continue to run this bot, please fix the bot source code.');
 };
 
-// Set the onTurnError for the singleton BotFrameworkAdapter.
+// Set the onTurnError for the singleton CloudAdapter.
 adapter.onTurnError = onTurnErrorHandler;
 
 // Create the main dialog.
 const myBot = new EchoBot();
 
 // Listen for incoming requests.
-server.post('/api/messages', (req, res) => {
-    adapter.processActivity(req, res, async (context) => {
-        // Route to main dialog.
-        await myBot.run(context);
-    });
+server.post('/api/messages', async (req, res) => {
+    // Route received a request to adapter for processing
+    await adapter.process(req, res, (context) => myBot.run(context));
 });
 
 // Listen for Upgrade requests for Streaming.
-server.on('upgrade', (req, socket, head) => {
+server.on('upgrade', async (req, socket, head) => {
     // Create an adapter scoped to this WebSocket connection to allow storing session data.
-    const streamingAdapter = new BotFrameworkAdapter({
-        appId: process.env.MicrosoftAppId,
-        appPassword: process.env.MicrosoftAppPassword
-    });
-    // Set onTurnError for the BotFrameworkAdapter created for each connection.
+    const streamingAdapter = new CloudAdapter(botFrameworkAuthentication);
+
+    // Set onTurnError for the CloudAdapter created for each connection.
     streamingAdapter.onTurnError = onTurnErrorHandler;
 
-    streamingAdapter.useWebSocket(req, socket as unknown as INodeSocket, head, async (context) => {
-        // After connecting via WebSocket, run this logic for every request sent over
-        // the WebSocket connection.
-        await myBot.run(context);
-    });
+    await streamingAdapter.process(req, socket as unknown as INodeSocket, head, (context) => myBot.run(context));
 });

--- a/samples/typescript_nodejs/03.welcome-users/.env
+++ b/samples/typescript_nodejs/03.welcome-users/.env
@@ -1,0 +1,4 @@
+MicrosoftAppType=
+MicrosoftAppId=
+MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/typescript_nodejs/03.welcome-users/package.json
+++ b/samples/typescript_nodejs/03.welcome-users/package.json
@@ -18,7 +18,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
         "replace": "~1.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/typescript_nodejs/05.multi-turn-prompt/.env
+++ b/samples/typescript_nodejs/05.multi-turn-prompt/.env
@@ -1,0 +1,4 @@
+MicrosoftAppType=
+MicrosoftAppId=
+MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/typescript_nodejs/05.multi-turn-prompt/package.json
+++ b/samples/typescript_nodejs/05.multi-turn-prompt/package.json
@@ -18,8 +18,8 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
-        "botbuilder-dialogs": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
+        "botbuilder-dialogs": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "replace": "~1.2.0",
         "restify": "~8.5.1"

--- a/samples/typescript_nodejs/06.using-cards/.env
+++ b/samples/typescript_nodejs/06.using-cards/.env
@@ -1,0 +1,4 @@
+MicrosoftAppType=
+MicrosoftAppId=
+MicrosoftAppPassword=
+MicrosoftAppTenantId=

--- a/samples/typescript_nodejs/06.using-cards/package.json
+++ b/samples/typescript_nodejs/06.using-cards/package.json
@@ -18,8 +18,8 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.14.0",
-        "botbuilder-dialogs": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
+        "botbuilder-dialogs": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "replace": "~1.2.0",
         "restify": "~8.5.1"

--- a/samples/typescript_nodejs/06.using-cards/src/index.ts
+++ b/samples/typescript_nodejs/06.using-cards/src/index.ts
@@ -7,7 +7,14 @@ import * as restify from 'restify';
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-import { BotFrameworkAdapter, ConversationState, MemoryStorage, UserState } from 'botbuilder';
+import {
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    ConversationState,
+    createBotFrameworkAuthenticationFromConfiguration,
+    MemoryStorage,
+    UserState
+} from 'botbuilder';
 
 // This bot's main dialog.
 import { DialogBot } from './bots/dialogBot';
@@ -17,12 +24,18 @@ import { MainDialog } from './dialogs/mainDialog';
 const ENV_FILE = path.join(__dirname, '.env');
 config({ path: ENV_FILE });
 
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
+});
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory);
+
 // Create the adapter. See https://aka.ms/about-bot-adapter to learn more about using information from
 // the .bot file when configuring your adapter.
-const adapter = new BotFrameworkAdapter({
-    appId: process.env.MicrosoftAppId,
-    appPassword: process.env.MicrosoftAppPassword
-});
+const adapter = new CloudAdapter(botFrameworkAuthentication);
 
 // Catch-all for errors.
 adapter.onTurnError = async (context, error) => {
@@ -61,6 +74,8 @@ const bot = new DialogBot(conversationState, userState, dialog);
 
 // Create HTTP server.
 const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
+
 server.listen(process.env.port || process.env.PORT || 3978, () => {
     console.log(`\n${server.name} listening to ${server.url}.`);
     console.log('\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator');
@@ -68,10 +83,7 @@ server.listen(process.env.port || process.env.PORT || 3978, () => {
 });
 
 // Listen for incoming activities and route them to your bot main dialog.
-server.post('/api/messages', (req, res) => {
+server.post('/api/messages', async (req, res) => {
     // Route received a request to adapter for processing
-    adapter.processActivity(req, res, async (context) => {
-        // Route the message to the bot's main handler.
-        await bot.run(context);
-    });
+    await adapter.process(req, res, (context) => bot.run(context));
 });

--- a/samples/typescript_nodejs/13.core-bot/.env
+++ b/samples/typescript_nodejs/13.core-bot/.env
@@ -1,5 +1,7 @@
+MicrosoftAppType=
 MicrosoftAppId=
 MicrosoftAppPassword=
+MicrosoftAppTenantId=
 LuisAppId=
 LuisAPIKey=
 LuisAPIHostName=

--- a/samples/typescript_nodejs/13.core-bot/package.json
+++ b/samples/typescript_nodejs/13.core-bot/package.json
@@ -38,10 +38,10 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.14.0",
-        "botbuilder-ai": "~4.14.0",
-        "botbuilder-dialogs": "~4.14.0",
-        "botbuilder-testing": "~4.14.0",
+        "botbuilder": "~4.15.0-rc0",
+        "botbuilder-ai": "~4.15.0-rc0",
+        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder-testing": "~4.15.0-rc0",
         "dotenv": "^8.2.0",
         "replace": "~1.2.0",
         "restify": "~8.5.1"
@@ -49,7 +49,6 @@
     "devDependencies": {
         "@types/dotenv": "6.1.1",
         "@types/mocha": "^7.0.2",
-        "@types/node": "^10.17.27",
         "@types/restify": "8.4.2",
         "mocha": "^7.1.2",
         "nodemon": "~2.0.4",

--- a/samples/typescript_nodejs/13.core-bot/package.json
+++ b/samples/typescript_nodejs/13.core-bot/package.json
@@ -49,6 +49,7 @@
     "devDependencies": {
         "@types/dotenv": "6.1.1",
         "@types/mocha": "^7.0.2",
+        "@types/node": "^16.11.6",
         "@types/restify": "8.4.2",
         "mocha": "^7.1.2",
         "nodemon": "~2.0.4",


### PR DESCRIPTION
Addresses #3550

## Description
This PR updates the TypeScript samples, adding support for CloudAdapter and MSI.

### Detailed Changes
- Updated the **_botbuilder_** dependency to the RC0 version.
- Updated **_index.js_** to:
   - Replace BotFrameworkAdapter with CloudAdapter.
   - Added an instance of ConfigurationServiceClientCredentialFactory to manage credentials.
   - Pass the new parameters AppType and AppTenantId to the _ConfigurationServiceClientCredentialFactory_ instance.
- Added the new settings _MicrosoftAppType_ and _MicrosoftAppTenantId_ to the **_env_** file.
- Added missing **env** files.
- Update devDependency **@types/node** from echo and core bots as it was causing issues when running `npm install`.

This PR updates the following samples:
- 00.empty-bot
- 02.echo-bot
- 03.welcome-users
- 05.multi-turn-prompt
- 06.using-cards
- 13.core-bot

## Testing
The following images show the 13.core-bot sample properly configured and working on Azure
![image](https://user-images.githubusercontent.com/44245136/139735812-95489062-4056-4016-9d29-30d71774b62d.png)
