### PR TITLE
[#3440] Fix adaptive-dialog samples with Unauthorized error

### DIFF
--- a/samples/csharp_dotnetcore/adaptive-dialog/09.integrating-composer-dialogs/Program.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/09.integrating-composer-dialogs/Program.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.IO;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder.AI.Luis;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -19,20 +17,6 @@ namespace Microsoft.BotBuilderSamples
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-
-                .ConfigureAppConfiguration((hostingConetxt, config) =>
-                {
-                    var di = new DirectoryInfo(".");
-                    foreach (var file in di.GetFiles($"appsettings.json", SearchOption.AllDirectories))
-                    {
-                        var relative = file.FullName.Substring(di.FullName.Length);
-                        if (!relative.Contains("bin\\") && !relative.Contains("obj\\"))
-                        {
-                            config.AddJsonFile(file.FullName, optional: false, reloadOnChange: true);
-                        }
-                    }
-                })
-
                 .ConfigureAppConfiguration((hostingContext, builder) =>
                 {
                     builder.UseLuisSettings();

--- a/samples/csharp_dotnetcore/adaptive-dialog/20.EchoBot-declarative/Program.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/20.EchoBot-declarative/Program.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.IO;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder.AI.Luis;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -19,20 +17,6 @@ namespace Microsoft.BotBuilderSamples
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-
-                .ConfigureAppConfiguration((hostingConetxt, config) =>
-                {
-                    var di = new DirectoryInfo(".");
-                    foreach (var file in di.GetFiles($"appsettings.json", SearchOption.AllDirectories))
-                    {
-                        var relative = file.FullName.Substring(di.FullName.Length);
-                        if (!relative.Contains("bin\\") && !relative.Contains("obj\\"))
-                        {
-                            config.AddJsonFile(file.FullName, optional: false, reloadOnChange: true);
-                        }
-                    }
-                })
-
                 .ConfigureAppConfiguration((hostingContext, builder) =>
                 {
                     builder.UseLuisSettings();

--- a/samples/csharp_dotnetcore/adaptive-dialog/21.AdaptiveBot-declarative/Program.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/21.AdaptiveBot-declarative/Program.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.IO;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder.AI.Luis;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -19,20 +17,6 @@ namespace Microsoft.BotBuilderSamples
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-
-                .ConfigureAppConfiguration((hostingConetxt, config) =>
-                {
-                    var di = new DirectoryInfo(".");
-                    foreach (var file in di.GetFiles($"appsettings.json", SearchOption.AllDirectories))
-                    {
-                        var relative = file.FullName.Substring(di.FullName.Length);
-                        if (!relative.Contains("bin\\") && !relative.Contains("obj\\"))
-                        {
-                            config.AddJsonFile(file.FullName, optional: false, reloadOnChange: true);
-                        }
-                    }
-                })
-
                 .ConfigureAppConfiguration((hostingContext, builder) =>
                 {
                     builder.UseLuisSettings();


### PR DESCRIPTION
Fixes #3440

## Description
This PR fixes an issue when setting the `appsettings.json` credentials, it throws `Unauthorized` error. This was caused by a process loading the `appsettings.json` manually, by removing this process the correct file is used.

### Detailed Changes
- Removed `ConfigureAppConfiguration` step by not loading the `appsettings.json` file manually.
  - This was causing to load the wrong configuration file, leading to use wrong credentials.

This PR updates the following samples:
- adaptive-dialog/09.integrating-composer-dialogs
- adaptive-dialog/20.EchoBot-declarative
- adaptive-dialog/21.AdaptiveBot-declarative

## Testing
The following image shows the bots are working as expected and using the right credentials.
![image](https://user-images.githubusercontent.com/62260472/139877352-f63850f6-853d-4fe8-8c60-60810da3060e.png)
