### PR TITLE
[#3582] Samples (csharp_dotnetcore/adaptive-dialog) are not validating the age correctly

### DIFF
--- a/samples/csharp_dotnetcore/adaptive-dialog/05.interruptions-bot/Dialogs/GetUserProfileDialog/GetUserProfileDialog.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/05.interruptions-bot/Dialogs/GetUserProfileDialog/GetUserProfileDialog.cs
@@ -92,10 +92,10 @@ namespace Microsoft.BotBuilderSamples
                                 // when we do not get a value for the personName entity. 
                                 AllowInterruptions = "turn.recognized.score >= 0.9 || !@personName"
                             },
-                            new TextInput()
+                            new NumberInput()
                             {
                                 Property = "user.profile.age",
-                                Prompt = new ActivityTemplate("${AskUserAage()}"),
+                                Prompt = new ActivityTemplate("${AskUserAge()}"),
                                 Validations = new List<BoolExpression>()
                                 {
                                     // Age must be within 1-150.

--- a/samples/csharp_dotnetcore/adaptive-dialog/05.interruptions-bot/Dialogs/GetUserProfileDialog/GetUserProfileDialog.lg
+++ b/samples/csharp_dotnetcore/adaptive-dialog/05.interruptions-bot/Dialogs/GetUserProfileDialog/GetUserProfileDialog.lg
@@ -10,10 +10,10 @@
 # AskFirstName.Invalid()
 - Sorry '${this.value}' does not work. I'm looking for a value between 3-50 characters. ${AskFirstName()}
 
-# AskUserAage
+# AskUserAge
 [Activity
     Text = ${AckPhrase()} ${user.profile.name}, ${GetAge()}
-    SuggestedActions = Why? | No age | Cancel
+    SuggestedActions = Why? | Will not give it | Cancel
 ]
 
 # AskUserAge.Invalid

--- a/samples/csharp_dotnetcore/adaptive-dialog/06.todo-bot/Dialogs/GetUserProfileDialog/GetUserProfileDialog.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/06.todo-bot/Dialogs/GetUserProfileDialog/GetUserProfileDialog.cs
@@ -90,10 +90,10 @@ namespace Microsoft.BotBuilderSamples
                                 // when we do not get a value for the personName entity. 
                                 AllowInterruptions = "turn.recognized.score >= 0.9 || !@personName",
                             },
-                            new TextInput()
+                            new NumberInput()
                             {
                                 Property = "user.profile.age",
-                                Prompt = new ActivityTemplate("${AskUserAage()}"),
+                                Prompt = new ActivityTemplate("${AskUserAge()}"),
                                 Validations = new List<BoolExpression>()
                                 {
                                     // Age must be within 1-150.
@@ -129,7 +129,7 @@ namespace Microsoft.BotBuilderSamples
                         Intent = "NoValue",
                         
                         // Only do this only on high confidence recognition
-                        Condition = "#NoValue.Score >= 0.9",
+                        Condition = "#NoValue.Score >= 0.8",
                         Actions = new List<Dialog>()
                         {
                             new IfCondition()

--- a/samples/csharp_dotnetcore/adaptive-dialog/06.todo-bot/Dialogs/GetUserProfileDialog/GetUserProfileDialog.lg
+++ b/samples/csharp_dotnetcore/adaptive-dialog/06.todo-bot/Dialogs/GetUserProfileDialog/GetUserProfileDialog.lg
@@ -10,10 +10,10 @@
 # AskFirstName.Invalid()
 - Sorry '${this.value}' does not work. I'm looking for a value between 3-50 characters. ${AskFirstName()}
 
-# AskUserAage
+# AskUserAge
 [Activity
     Text = ${AckPhrase()} ${user.profile.name}, ${GetAge()}
-    SuggestedActions = Why? | No age | Cancel
+    SuggestedActions = Why? | Will not give it | Cancel
 ]
 
 # AskUserAge.Invalid

--- a/samples/csharp_dotnetcore/adaptive-dialog/08.todo-bot-luis-qnamaker/Dialogs/GetUserProfileDialog/GetUserProfileDialog.cs
+++ b/samples/csharp_dotnetcore/adaptive-dialog/08.todo-bot-luis-qnamaker/Dialogs/GetUserProfileDialog/GetUserProfileDialog.cs
@@ -96,10 +96,10 @@ namespace Microsoft.BotBuilderSamples
                                 // when we do not get a value for the personName entity. 
                                 AllowInterruptions = "turn.recognized.score >= 0.9 || !@personName",
                             },
-                            new TextInput()
+                            new NumberInput()
                             {
                                 Property = "user.profile.age",
-                                Prompt = new ActivityTemplate("${AskUserAage()}"),
+                                Prompt = new ActivityTemplate("${AskUserAge()}"),
                                 Validations = new List<BoolExpression>()
                                 {
                                     // Age must be within 1-150.

--- a/samples/csharp_dotnetcore/adaptive-dialog/08.todo-bot-luis-qnamaker/Dialogs/GetUserProfileDialog/GetUserProfileDialog.lg
+++ b/samples/csharp_dotnetcore/adaptive-dialog/08.todo-bot-luis-qnamaker/Dialogs/GetUserProfileDialog/GetUserProfileDialog.lg
@@ -7,10 +7,10 @@
 # AskFirstName.Invalid()
 - Sorry '${this.value}' does not work. I'm looking for a value between 3-50 characters. ${AskFirstName()}
 
-# AskUserAage
+# AskUserAge
 [Activity
     Text = ${AckPhrase()} ${user.profile.name}, ${GetAge()}
-    SuggestedActions = Why? | No age | Cancel
+    SuggestedActions = Why? | Will not give it | Cancel
 ]
 
 # AskUserAge.Invalid

--- a/samples/csharp_dotnetcore/adaptive-dialog/08.todo-bot-luis-qnamaker/Dialogs/GetUserProfileDialog/GetUserProfileDialog.qna
+++ b/samples/csharp_dotnetcore/adaptive-dialog/08.todo-bot-luis-qnamaker/Dialogs/GetUserProfileDialog/GetUserProfileDialog.qna
@@ -1,7 +1,7 @@
 ﻿> QnA definition.
 > See https://aka.ms/qna-file-format to learn more.
 
-[ChitChat](./ChitChat.qna)
+[ChitChat](../RootDialog/ChitChat.qna)
 
 # ?Why do you need my name?
 - why do you ask for my name?

--- a/samples/csharp_dotnetcore/adaptive-dialog/08.todo-bot-luis-qnamaker/Dialogs/RootDialog/RootDialog.qna
+++ b/samples/csharp_dotnetcore/adaptive-dialog/08.todo-bot-luis-qnamaker/Dialogs/RootDialog/RootDialog.qna
@@ -21,7 +21,6 @@ Sorry, I do not support that yet. But I will let the development team know!
 
 # ?What do you do with my profile?
 - why profile?
-- profile?
 ```
 I need your profile to provide you the best experience. See http://contoso.com/privacy to learn more about our privacy policy.
 ```


### PR DESCRIPTION
Fixes #3582

## Description
This PR fixes an issue when the bot asks for the user's age and when provided, it shows `Sorry, 'XX' does not work. I'm looking for a value between 1-150.`.

### Detailed Changes
- Ask for the age step recognition, was changed from `TextInput` to `NumberInput`.
  - The ActivityTemplate `AskUserAege` was changed to `AskUserAge` to be more clear.
  - In the `AskUserAge` template, the `No age` suggested option, was changed to `Will not give it`, as LUIS was returning a coincidence with the `age` utterance, causing to return an age of 0 (zero).
- **06.todo-bot**
  - `NoValue` intent score was changed from `0.9` to `0.8`, due to not recognizing the step when `No name` was provided by a significant amount of `0.15`.
- **08.todo-bot-luis-qnamaker**
  - `GetUserProfileDialog.qna` ChitChat path was changed from `[ChitChat](./ChitChat.qna)` to `[ChitChat](../RootDialog/ChitChat.qna)`. (Fixes #2758)
  - Removed `profile?` from QnA, due to not recognizing `Profile` suggested action provided by the user.

This PR updates the following samples
- 05.interruptions-bot
- 06.todo-bot
- 08.todo-bot-luis-qnamaker

## Testing
The following images show the bot unable to recognize the age, and the bot after the fix recognizing the age properly.
![image](https://user-images.githubusercontent.com/62260472/140949632-d282e912-2269-41ca-b749-eb7d5871e65b.png)
![image](https://user-images.githubusercontent.com/62260472/140949641-997b35ac-b019-4293-9be6-236c820581ab.png)