### PR TITLE
set headers for get request

### DIFF
--- a/samples/javascript_nodejs/56.teams-file-upload/services/fileService.js
+++ b/samples/javascript_nodejs/56.teams-file-upload/services/fileService.js
@@ -15,7 +15,12 @@ const geneFileName = async (fileDir) => {
 
 // Download and Save Streams into File
 const writeFile = async (contentUrl, config, filePath) => {
-    const response = await axios({ method: 'GET', url: contentUrl, responseType: 'stream' });
+    const response = await axios({
+        method: 'GET',
+        url: contentUrl,
+        headers: config.headers || {},
+        responseType: config.responseType || 'stream'
+    });
     return await new Promise((resolve, reject) => response.data.pipe(fs.createWriteStream(filePath)).once('finish', resolve).once('error', reject));
 };
 


### PR DESCRIPTION
Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->
<!-- If you are introducing a new sample, make sure that the sample adheres to sample guidelines -->

  - Nodejs sample 56 failed when upload inline images, the root cause is that the http request header for authorization is not set.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
My local test verify the fix.