### PR TITLE
[#3439] Samples (02.echo-bot/13.core-bot) fails due to AppServicePlan not found in null RG

### DIFF
--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/template.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/template.json
@@ -32,13 +32,62 @@
             "type": "string"
         },
         "appSecret": {
-            "defaultValue": "blank",
+            "defaultValue": "",
             "type": "string"
+        },
+        "appType": {
+            "defaultValue": "MultiTenant",
+            "type": "string",
+            "allowedValues": [
+                "MultiTenant",
+                "SingleTenant",
+                "UserAssignedMSI"
+            ]
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]"
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": ""
         }
     },
     "variables": {
         "siteHost": "[concat(parameters('botName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -65,6 +114,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', parameters('botName'))]"
             ],
             "kind": "app,linux",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "enabled": true,
                 "hostNameSslStates": [
@@ -88,12 +138,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ]
                 },
@@ -212,6 +270,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/template.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/template.json
@@ -32,13 +32,62 @@
             "type": "string"
         },
         "appSecret": {
-            "defaultValue": "blank",
+            "defaultValue": "",
             "type": "string"
+        },
+        "appType": {
+            "defaultValue": "MultiTenant",
+            "type": "string",
+            "allowedValues": [
+                "MultiTenant",
+                "SingleTenant",
+                "UserAssignedMSI"
+            ]
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]"
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": ""
         }
     },
     "variables": {
         "siteHost": "[concat(parameters('botName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
     },
     "resources": [
         {
@@ -65,6 +114,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', parameters('botName'))]"
             ],
             "kind": "app,linux",
+            "identity": "[variables('appType').identity]",
             "properties": {
                 "enabled": true,
                 "hostNameSslStates": [
@@ -88,12 +138,20 @@
                             "value": "10.14.1"
                         },
                         {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
                             "name": "MicrosoftAppId",
                             "value": "[parameters('appId')]"
                         },
                         {
                             "name": "MicrosoftAppPassword",
                             "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
                         }
                     ]
                 },
@@ -212,6 +270,9 @@
                 "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
                 "endpoint": "[variables('botEndpoint')]",
                 "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
                 "luisAppIds": [],
                 "schemaTransformationVersion": "1.3",
                 "isCmekEnabled": false,

--- a/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/linux/template.json
+++ b/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/linux/template.json
@@ -32,7 +32,7 @@
             "type": "string"
         },
         "appSecret": {
-            "defaultValue": "blank",
+            "defaultValue": "",
             "type": "string"
         }
     },

--- a/samples/typescript_nodejs/13.core-bot/deploymentTemplates/linux/template.json
+++ b/samples/typescript_nodejs/13.core-bot/deploymentTemplates/linux/template.json
@@ -32,7 +32,7 @@
             "type": "string"
         },
         "appSecret": {
-            "defaultValue": "blank",
+            "defaultValue": "",
             "type": "string"
         }
     },


### PR DESCRIPTION
Fixes #3439

## Proposed Changes
This PR fixes small issues in Linux templates for JS and TS _echo-bot_ and _core-bot_ samples to work with MSI.

### Detailed Changes
- Changed _appSecret_ parameter's default value from "blank" to "".
- Added the Identity resource in _Microsoft.Web/sites_ definition.

## Testing
These images show the bot's resources successfully created with MSI and the bot working as expected.
![image](https://user-images.githubusercontent.com/44245136/139941570-b34fa980-3c15-4612-81c3-4757d41d2521.png)
