### PR TITLE
Make Samples E2E test pipelines runnable in branch 4.11

### DIFF
--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -1,0 +1,376 @@
+# This is used in the pipelines Sample-DotNet-CoreBot-Linux-Test-yaml and Sample-DotNet-EchoBot-Linux-Test-yaml.
+
+# 'Allow scripts to access the OAuth token' was selected in pipeline.  Add the following YAML to any steps requiring access:
+#       env:
+#           MY_ACCESS_TOKEN: $(System.AccessToken)
+# Variable 'AppId' is defined in Azure
+# Variable 'AppSecret' is defined in Azure
+# Variable 'AzureBotName' is defined in Azure
+# Variable 'AzureSubscription' is defined in Azure
+# Variable 'BotGroup' is defined in Azure
+# Variable 'BuildConfiguration' is defined in Azure
+# Variable 'DeleteResourceGroup' is defined in Azure
+# Variable 'MyGetPersonalAccessToken' is defined in Azure
+# Variable 'runCodesignValidationInjection' is defined in Azure
+# Variable 'SampleBotName' is defined in Azure
+# Variable 'SampleFolderName' is defined in Azure
+# Variable 'SampleRootPath' is defined in Azure
+# Variable Group 'AzureDeploymentCredsVariableGroup' is defined in Azure
+# Variable Group 'SamplesE2ETestsVariableGroup' is defined in Azure
+# Variable Group 'MyGetPersonalAccessTokenVariableGroup' is defined in Azure
+
+parameters:
+  - name: testLatestPackage
+    displayName: Test latest package version
+    type: boolean
+    default: true
+  - name: versionToTest
+    displayName: Version to test (Only if 'Test latest' is unchecked)
+    type: string
+    default: 'Example: 4.15.0-daily.20210714.258979.1220aed'
+  - name: packageFeed
+    displayName: Package feed to use
+    type: string
+    default: Azure
+    values:
+    - Azure
+    - MyGet
+    - NuGet
+
+# Run this job every night at 2 AM (PST) on the main branch
+schedules:
+- cron: 0 9 * * *
+  displayName: Daily 2AM PST build
+  branches:
+    include:
+    - main
+  always: true
+
+# Do not run PR validation
+pr: none
+
+# Do not run CI validation
+trigger: none
+
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: main
+
+#variables:
+#- group: AzureDeploymentCredsVariableGroup
+#- group: SamplesE2ETestsVariableGroup
+#- group: MyGetPersonalAccessTokenVariableGroup
+
+jobs:
+- job: Job_1
+  displayName: Agent job 1
+  pool:
+    vmImage: windows-2019
+  steps:
+  - checkout: self
+    persistCredentials: True
+  
+  - powershell: |
+      $file = "$(SampleRootPath)\nuget.config";
+
+      $content = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <add key="ConversationalAI" value="https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" />
+          <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
+
+      "@;
+
+      New-Item -Path $file -ItemType "file" -Value $content;
+      '-------------'; get-content "$file"; '===================';
+    displayName: Create nuget.config for Azure feed
+    condition: ${{ eq(parameters.packageFeed, 'Azure') }}
+
+  - powershell: |
+      $file = "$(SampleRootPath)\nuget.config";
+
+      $content = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <add key="MyGet" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
+
+      "@;
+
+      New-Item -Path $file -ItemType "file" -Value $content;
+      '-------------'; get-content "$file"; '===================';
+    displayName: Create nuget.config for MyGet feed
+    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
+
+  - powershell: |
+      $file = "$(SampleRootPath)\nuget.config";
+
+      $content = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
+
+      "@;
+
+      New-Item -Path $file -ItemType "file" -Value $content;
+      '-------------'; get-content "$file"; '===================';
+    displayName: Create nuget.config for NuGet feed
+    condition: ${{ eq(parameters.packageFeed, 'NuGet') }}
+
+  - powershell: |
+      $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
+   
+      #$url = "https://feeds.dev.azure.com/ConversationalAI/BotFramework/_apis/packaging/Feeds/SDK/Packages/26dde74d-6079-401c-a9e0-c6d839e02c18/versions?api-version=5.1-preview.1"
+   
+      Write-Host "Get latest $packageName version number from Azure ConversationalAI BotFramework SDK feed";
+   
+      $RegistryUrlSource = "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" 
+      " "
+      "Available versions:";
+      nuget list Microsoft.Bot.Builder.Integration.AspNet.Core -Source "$RegistryUrlSource" -PreRelease -AllVersions | Select -First 30;
+
+      $PackageList = nuget list Microsoft.Bot.Builder.Integration.AspNet.Core -Source "$RegistryUrlSource" -PreRelease;
+      [string]$latestVersion = $PackageList.Split(" ")[-1];
+      " "
+      "Latest version:";
+      $packageName;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+    displayName: 'From Azure feed get latest Bot.Builder version number - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
+
+  - powershell: |
+      $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      $myGetFeedName = "botbuilder-v4-dotnet-daily";
+      $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
+
+      $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
+
+      Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
+      $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+
+      $package = $result.packages | Where-Object {$_.id -eq $packageName};
+      " "
+      "Available versions:";
+      $package.versions | Select -Last 30;
+
+      [string]$latestVersion = $package.versions[-1];
+      " "
+      "Latest version:";
+      $package.id;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
+    displayName: 'From MyGet feed get latest Bot.Builder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
+
+  - powershell: |
+      $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
+   
+      Write-Host "Get latest $packageName version number from NuGet.org feed";
+         
+      $registryUrlSource = "https://nuget.org/api/v2/";
+
+      $packageList = Find-package -AllVersions -source $registryUrlSource -Name $packageName -AllowPrereleaseVersions | Select -First 30;
+      " "
+      "Available versions:";
+      $PackageList.Version
+
+      $latestVersion = $PackageList.Version[0];
+      " "
+      "Latest version:";
+      $packageName;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+    displayName: 'From NuGet feed get latest Bot.Builder version number - https://www.nuget.org/packages?q=Bot.Builder'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'NuGet')) }}
+
+  - powershell: |
+     $targetVersion = "${{ parameters.versionToTest }}";
+     $targetVersion;
+     "##vso[task.setvariable variable=TargetVersion;]$targetVersion";
+    displayName: 'From user input get specific Bot.Builder version number'
+    condition: ${{ ne(parameters.testLatestPackage, true) }}
+
+  - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
+    displayName: 'Display env vars'
+ 
+  - task: tagBuildOrRelease@0
+    displayName: Tag Build with Bot.Builder version
+    inputs:
+      tags: |
+        Using Bot.Builder version $(TargetVersion)
+        From ${{ parameters.packageFeed }} feed 
+        Test latest = ${{ parameters.testLatestPackage }}
+
+  - powershell: |
+      $path = "$(SampleRootPath)\\$(SampleBotName).csproj";
+      $packages = @('Microsoft.Bot.Builder.Integration.AspNet.Core','Microsoft.Bot.Builder.AI.Luis','Microsoft.Bot.Builder.Dialogs');
+      $newVersion = "$(TargetVersion)";
+
+      $content = Get-ChildItem -Path "$path" | Get-Content -Raw
+
+      foreach ($package in $packages) {
+          $find = "$package`" Version=`"\S*`"";
+          $replace = "$package`" Version=`"$newVersion`"";
+          $content = $content -Replace "$find", "$replace";
+      }
+
+      Set-Content -Path $path -Value $content;
+      '-------------'; get-content $path; '===================';
+    displayName: Set Bot.Builder version reference in $(SampleBotName).csproj
+
+  - task: NuGetToolInstaller@1
+    displayName: Use NuGet 5.5.1
+    inputs:
+      versionSpec: 5.5.1
+
+  - task: NuGetCommand@2
+    displayName: NuGet restore $(SampleBotName).csproj
+    inputs:
+      solution: $(SampleRootPath)\$(SampleBotName).csproj
+      selectOrConfig: config
+      nugetConfigPath: $(SampleRootPath)\nuget.config
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet publish $(SampleBotName).csproj
+    inputs:
+      command: publish
+      publishWebProjects: false
+      projects: $(SampleRootPath)\$(SampleBotName).csproj
+      custom: publish
+      arguments: --runtime linux-x64 --configuration $(BuildConfiguration) --output $(SampleRootPath)\publishedbot
+      zipAfterPublish: false
+      modifyOutputPath: false
+
+  - task: AzureCLI@2
+    displayName: 'Preexisting RG: create group, create resources, #prepare .deployment file'
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+       Set-PSDebug -Trace 1;
+     
+       az group create --location westus --name $(BotGroup)
+     
+       # set up bot channels registration, app service, app service plan
+       az deployment group create --resource-group "$(BotGroup)" --template-file "$(SampleRootPath)\DeploymentTemplates\LinuxDotNet\template.json" --parameters appId="$(AppId)" appSecret="$(AppSecret)" botName="$(AzureBotName)" --name "$(AzureBotName)";
+     
+       #az bot prepare-deploy --lang Csharp --code-dir "$(SampleRootPath)" --proj-file-path "$(SampleBotName).csproj";
+     
+       Set-PSDebug -Trace 0;
+
+  - powershell: |
+      Set-PSDebug -Trace 1;
+      # Copy Azure deploy scripts for Linux
+      Move-Item -Path $(SampleRootPath)\DeploymentScripts\Linux\* -Destination $(SampleRootPath)\;
+      Set-PSDebug -Trace 0;
+    displayName: Move .deployment, deploy.sh scripts into position
+
+  - script: |
+      echo on
+      git config --global user.name "BotBuilderSamplesPipeline"
+      git config --global user.email BotBuilderSamples@Pipeline.com
+      git init
+   
+      git add .
+      git commit -m "Add bot source code"
+      git remote add azure https://$(AzureDeploymentUser):$(AzureDeploymentPassword)@$(AzureBotName).scm.azurewebsites.net:443/$(AzureBotName).git
+   
+      git push azure master
+    workingDirectory: '$(SampleRootPath)'
+    displayName: 'Deploy the bot to Azure'
+
+  - task: AzureCLI@2
+    displayName: Create DirectLine channel
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: batch
+      scriptLocation: inlineScript
+      inlineScript: call az bot directline create --name "$(AzureBotName)" --resource-group "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json" --debug
+
+  - powershell: |
+      # Key = Direct Line channel "Secret keys" in Azure portal
+      $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
+      $key = $json.properties.properties.sites.key;
+      echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
+      echo "##vso[task.setvariable variable=BOTID;]$(AzureBotName)";
+      Write-Host "setx DIRECTLINE $key";
+      Write-Host "setx BOTID $(AzureBotName)";
+    displayName: Set DIRECTLINE key, BOTID for running tests
+
+  - task: NuGetCommand@2
+    displayName: NuGet restore Samples.$(SampleBotName).FunctionalTests.csproj
+    inputs:
+      solution: samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
+      selectOrConfig: config
+      nugetConfigPath: $(SampleRootPath)\nuget.config
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build Samples.$(SampleBotName).FunctionalTests.csproj
+    inputs:
+      projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
+
+  - powershell: |
+      Start-Sleep -Seconds 800
+    displayName: 'Sleep for 13 min 20 sec'
+    enabled: true
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test
+    inputs:
+      command: test
+      projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/**Tests.csproj
+      arguments: --verbosity Normal
+
+  - script: |
+      dir .. /s
+    displayName: 'Dir workspace'
+    continueOnError: true
+    condition: always()
+
+  - task: AzureCLI@2
+    displayName: Delete bot, app service, app service plan, group
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        Set-PSDebug -Trace 1;
+
+        Write-Host "1) Delete Bot:";
+        az bot delete --name $(AzureBotName) --resource-group $(BotGroup);
+
+        Write-Host "2) Delete App Service:";
+        az webapp delete --name $(AzureBotName) --resource-group $(BotGroup);
+
+        Write-Host "3) Delete App Service plan:";
+        az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes;
+
+        Write-Host "4) Delete Resource Group:";
+        az group delete --name $(BotGroup) --yes;
+
+        Set-PSDebug -Trace 0;
+    condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
+    continueOnError: True
+
+...

--- a/build/yaml/sample-dotnet-samplebot-win-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-win-test.yml
@@ -1,0 +1,386 @@
+# This is used in the pipelines Sample-DotNet-CoreBot-Win-Test-yaml and Sample-DotNet-EchoBot-Win-Test-yaml.
+
+# 'Allow scripts to access the OAuth token' was selected in pipeline.  Add the following YAML to any steps requiring access:
+#       env:
+#           MY_ACCESS_TOKEN: $(System.AccessToken)
+# Variable 'AppId' is defined in Azure
+# Variable 'AppSecret' is defined in Azure
+# Variable 'AzureBotName' is defined in Azure
+# Variable 'AzureSubscription' is defined in Azure
+# Variable 'BotGroup' is defined in Azure
+# Variable 'BuildConfiguration' is defined in Azure
+# Variable 'DeleteResourceGroup' is defined in Azure
+# Variable 'MyGetPersonalAccessToken' is defined in Azure
+# Variable 'runCodesignValidationInjection' is defined in Azure
+# Variable 'SampleBotName' is defined in Azure
+# Variable 'SampleFolderName' is defined in Azure
+# Variable 'SampleRootPath' is defined in Azure
+# Variable Group 'SamplesE2ETestsVariableGroup' is defined in Azure
+# Variable Group 'MyGetPersonalAccessTokenVariableGroup' is defined in Azure
+
+parameters:
+  - name: testLatestPackage
+    displayName: Test latest package version
+    type: boolean
+    default: true
+  - name: versionToTest
+    displayName: Version to test (Only if 'Test latest' is unchecked)
+    type: string
+    default: 'Example: 4.15.0-daily.20210714.258979.1220aed'
+  - name: packageFeed
+    displayName: Package feed to use
+    type: string
+    default: Azure
+    values:
+    - Azure
+    - MyGet
+    - NuGet
+
+# Run this job every night at 2 AM (PST) on the main branch
+schedules:
+- cron: 0 9 * * *
+  displayName: Daily 2AM PST build
+  branches:
+    include:
+    - main
+  always: true
+
+# Do not run PR validation
+pr: none
+
+# Do not run CI validation
+trigger: none
+
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: main
+
+#variables:
+#- group: SamplesE2ETestsVariableGroup
+#- group: MyGetPersonalAccessTokenVariableGroup
+
+jobs:
+- job: Job_1
+  displayName: Agent job 1
+  pool:
+    vmImage: windows-2019
+  steps:
+  - checkout: self
+    persistCredentials: True
+  
+  - powershell: |
+      $file = "$(SampleRootPath)\nuget.config";
+
+      $content = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <add key="ConversationalAI" value="https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" />
+          <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
+
+      "@;
+
+      New-Item -Path $file -ItemType "file" -Value $content;
+      '-------------'; get-content "$file"; '===================';
+    displayName: Create nuget.config for Azure feed
+    condition: ${{ eq(parameters.packageFeed, 'Azure') }}
+
+  - powershell: |
+      $file = "$(SampleRootPath)\nuget.config";
+
+      $content = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <add key="MyGet" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
+
+      "@;
+
+      New-Item -Path $file -ItemType "file" -Value $content;
+      '-------------'; get-content "$file"; '===================';
+    displayName: Create nuget.config for MyGet feed
+    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
+
+  - powershell: |
+      $file = "$(SampleRootPath)\nuget.config";
+
+      $content = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
+
+      "@;
+
+      New-Item -Path $file -ItemType "file" -Value $content;
+      '-------------'; get-content "$file"; '===================';
+    displayName: Create nuget.config for NuGet feed
+    condition: ${{ eq(parameters.packageFeed, 'NuGet') }}
+
+  - powershell: |
+      $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
+   
+      #$url = "https://feeds.dev.azure.com/ConversationalAI/BotFramework/_apis/packaging/Feeds/SDK/Packages/26dde74d-6079-401c-a9e0-c6d839e02c18/versions?api-version=5.1-preview.1"
+   
+      Write-Host "Get latest $packageName version number from Azure ConversationalAI BotFramework SDK feed";
+   
+      $RegistryUrlSource = "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" 
+      " "
+      "Available versions:";
+      nuget list Microsoft.Bot.Builder.Integration.AspNet.Core -Source "$RegistryUrlSource" -PreRelease -AllVersions | Select -First 30;
+
+      $PackageList = nuget list Microsoft.Bot.Builder.Integration.AspNet.Core -Source "$RegistryUrlSource" -PreRelease;
+      [string]$latestVersion = $PackageList.Split(" ")[-1];
+   
+      #$result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+      #[string]$latestVersion = $result.value[0].protocolMetadata.data.version;
+      " "
+      "Latest version:";
+      $packageName;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+    displayName: 'From Azure feed get latest Bot.Builder version number - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
+
+  - powershell: |
+      $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      $myGetFeedName = "botbuilder-v4-dotnet-daily";
+      $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
+
+      $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
+
+      Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
+      $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+
+      $package = $result.packages | Where-Object {$_.id -eq $packageName};
+      " "
+      "Available versions:";
+      $package.versions | Select -Last 30;
+
+      [string]$latestVersion = $package.versions[-1];
+      " "
+      "Latest version:";
+      $package.id;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
+    displayName: 'From MyGet feed get latest Bot.Builder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
+
+  - powershell: |
+      $packageName = "Microsoft.Bot.Builder.Integration.AspNet.Core";
+   
+      Write-Host "Get latest $packageName version number from NuGet.org feed";
+         
+      $registryUrlSource = "https://nuget.org/api/v2/";
+
+      $packageList = Find-package -AllVersions -source $registryUrlSource -Name $packageName -AllowPrereleaseVersions | Select -First 30;
+      " "
+      "Available versions:";
+      $PackageList.Version
+
+      $latestVersion = $PackageList.Version[0];
+      " "
+      "Latest version:";
+      $packageName;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+    displayName: 'From NuGet feed get latest Bot.Builder version number - https://www.nuget.org/packages?q=Bot.Builder'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'NuGet')) }}
+
+  - powershell: |
+     $targetVersion = "${{ parameters.versionToTest }}";
+     $targetVersion;
+     "##vso[task.setvariable variable=TargetVersion;]$targetVersion";
+    displayName: 'From user input get specific Bot.Builder version number'
+    condition: ${{ ne(parameters.testLatestPackage, true) }}
+
+  - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
+    displayName: 'Display env vars'
+ 
+  - task: tagBuildOrRelease@0
+    displayName: Tag Build with Bot.Builder version
+    inputs:
+      tags: |
+        Using Bot.Builder version $(TargetVersion)
+        From ${{ parameters.packageFeed }} feed 
+        Test latest = ${{ parameters.testLatestPackage }}
+
+  - powershell: |
+      $path = "$(SampleRootPath)\\$(SampleBotName).csproj";
+      $packages = @('Microsoft.Bot.Builder.Integration.AspNet.Core','Microsoft.Bot.Builder.AI.Luis','Microsoft.Bot.Builder.Dialogs');
+      $newVersion = "$(TargetVersion)";
+
+      $content = Get-ChildItem -Path "$path" | Get-Content -Raw
+
+      foreach ($package in $packages) {
+          $find = "$package`" Version=`"\S*`"";
+          $replace = "$package`" Version=`"$newVersion`"";
+          $content = $content -Replace "$find", "$replace";
+      }
+
+      Set-Content -Path $path -Value $content;
+      '-------------'; get-content $path; '===================';
+    displayName: Set Bot.Builder version reference in $(SampleBotName).csproj
+
+  - task: NuGetToolInstaller@1
+    displayName: Use NuGet 5.5.1
+    inputs:
+      versionSpec: 5.5.1
+
+  - task: NuGetCommand@2
+    displayName: NuGet restore $(SampleBotName).csproj
+    inputs:
+      restoreSolution: $(SampleRootPath)\$(SampleBotName).csproj
+      feedsToUse: config
+      nugetConfigPath: $(SampleRootPath)\nuget.config
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet publish $(SampleBotName).csproj
+    inputs:
+      command: publish
+      publishWebProjects: false
+      projects: $(SampleRootPath)\$(SampleBotName).csproj
+      arguments: --configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)
+
+  - task: AzureCLI@2
+    displayName: 'Preexisting RG: create Azure resources. Runs in even builds.'
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        Write-Host "`n***** Creating Azure resources using the preexisting-rg template *****";
+        Write-Host "This task runs for even-numbered builds. Build ID = $(Build.BuildId)";
+        Write-Host "************************************************************************";
+        Set-PSDebug -Trace 1;
+     
+        az group create --location westus --name $(BotGroup);
+     
+        # set up bot channels registration, app service, app service plan
+        az deployment group create --resource-group "$(BotGroup)" --template-file "$(SampleRootPath)\DeploymentTemplates\template-with-preexisting-rg.json" --parameters appId="$(AppId)" appSecret="$(AppSecret)" botId="$(AzureBotName)" newWebAppName="$(AzureBotName)" newAppServicePlanName="$(AzureBotName)" appServicePlanLocation="westus" --name "$(AzureBotName)";
+     
+        Set-PSDebug -Trace 0;
+    condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 0), endsWith(variables['Build.BuildId'], 2), endsWith(variables['Build.BuildId'], 4), endsWith(variables['Build.BuildId'], 6), endsWith(variables['Build.BuildId'], 8)))
+
+  - task: AzureCLI@2
+    displayName: 'New RG: create Azure resources. Runs in odd builds.'
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        Write-Host "`n***** Creating Azure resources using the new-rg template *****";
+        Write-Host "This task runs for odd-numbered builds. Build ID = $(Build.BuildId)";
+        Write-Host "****************************************************************";
+        Set-PSDebug -Trace 1;
+
+        # set up resource group, bot channels registration, app service, app service plan
+        az deployment sub create --name "$(BotGroup)" --template-file "$(SampleRootPath)\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(AzureBotName)" botSku=F0 newAppServicePlanName="$(AzureBotName)" newWebAppName="$(AzureBotName)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus";
+     
+        Set-PSDebug -Trace 0;
+    condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 1), endsWith(variables['Build.BuildId'], 3), endsWith(variables['Build.BuildId'], 5), endsWith(variables['Build.BuildId'], 7), endsWith(variables['Build.BuildId'], 9)))
+
+  - task: AzureCLI@2
+    displayName: 'Deploy bot, create DirectLine channel '
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        # prepare .deployment file
+        az bot prepare-deploy --lang Csharp --code-dir "$(SampleRootPath)" --proj-file-path "$(SampleBotName).csproj";
+
+        az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(AzureBotName)" --src "$(Build.ArtifactStagingDirectory)/$(SampleFolderName).zip"
+
+        az bot directline create -n "$(AzureBotName)" -g "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json"
+
+  - powershell: |
+      # Key = Direct Line channel "Secret keys" in Azure portal
+      $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
+      $key = $json.properties.properties.sites.key;
+      echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
+      echo "##vso[task.setvariable variable=BOTID;]$(AzureBotName)";
+      Write-Host "setx DIRECTLINE $key";
+      Write-Host "setx BOTID $(AzureBotName)";
+    displayName: Set DIRECTLINE key, BOTID for running tests
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: $(SampleFolderName)-zip'
+    continueOnError: True
+    enabled: False
+    inputs:
+      ArtifactName: $(SampleFolderName)-zip
+
+  - task: NuGetCommand@2
+    displayName: NuGet restore Samples.$(SampleBotName).FunctionalTests.csproj
+    inputs:
+      solution: samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
+      selectOrConfig: config
+      nugetConfigPath: $(SampleRootPath)\nuget.config
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build Samples.$(SampleBotName).FunctionalTests.csproj
+    inputs:
+      projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
+
+  - powershell: |
+      Start-Sleep -Seconds 15
+    displayName: Sleep for 15 seconds
+    enabled: true
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test
+    inputs:
+      command: test
+      projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/**Tests.csproj
+      arguments: --verbosity Normal
+
+  - script: |
+      dir .. /s
+    displayName: 'Dir workspace'
+    continueOnError: true
+    condition: always()
+
+  - task: AzureCLI@2
+    displayName: Delete bot, app service, app service plan, group
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        Set-PSDebug -Trace 1;
+
+        Write-Host "1) Delete Bot:";
+        az bot delete --name $(AzureBotName) --resource-group $(BotGroup);
+
+        Write-Host "2) Delete App Service:";
+        az webapp delete --name $(AzureBotName) --resource-group $(BotGroup);
+
+        Write-Host "3) Delete App Service plan:";
+        az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes;
+
+        Write-Host "4) Delete Resource Group:";
+        az group delete --name $(BotGroup) --yes;
+
+        Set-PSDebug -Trace 0;
+    condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
+    continueOnError: True
+
+...

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -1,0 +1,303 @@
+# This is used in the pipelines Sample-Js-CoreBot-Linux-Test-yaml and Sample-Js-EchoBot-Linux-Test-yaml.
+
+# 'Allow scripts to access the OAuth token' was selected in pipeline.  Add the following YAML to any steps requiring access:
+#       env:
+#           MY_ACCESS_TOKEN: $(System.AccessToken)
+# Variable 'AppId' is defined in Azure
+# Variable 'AppSecret' is defined in Azure
+# Variable 'AzureBotName' is defined in Azure
+# Variable 'AzureSubscription' is defined in Azure
+# Variable 'BotGroup' is defined in Azure
+# Variable 'DeleteResourceGroup' is defined in Azure
+# Variable 'MyGetPersonalAccessToken' is defined in Azure
+# Variable 'runCodesignValidationInjection' is defined in Azure
+# Variable 'SampleBotName' is defined in Azure
+# Variable 'SampleFolderName' is defined in Azure
+# Variable 'SampleRootPath' is defined in Azure
+# Variable Group 'AzureDeploymentCredsVariableGroup' is defined in Azure
+# Variable Group 'SamplesE2ETestsVariableGroup' is defined in Azure
+# Variable Group 'MyGetPersonalAccessTokenVariableGroup' is defined in Azure
+
+parameters:
+  - name: testLatestPackage
+    displayName: Test latest package version
+    type: boolean
+    default: true
+  - name: versionToTest
+    displayName: Version to test (Only if 'Test latest' is unchecked)
+    type: string
+    default: 'Example: 4.15.0-dev.20210726.c56bbf1'
+  - name: packageFeed
+    displayName: Package feed to use
+    type: string
+    default: npm
+    values:
+    - npm
+    - MyGet
+
+# Run this job every night at 2 AM (PST) on the main branch
+schedules:
+- cron: 0 9 * * *
+  displayName: Daily 2AM PST build
+  branches:
+    include:
+    - main
+  always: true
+
+# Do not run PR validation
+pr: none
+
+# Do not run CI validation
+trigger: none
+
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: main
+
+#variables:
+#- group: AzureDeploymentCredsVariableGroup
+#- group: SamplesE2ETestsVariableGroup
+#- group: MyGetPersonalAccessTokenVariableGroup
+
+jobs:
+- job: Job_1
+  displayName: Agent job 1
+  pool:
+    vmImage: windows-2019
+  steps:
+  - checkout: self
+    persistCredentials: True
+
+  - powershell: |
+      $packageName = "botbuilder";
+
+      Write-Host "Get $packageName preview version tagged 'next' from npmjs.com";
+      " "
+      "Available versions:";
+      npm view $packageName versions | Select -Last 30;
+
+      $dist = npm dist-tag ls $packageName;
+      $next = $dist.Where({$_.StartsWith("next:")});
+      [string]$latestVersion = $next.Split(':')[-1].Trim();
+
+      "Latest version:";
+      $packageName;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+    displayName: From npm feed get latest botbuilder package version  - https://www.npmjs.com/package/botbuilder
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'npm')) }}
+
+  - powershell: |
+      $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      $myGetFeedName = "botbuilder-v4-js-daily";
+      $packageName = "botbuilder-ai";
+
+      $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
+
+      Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
+      $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+
+      $package = $result.packages | Where-Object {$_.id -eq $packageName};
+      " "
+      "Available versions:";
+      $package.versions | Select -Last 30;
+
+      [string]$latestVersion = $package.versions[-1];
+      " "
+      "Latest version:";
+      $package.id;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
+    displayName: 'From MyGet feed get latest botbuilder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-js-daily'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
+
+  - powershell: |
+     $targetVersion = "${{ parameters.versionToTest }}";
+     $targetVersion;
+     "##vso[task.setvariable variable=TargetVersion;]$targetVersion";
+    displayName: 'From user input get specific botbuilder version number'
+    condition: ${{ ne(parameters.testLatestPackage, true) }}
+
+  - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
+    displayName: 'Display env vars'
+ 
+  - task: tagBuildOrRelease@0
+    displayName: Tag Build with botbuilder version
+    inputs:
+      tags: |
+        Using botbuilder version $(TargetVersion)
+        From ${{ parameters.packageFeed }} feed 
+        Test latest = ${{ parameters.testLatestPackage }}
+
+  - powershell: |
+     # SetDependencyVersionInPackageJsonFile0.ps1
+      $path = "$(SampleRootPath)/package.json";
+      $packages = @('botbuilder','botbuilder-ai','botbuilder-dialogs','botbuilder-testing');
+      $newVersion = "$(TargetVersion)";
+
+      $content = Get-ChildItem -Path "$path" | Get-Content -Raw
+
+      foreach ($package in $packages) {
+          $find = "$package`": `"\S*`"";
+          $replace = "$package`": `"$newVersion`"";
+          $content = $content -Replace "$find", "$replace";
+      }
+
+      Set-Content -Path $path -Value $content;
+      '-------------'; get-content $path; '===================';
+    displayName: Set botbuilder version reference in package.json
+
+  - powershell: |
+        Set-Location -Path "$(SampleRootPath)"
+
+        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://registry.npmjs.com/"
+    displayName: Create .npmrc for npm feed - https://www.npmjs.com/search?q=botbuilder
+    condition: ${{ eq(parameters.packageFeed, 'npm') }}
+
+  - powershell: |
+        Set-Location -Path "$(SampleRootPath)"
+
+        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
+    displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
+    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
+
+  - task: Npm@1
+    displayName: npm install $(SampleFolderName)
+    inputs:
+      workingDir: $(SampleRootPath)
+      verbose: false
+
+  - task: AzureCLI@2
+    displayName: 'create group, create resources, generate web.config (uses dotnet template)'
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        Set-PSDebug -Trace 1;
+     
+        az group create --location westus --name $(BotGroup);
+     
+        # set up bot channels registration, app service, app service plan
+        az deployment group create --resource-group "$(BotGroup)" --template-file "$(SampleRootPath)\deploymentTemplates\linux\template.json" --parameters appId="$(AppId)" appSecret="$(AppSecret)" botName="$(AzureBotName)" --name "$(AzureBotName)";
+     
+        # Generate web.config for bot deploy
+        az bot prepare-deploy --code-dir "$(SampleRootPath)" --lang Javascript
+     
+        Set-PSDebug -Trace 0;
+
+  - powershell: |
+      Set-PSDebug -Trace 1;
+      # Copy Azure deploy scripts for Linux
+      Move-Item -Path $(SampleRootPath)\deploymentScripts\linux\* -Destination $(SampleRootPath)\;
+      Set-PSDebug -Trace 0;
+    displayName: Move .deployment, deploy.sh scripts into position
+
+  - script: |
+      echo on
+      git config --global user.name "SampleJs$(SampleBotName)LinuxTestPipeline"
+      git config --global user.email BotBuilderJs@Pipeline.com
+      git init
+   
+      git add .
+      git commit -m "Add bot source code"
+      git remote add azure https://$(AzureDeploymentUser):$(AzureDeploymentPassword)@$(AzureBotName).scm.azurewebsites.net:443/$(AzureBotName).git
+   
+      git push azure master
+    workingDirectory: '$(System.DefaultWorkingDirectory)/samples/javascript_nodejs/$(SampleFolderName)'
+    displayName: 'Deploy the bot to Azure'
+
+  - task: AzureCLI@2
+    displayName: Create DirectLine channel
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: batch
+      scriptLocation: inlineScript
+      inlineScript: call az bot directline create --name "$(AzureBotName)" --resource-group "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json" --debug
+
+  - powershell: |
+      # Key = Direct Line channel "Secret keys" in Azure portal
+      $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
+      $key = $json.properties.properties.sites.key;
+      echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
+      echo "##vso[task.setvariable variable=BOTID;]$(AzureBotName)";
+      Write-Host "setx DIRECTLINE $key";
+      Write-Host "setx BOTID $(AzureBotName)";
+    displayName: Set DIRECTLINE key, BOTID for running tests
+
+  - task: NuGetToolInstaller@1
+    displayName: Use NuGet 5.5.1
+    inputs:
+      versionSpec: 5.5.1
+
+  - powershell: |
+      $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
+
+      $content = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
+      "@;
+
+      New-Item -Path $file -ItemType "file" -Value $content;
+      '-------------'; get-content "$file"; '==================='
+    displayName: Create nuget.config for Samples.$(SampleBotName).FunctionalTests.csproj for NuGet.org feed
+
+  - task: NuGetCommand@2
+    displayName: NuGet restore dotnet Samples.$(SampleBotName).FunctionalTests.csproj
+    inputs:
+      solution: samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
+      nugetConfigPath: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build dotnet Samples.$(SampleBotName).FunctionalTests.csproj
+    inputs:
+      projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test
+    inputs:
+      command: test
+      projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/**Tests.csproj
+      arguments: --verbosity Normal
+
+  - script: |
+      dir .. /s
+    displayName: 'Dir workspace'
+    continueOnError: true
+    condition: always()
+
+  - task: AzureCLI@2
+    displayName: Delete bot, app service, app service plan, group
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        Set-PSDebug -Trace 1;
+
+        Write-Host "1) Delete Bot:";
+        az bot delete --name $(AzureBotName) --resource-group $(BotGroup);
+
+        Write-Host "2) Delete App Service:";
+        az webapp delete --name $(AzureBotName) --resource-group $(BotGroup);
+
+        Write-Host "3) Delete App Service plan:";
+        az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes;
+
+        Write-Host "4) Delete Resource Group:";
+        az group delete --name $(BotGroup) --yes;
+
+        Set-PSDebug -Trace 0;
+    condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
+    continueOnError: True
+
+...

--- a/build/yaml/sample-js-samplebot-win-test.yml
+++ b/build/yaml/sample-js-samplebot-win-test.yml
@@ -1,0 +1,334 @@
+# This is used in the pipelines Sample-Js-CoreBot-Win-Test-yaml and Sample-Js-EchoBot-Win-Test-yaml.
+
+# 'Allow scripts to access the OAuth token' was selected in pipeline.  Add the following YAML to any steps requiring access:
+#       env:
+#           MY_ACCESS_TOKEN: $(System.AccessToken)
+# Variable 'AppId' is defined in Azure
+# Variable 'AppSecret' is defined in Azure
+# Variable 'AzureBotName' is defined in Azure
+# Variable 'AzureSubscription' is defined in Azure
+# Variable 'BotGroup' is defined in Azure
+# Variable 'DeleteResourceGroup' is defined in Azure
+# Variable 'MyGetPersonalAccessToken' is defined in Azure
+# Variable 'runCodesignValidationInjection' is defined in Azure
+# Variable 'SampleBotName' is defined in Azure
+# Variable 'SampleFolderName' is defined in Azure
+# Variable 'SampleRootPath' is defined in Azure
+# Variable Group 'SamplesE2ETestsVariableGroup' is defined in Azure
+# Variable Group 'MyGetPersonalAccessTokenVariableGroup' is defined in Azure
+
+parameters:
+  - name: testLatestPackage
+    displayName: Test latest package version
+    type: boolean
+    default: true
+  - name: versionToTest
+    displayName: Version to test (Only if 'Test latest' is unchecked)
+    type: string
+    default: 'Example: 4.15.0-dev.20210726.c56bbf1'
+  - name: packageFeed
+    displayName: Package feed to use
+    type: string
+    default: npm
+    values:
+    - npm
+    - MyGet
+
+# Run this job every night at 2 AM (PST) on the main branch
+schedules:
+- cron: 0 9 * * *
+  displayName: Daily 2AM PST build
+  branches:
+    include:
+    - main
+  always: true
+
+# Do not run PR validation
+pr: none
+
+# Do not run CI validation
+trigger: none
+
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: main
+
+#variables:
+#- group: SamplesE2ETestsVariableGroup
+#- group: MyGetPersonalAccessTokenVariableGroup
+
+jobs:
+- job: Job_1
+  displayName: Agent job 1
+  pool:
+    vmImage: windows-2019
+  steps:
+  - checkout: self
+    persistCredentials: True
+
+  - powershell: |
+      $packageName = "botbuilder";
+
+      Write-Host "Get $packageName preview version tagged 'next' from npmjs.com";
+      " "
+      "Available versions:";
+      npm view $packageName versions | Select -Last 30;
+
+      $dist = npm dist-tag ls $packageName;
+      $next = $dist.Where({$_.StartsWith("next:")});
+      [string]$latestVersion = $next.Split(':')[-1].Trim();
+
+      "Latest version:";
+      $packageName;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+    displayName: From npm feed get latest botbuilder package version  - https://www.npmjs.com/package/botbuilder
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'npm')) }}
+
+  - powershell: |
+      $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      $myGetFeedName = "botbuilder-v4-js-daily";
+      $packageName = "botbuilder-ai";
+
+      $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
+
+      Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
+      $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+
+      $package = $result.packages | Where-Object {$_.id -eq $packageName};
+      " "
+      "Available versions:";
+      $package.versions | Select -Last 30;
+
+      [string]$latestVersion = $package.versions[-1];
+      " "
+      "Latest version:";
+      $package.id;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
+    displayName: 'From MyGet feed get latest botbuilder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
+
+  - powershell: |
+     $targetVersion = "${{ parameters.versionToTest }}";
+     $targetVersion;
+     "##vso[task.setvariable variable=TargetVersion;]$targetVersion";
+    displayName: 'From user input get specific botbuilder version number'
+    condition: ${{ ne(parameters.testLatestPackage, true) }}
+
+  - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
+    displayName: 'Display env vars'
+ 
+  - task: tagBuildOrRelease@0
+    displayName: Tag Build with botbuilder version
+    inputs:
+      tags: |
+        Using botbuilder version $(TargetVersion)
+        From ${{ parameters.packageFeed }} feed 
+        Test latest = ${{ parameters.testLatestPackage }}
+
+  - powershell: |
+     # SetDependencyVersionInPackageJsonFile0.ps1
+      $path = "$(SampleRootPath)/package.json";
+      $packages = @('botbuilder','botbuilder-ai','botbuilder-dialogs','botbuilder-testing');
+      $newVersion = "$(TargetVersion)";
+
+      $content = Get-ChildItem -Path "$path" | Get-Content -Raw
+
+      foreach ($package in $packages) {
+          $find = "$package`": `"\S*`"";
+          $replace = "$package`": `"$newVersion`"";
+          $content = $content -Replace "$find", "$replace";
+      }
+
+      Set-Content -Path $path -Value $content;
+      '-------------'; get-content $path; '===================';
+    displayName: Set botbuilder version reference in package.json
+
+  - powershell: |
+        Set-Location -Path "$(SampleRootPath)"
+
+        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://registry.npmjs.com/"
+    displayName: Create .npmrc for npm feed - https://www.npmjs.com/search?q=botbuilder
+    condition: ${{ eq(parameters.packageFeed, 'npm') }}
+
+  - powershell: |
+        Set-Location -Path "$(SampleRootPath)"
+
+        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
+    displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
+    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
+
+  - task: Npm@1
+    displayName: npm install $(SampleFolderName)
+    inputs:
+      workingDir: $(SampleRootPath)
+      verbose: false
+
+  - powershell: |
+      Set-PSDebug -Trace 1;
+
+      move-item -path $(SampleRootPath)/deploymentScripts/windows/* -destination $(SampleRootPath);
+
+      $DirToCompress = "$(SampleRootPath)";
+      $DirtoExclude =@("node_modules", "deploymentTemplates", "deploymentScripts");
+      $files = Get-ChildItem -Path $DirToCompress -Exclude $DirtoExclude;
+      $ZipFileDestination ="$(SampleRootPath)/testbot.zip";
+
+      Compress-Archive -Path $files -DestinationPath $ZipFileDestination;
+
+      Set-PSDebug -Trace 0;
+    displayName: Set up deploy scripts, zip the bot
+
+  - task: CopyFiles@2
+    displayName: 'Copy testbot.zip to: $(Build.ArtifactStagingDirectory)'
+    inputs:
+      SourceFolder: $(SampleRootPath)
+      Contents: testbot.zip
+      TargetFolder: $(Build.ArtifactStagingDirectory)
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: testbot-zip'
+    inputs:
+      ArtifactName: testbot-zip
+
+  - task: AzureCLI@2
+    displayName: 'Preexisting RG: create Azure resources. Runs in even builds.'
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        Write-Host "`n***** Creating Azure resources using the preexisting-rg template *****";
+        Write-Host "This task runs for even-numbered builds. Build ID = $(Build.BuildId)";
+        Write-Host "************************************************************************";
+        Set-PSDebug -Trace 1;
+     
+        az group create --location westus --name $(BotGroup);
+     
+        # set up bot channels registration, app service, app service plan
+        az deployment group create --resource-group "$(BotGroup)" --template-file "$(SampleRootPath)\DeploymentTemplates\template-with-preexisting-rg.json" --parameters appId="$(AppId)" appSecret="$(AppSecret)" botId="$(AzureBotName)" newWebAppName="$(AzureBotName)" newAppServicePlanName="$(AzureBotName)" appServicePlanLocation="westus" --name "$(AzureBotName)";
+     
+        Set-PSDebug -Trace 0;
+    condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 0), endsWith(variables['Build.BuildId'], 2), endsWith(variables['Build.BuildId'], 4), endsWith(variables['Build.BuildId'], 6), endsWith(variables['Build.BuildId'], 8)))
+
+  - task: AzureCLI@2
+    displayName: 'New RG: create Azure resources. Runs in odd builds.'
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        Write-Host "`n***** Creating Azure resources using the new-rg template *****";
+        Write-Host "This task runs for odd-numbered builds. Build ID = $(Build.BuildId)";
+        Write-Host "****************************************************************";
+        Set-PSDebug -Trace 1;
+
+        # set up resource group, bot channels registration, app service, app service plan
+        az deployment sub create --name "$(BotGroup)" --template-file "$(SampleRootPath)\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(AzureBotName)" botSku=F0 newAppServicePlanName="$(AzureBotName)" newWebAppName="$(AzureBotName)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus";
+     
+        Set-PSDebug -Trace 0;
+    condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 1), endsWith(variables['Build.BuildId'], 3), endsWith(variables['Build.BuildId'], 5), endsWith(variables['Build.BuildId'], 7), endsWith(variables['Build.BuildId'], 9)))
+
+  - task: AzureCLI@2
+    displayName: 'Deploy bot, create directline channel '
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        # Generate web.config for bot deploy
+        az bot prepare-deploy --code-dir "$(SampleRootPath)" --lang Javascript
+
+        az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(AzureBotName)" --src "$(Build.ArtifactStagingDirectory)\testbot.zip" --debug
+
+        az bot directline create --name "$(AzureBotName)" --resource-group "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json" --debug
+
+  - powershell: |
+      # Key = Direct Line channel "Secret keys" in Azure portal
+      $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
+      $key = $json.properties.properties.sites.key;
+      echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
+      echo "##vso[task.setvariable variable=BOTID;]$(AzureBotName)";
+      Write-Host "setx DIRECTLINE $key";
+      Write-Host "setx BOTID $(AzureBotName)";
+    displayName: Set DIRECTLINE key, BOTID for running tests
+
+  - task: NuGetToolInstaller@1
+    displayName: Use NuGet 5.5.1
+    inputs:
+      versionSpec: 5.5.1
+
+  - powershell: |
+      $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
+
+      $content = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
+
+      "@;
+
+      New-Item -Path $file -ItemType "file" -Value $content;
+        '-------------'; get-content "$file"; '==================='
+    displayName: Create nuget.config for Samples.$(SampleBotName).FunctionalTests.csproj for NuGet.org feed
+
+  - task: NuGetCommand@2
+    displayName: NuGet restore dotnet Samples.$(SampleBotName).FunctionalTests.csproj
+    inputs:
+      solution: samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
+      selectOrConfig: config
+      nugetConfigPath: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build dotnet Samples.$(SampleBotName).FunctionalTests.csproj
+    inputs:
+      projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test
+    inputs:
+      command: test
+      projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/**Tests.csproj
+      arguments: --verbosity Normal
+
+  - script: |
+      dir .. /s
+    displayName: 'Dir workspace'
+    continueOnError: true
+    condition: always()
+
+  - task: AzureCLI@2
+    displayName: Delete bot, app service, app service plan, group
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        Set-PSDebug -Trace 1;
+
+        Write-Host "1) Delete Bot:";
+        az bot delete --name $(AzureBotName) --resource-group $(BotGroup);
+
+        Write-Host "2) Delete App Service:";
+        az webapp delete --name $(AzureBotName) --resource-group $(BotGroup);
+
+        Write-Host "3) Delete App Service plan:";
+        az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes;
+
+        Write-Host "4) Delete Resource Group:";
+        az group delete --name $(BotGroup) --yes;
+
+        Set-PSDebug -Trace 0;
+    condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
+    continueOnError: True
+
+...

--- a/build/yaml/sample-py-samplebot-linux-test.yml
+++ b/build/yaml/sample-py-samplebot-linux-test.yml
@@ -1,0 +1,449 @@
+# This is used in the pipelines Sample-Py-CoreBot-Linux-Test-yaml and Sample-Py-EchoBot-Linux-Test-yaml.
+
+# 'Allow scripts to access the OAuth token' was selected in pipeline.  Add the following YAML to any steps requiring access:
+#       env:
+#           MY_ACCESS_TOKEN: $(System.AccessToken)
+# Variable 'AppId' is defined in Azure
+# Variable 'AppSecret' is defined in Azure
+# Variable 'AzureBotName' is defined in Azure
+# Variable 'AzureSubscription' is defined in Azure
+# Variable 'BotGroup' is defined in Azure
+# Variable 'DeleteResourceGroup' is defined in Azure
+# Variable 'MyGetPersonalAccessToken' is defined in Azure
+# Variable 'runCodesignValidationInjection' is defined in Azure
+# Variable 'SampleBotName' is defined in Azure
+# Variable 'SampleFolderName' is defined in Azure
+# Variable 'SampleRootPath' is defined in Azure
+# Variable Group 'AzureDeploymentCredsVariableGroup' is defined in Azure
+# Variable Group 'SamplesE2ETestsVariableGroup' is defined in Azure
+# Variable Group 'MyGetPersonalAccessTokenVariableGroup' is defined in Azure
+
+parameters:
+  - name: testLatestPackage
+    displayName: Test latest package version
+    type: boolean
+    default: true
+  - name: versionToTest
+    displayName: Version to test (Only if 'Test latest' is unchecked)
+    type: string
+    default: 'Example: 4.12.0.20210413.dev234515'
+  - name: packageFeed
+    displayName: Package feed to use
+    type: string
+    default: Azure
+    values:
+    - Azure
+    - MyGet
+    - PyPI
+
+# Run this job every night at 2 AM (PST) on the main branch
+schedules:
+- cron: 0 9 * * *
+  displayName: Daily 2AM PST build
+  branches:
+    include:
+    - main
+  always: true
+
+# Do not run PR validation
+pr: none
+
+# Do not run CI validation
+trigger: none
+
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: main
+
+#variables:
+#- group: AzureDeploymentCredsVariableGroup
+#- group: SamplesE2ETestsVariableGroup
+#- group: MyGetPersonalAccessTokenVariableGroup
+
+jobs:
+- job: Job_1
+  displayName: Agent job 1
+  pool:
+    vmImage: windows-2019
+  steps:
+  - checkout: self
+    persistCredentials: True
+
+  - task: AzureCLI@2
+    displayName: 'Delete bot, app service, app service plan, group'
+    inputs:
+      azureSubscription: 'FUSE Temporary (174c5021-8109-4087-a3e2-a1de20420569)'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+       Set-PSDebug -Trace 1;
+     
+       Write-Host "1) Delete Bot:"
+       az bot delete --name $(AzureBotName) --resource-group $(BotGroup)
+     
+       Write-Host "2) Delete App Service:"
+       az webapp delete --name $(AzureBotName) --resource-group $(BotGroup)
+     
+       Write-Host "3) Delete App Service plan:"
+       az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes
+     
+       Write-Host "4) Delete Resource Group:"
+       az group delete --name $(BotGroup) --yes
+     
+       Set-PSDebug -Trace 0;
+    enabled: false
+    continueOnError: true
+    condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
+
+  - powershell: |
+      $packageName = "botbuilder-integration-aiohttp";
+      $url = "https://feeds.dev.azure.com/ConversationalAI/BotFramework/_apis/packaging/Feeds/SDK/Packages/26dde74d-6079-401c-a9e0-c6d839e02c18/versions?api-version=5.1-preview.1"
+   
+      Write-Host "Get latest $packageName version number from ConversationalAI BotFramework SDK feed";
+      $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+      [string]$latestVersion = $result.value[0].protocolMetadata.data.version;
+   
+      $packageName;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+    displayName: 'From Azure feed get latest botbuilder package version - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
+
+  - powershell: |
+      $myGetFeedName = "botbuilderdaily_python";
+      $packageName = "botbuilder-ai";
+      $url = "https://botbuilder.myget.org/F/$myGetFeedName/python"
+
+      py -m pip install --index-url $url $packageName== 2>&1 | Tee-Object -Variable pipError | Out-Null
+
+      [string]$errorString = $pipError
+      $start = $errorString.IndexOf("from versions:") + 15;
+      $end = $errorString.IndexOf(")");
+      $versions = $errorString.Substring($start, $end - $start);
+      $versionsArray = $versions -Split ", ";
+      $latestVersion = $versionsArray[-1];
+      " ";
+      $packageName;
+      "Available versions:";
+      $versionsArray | Select -Last 30;
+      " ";
+      "Latest version:";
+      $latestVersion;
+
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+    errorActionPreference: continue
+    ignoreLASTEXITCODE: true
+    displayName: 'From MyGet feed get latest Bot.Builder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
+
+  - powershell: |
+      $packageName = "botbuilder-integration-aiohttp";
+   
+      py -m pip install yolk3k;
+      $result = py -m yolk -V $packageName;
+   
+      $array = $result -split " ";
+      $latestVersion = $array[1];
+      " ";
+      $packageName;
+      $latestVersion;
+   
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+    displayName: 'From PyPI feed get latest botbuilder package version - https://pypi.org/search/?q=botbuilder&o='
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'PyPI')) }}
+
+  - powershell: |
+     $targetVersion = "${{ parameters.versionToTest }}";
+     $targetVersion;
+     "##vso[task.setvariable variable=TargetVersion;]$targetVersion";
+    displayName: 'From user input get specific botbuilder version number'
+    condition: ${{ ne(parameters.testLatestPackage, true) }}
+
+  - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
+    displayName: 'Display env vars'
+ 
+  - task: tagBuildOrRelease@0
+    displayName: Tag Build with botbuilder version
+    inputs:
+      tags: |
+        Using botbuilder version $(TargetVersion)
+        From ${{ parameters.packageFeed }} feed 
+        Test latest = ${{ parameters.testLatestPackage }}
+
+  - powershell: |
+     # This adapted from PyPySkillBotFunctionalTest, file BotFramework-FunctionalTests\build\yaml\pythonDeploySteps.yml, task Set BotBuilder Package Version & Registry Url.
+   
+     $file = "$(SampleRootPath)/requirements.txt";
+   
+     $indexUrl = "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/pypi/simple/"
+     $extraIndexUrl = "https://pypi.org/simple/"
+   
+     $comparisonOperator = ""
+     $newVersion = ""
+     $pipInstallOption =  "--pre" # Include prerelease and development versions.
+   
+     # Add the index URL specs at the beginning of the requirements.txt file
+     $content = @(Get-Content $file)
+     Set-Content -Path $file -Value ("$pipInstallOption --index-url $indexUrl --extra-index-url $extraIndexUrl".Trim())
+     Add-Content -Path $file -Value $content
+   
+     function UpdatePackageVersion($package) {
+       # Set Package version to empty value
+       $content = @(Get-Content $file)
+       $matchinfo = Select-String -Path $file -Pattern $package
+   
+       $script = "$package $comparisonOperator $newVersion"
+   
+       # Update or add dependency
+       if($matchinfo.LineNumber -gt 0) {
+         $content[$matchinfo.LineNumber - 1] = $script
+         Set-Content -Path $file -Value $content
+     
+       } else {
+         Add-Content -Path $file -Value $script
+       }
+     }
+   
+     UpdatePackageVersion "botbuilder-integration-aiohttp"
+     UpdatePackageVersion "botbuilder-dialogs" 
+     UpdatePackageVersion "botbuilder-ai" 
+   
+     '------ $file -------'; get-content $file; '===================';
+    displayName: 'For Azure feed, set requirements.txt to get targeted botframework packages'
+    condition: ${{ eq(parameters.packageFeed, 'Azure') }}
+
+  - powershell: |
+     # This adapted from PyPySkillBotFunctionalTest, file BotFramework-FunctionalTests\build\yaml\pythonDeploySteps.yml, task Set BotBuilder Package Version & Registry Url.
+   
+     $file = "$(SampleRootPath)/requirements.txt";
+   
+     $indexUrl = "https://botbuilder.myget.org/F/botbuilderdaily_python/python/"
+     $extraIndexUrl = "https://pypi.org/simple/"
+   
+     $comparisonOperator = ""
+     $newVersion = ""
+     $pipInstallOption =  "--pre" # Include prerelease and development versions.
+   
+     # Add the index URL specs at the beginning of the requirements.txt file
+     $content = @(Get-Content $file)
+     Set-Content -Path $file -Value ("$pipInstallOption --index-url $indexUrl --extra-index-url $extraIndexUrl".Trim())
+     Add-Content -Path $file -Value $content
+   
+     function UpdatePackageVersion($package) {
+       # Set Package version to empty value
+       $content = @(Get-Content $file)
+       $matchinfo = Select-String -Path $file -Pattern $package
+   
+       $script = "$package $comparisonOperator $newVersion"
+   
+       # Update or add dependency
+       if($matchinfo.LineNumber -gt 0) {
+         $content[$matchinfo.LineNumber - 1] = $script
+         Set-Content -Path $file -Value $content
+     
+       } else {
+         Add-Content -Path $file -Value $script
+       }
+     }
+   
+     UpdatePackageVersion "botbuilder-integration-aiohttp"
+     UpdatePackageVersion "botbuilder-dialogs" 
+     UpdatePackageVersion "botbuilder-ai" 
+   
+     '------ $file -------'; get-content $file; '===================';
+    displayName: 'For MyGet feed, set requirements.txt to get targeted botframework packages'
+    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
+
+  - powershell: |
+     # This adapted from PyPySkillBotFunctionalTest, file BotFramework-FunctionalTests\build\yaml\pythonDeploySteps.yml, task Set BotBuilder Package Version & Registry Url.
+   
+     $file = "$(SampleRootPath)/requirements.txt";
+   
+     $indexUrl = "https://pypi.org/simple/"
+     $extraIndexUrl = "https://pypi.org/simple/"
+   
+     $comparisonOperator = ""
+     $newVersion = ""
+     $pipInstallOption =  "--pre" # Include prerelease and development versions.
+   
+     # Add the index URL specs at the beginning of the requirements.txt file
+     $content = @(Get-Content $file)
+     Set-Content -Path $file -Value ("$pipInstallOption --index-url $indexUrl --extra-index-url $extraIndexUrl".Trim())
+     Add-Content -Path $file -Value $content
+   
+     function UpdatePackageVersion($package) {
+       # Set Package version to empty value
+       $content = @(Get-Content $file)
+       $matchinfo = Select-String -Path $file -Pattern $package
+   
+       $script = "$package $comparisonOperator $newVersion"
+   
+       # Update or add dependency
+       if($matchinfo.LineNumber -gt 0) {
+         $content[$matchinfo.LineNumber - 1] = $script
+         Set-Content -Path $file -Value $content
+     
+       } else {
+         Add-Content -Path $file -Value $script
+       }
+     }
+   
+     UpdatePackageVersion "botbuilder-integration-aiohttp"
+     UpdatePackageVersion "botbuilder-dialogs" 
+     UpdatePackageVersion "botbuilder-ai" 
+   
+     '------ $file -------'; get-content $file; '===================';
+    displayName: 'For PyPI feed, set requirements.txt to get targeted botframework packages'
+    condition: ${{ eq(parameters.packageFeed, 'PyPI') }}
+
+  - task: AzureCLI@2
+    displayName: 'Preexisting RG: create Azure resources. Runs in even builds.'
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+       Write-Host "`n***** Creating Azure resources using the preexisting-rg template *****";
+       Write-Host "This task runs for even-numbered builds. Build ID = $(Build.BuildId)";
+       Write-Host "************************************************************************";
+       #Set-PSDebug -Trace 1;
+     
+       az group create --location westus --name $(BotGroup);
+     
+       # set up bot channels registration, app service, app service plan
+       az deployment group create --resource-group "$(BotGroup)" --template-file "$(SampleRootPath)\deploymentTemplates\template-with-preexisting-rg.json" --parameters botId="$(AzureBotName)" appId="$(AppId)" appSecret="$(AppSecret)" newAppServicePlanName="$(AzureBotName)" appServicePlanLocation="westus" --name "$(AzureBotName)";
+
+       #Set-PSDebug -Trace 0;
+    condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 0), endsWith(variables['Build.BuildId'], 2), endsWith(variables['Build.BuildId'], 4), endsWith(variables['Build.BuildId'], 6), endsWith(variables['Build.BuildId'], 8)))
+
+  - task: AzureCLI@2
+    displayName: 'New RG: create Azure resources. Runs in odd builds.'
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        Write-Host "`n***** Creating Azure resources using the new-rg template *****";
+        Write-Host "This task runs for odd-numbered builds. Build ID = $(Build.BuildId)";
+        Write-Host "****************************************************************";
+
+        #Set-PSDebug -Trace 1;
+
+        # set up resource group, bot channels registration, app service, app service plan
+        az deployment sub create --name "$(BotGroup)" --template-file "$(SampleRootPath)\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(AzureBotName)" botSku=S1 newAppServicePlanName="$(AzureBotName)" newWebAppName="$(AzureBotName)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus";
+
+        #Set-PSDebug -Trace 0;
+    condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 1), endsWith(variables['Build.BuildId'], 3), endsWith(variables['Build.BuildId'], 5), endsWith(variables['Build.BuildId'], 7), endsWith(variables['Build.BuildId'], 9)))
+
+  - task: AzureCLI@2
+    displayName: Create directline channel
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+       az bot directline create --name "$(AzureBotName)" --resource-group "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json" --debug
+
+       #az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(AzureBotName)" --src "$(SampleRootPath)\testbot.zip" --debug
+
+  - script: |
+     echo git config
+     git config --global user.name "SamplePy$(SampleBotName)LinuxTestPipeline"
+     git config --global user.email BotBuilderPy@Pipeline.com
+     git init
+   
+     echo git add .
+     git add .
+     git commit -m "Add bot source code"
+     git remote add azure https://$(AzureDeploymentUser):$(AzureDeploymentPassword)@$(AzureBotName).scm.azurewebsites.net:443/$(AzureBotName).git
+   
+     echo git push azure master
+     git push azure master
+    workingDirectory: '$(SampleRootPath)'
+    displayName: 'git push the bot to Azure'
+
+  - powershell: |
+      # Key = Direct Line channel "Secret keys" in Azure portal
+      $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
+      $key = $json.properties.properties.sites.key;
+      echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
+      echo "##vso[task.setvariable variable=BOTID;]$(AzureBotName)";
+      Write-Host "setx DIRECTLINE $key";
+      Write-Host "setx BOTID $(AzureBotName)";
+    displayName: Set DIRECTLINE key, BOTID for running tests
+
+  - task: NuGetToolInstaller@1
+    displayName: Use NuGet 5.5.1
+    inputs:
+      versionSpec: 5.5.1
+
+  - powershell: |
+      $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
+
+      $content = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
+      "@;
+
+      New-Item -Path $file -ItemType "file" -Value $content;
+      '-------------'; get-content "$file"; '==================='
+    displayName: Create nuget.config for Samples.$(SampleBotName).FunctionalTests.csproj for NuGet.org feed
+
+  - task: NuGetCommand@2
+    displayName: NuGet restore dotnet Samples.$(SampleBotName).FunctionalTests.csproj
+    inputs:
+      solution: samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
+      nugetConfigPath: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build dotnet Samples.$(SampleBotName).FunctionalTests.csproj
+    inputs:
+      projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test
+    inputs:
+      command: test
+      projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/**Tests.csproj
+      arguments: --verbosity Normal
+
+  - script: |
+      dir .. /s
+    displayName: 'Dir workspace'
+    continueOnError: true
+    condition: always()
+
+  - task: AzureCLI@2
+    displayName: Delete bot, app service, app service plan, group
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        Set-PSDebug -Trace 1;
+
+        Write-Host "1) Delete Bot:";
+        az bot delete --name $(AzureBotName) --resource-group $(BotGroup);
+
+        Write-Host "2) Delete App Service:";
+        az webapp delete --name $(AzureBotName) --resource-group $(BotGroup);
+
+        Write-Host "3) Delete App Service plan:";
+        az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes;
+
+        Write-Host "4) Delete Resource Group:";
+        az group delete --name $(BotGroup) --yes;
+
+        Set-PSDebug -Trace 0;
+    condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
+    continueOnError: True
+...

--- a/build/yaml/sample-py-zipdeploy-echobot-linux-test.yml
+++ b/build/yaml/sample-py-zipdeploy-echobot-linux-test.yml
@@ -1,0 +1,459 @@
+# This is used in the pipeline Sample-Py-Zipdeploy-EchoBot-Linux-Test-yaml.
+
+# 'Allow scripts to access the OAuth token' was selected in pipeline.  Add the following YAML to any steps requiring access:
+#       env:
+#           MY_ACCESS_TOKEN: $(System.AccessToken)
+# Variable 'AppId' is defined in Azure
+# Variable 'AppSecret' is defined in Azure
+# Variable 'AzureBotName' is defined in Azure
+# Variable 'AzureSubscription' is defined in Azure
+# Variable 'BotGroup' is defined in Azure
+# Variable 'DeleteResourceGroup' is defined in Azure
+# Variable 'MyGetPersonalAccessToken' is defined in Azure
+# Variable 'MyGetFeedName' was defined in the Variables tab
+# Variable 'PackageDependencyName' was defined in the Variables tab
+# Variable 'runCodesignValidationInjection' is defined in Azure
+# Variable 'SampleBotName' is defined in Azure
+# Variable 'SampleFolderName' is defined in Azure
+# Variable 'SampleRootPath' is defined in Azure
+# Variable Group 'AzureDeploymentCredsVariableGroup' is defined in Azure
+# Variable Group 'SamplesE2ETestsVariableGroup' is defined in Azure
+# Variable Group 'MyGetPersonalAccessTokenVariableGroup' is defined in Azure
+
+parameters:
+  - name: testLatestPackage
+    displayName: Test latest package version
+    type: boolean
+    default: true
+  - name: versionToTest
+    displayName: Version to test (Only if 'Test latest' is unchecked)
+    type: string
+    default: 'Example: 4.12.0.20210413.dev234515'
+  - name: packageFeed
+    displayName: Package feed to use
+    type: string
+    default: Azure
+    values:
+    - Azure
+    - MyGet
+    - PyPI
+
+# Run this job every night at 2 AM (PST) on the main branch
+schedules:
+- cron: 0 9 * * *
+  displayName: Daily 2AM PST build
+  branches:
+    include:
+    - main
+  always: true
+
+# Do not run PR validation
+pr: none
+
+# Do not run CI validation
+trigger: none
+
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: main
+
+#variables:
+#- group: AzureDeploymentCredsVariableGroup
+#- group: SamplesE2ETestsVariableGroup
+#- group: MyGetPersonalAccessTokenVariableGroup
+
+jobs:
+- job: Job_1
+  displayName: Agent job 1
+  pool:
+    vmImage: windows-2019
+  steps:
+  - checkout: self
+    persistCredentials: True
+
+  - task: AzureCLI@2
+    displayName: 'Delete bot, app service, app service plan, group'
+    inputs:
+      azureSubscription: 'FUSE Temporary (174c5021-8109-4087-a3e2-a1de20420569)'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+       Set-PSDebug -Trace 1;
+     
+       Write-Host "1) Delete Bot:"
+       az bot delete --name $(AzureBotName) --resource-group $(BotGroup)
+     
+       Write-Host "2) Delete App Service:"
+       az webapp delete --name $(AzureBotName) --resource-group $(BotGroup)
+     
+       Write-Host "3) Delete App Service plan:"
+       az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes
+     
+       Write-Host "4) Delete Resource Group:"
+       az group delete --name $(BotGroup) --yes
+     
+       Set-PSDebug -Trace 0;
+    enabled: false
+    continueOnError: true
+    condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
+
+  - powershell: |
+      $packageName = "botbuilder-integration-aiohttp";
+      $url = "https://feeds.dev.azure.com/ConversationalAI/BotFramework/_apis/packaging/Feeds/SDK/Packages/26dde74d-6079-401c-a9e0-c6d839e02c18/versions?api-version=5.1-preview.1"
+   
+      Write-Host "Get latest $packageName version number from ConversationalAI BotFramework SDK feed";
+      $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+      [string]$latestVersion = $result.value[0].protocolMetadata.data.version;
+   
+      $packageName;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+    displayName: 'From Azure feed get latest botbuilder package version - https://dev.azure.com/ConversationalAI/BotFramework/_packaging?_a=feed&feed=SDK'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'Azure')) }}
+
+  - powershell: |
+      $myGetFeedName = "botbuilderdaily_python";
+      $packageName = "botbuilder-ai";
+      $url = "https://botbuilder.myget.org/F/$myGetFeedName/python"
+
+      py -m pip install --index-url $url $packageName== 2>&1 | Tee-Object -Variable pipError | Out-Null
+
+      [string]$errorString = $pipError
+      $start = $errorString.IndexOf("from versions:") + 15;
+      $end = $errorString.IndexOf(")");
+      $versions = $errorString.Substring($start, $end - $start);
+      $versionsArray = $versions -Split ", ";
+      $latestVersion = $versionsArray[-1];
+      " ";
+      $packageName;
+      "Available versions:";
+      $versionsArray | Select -Last 30;
+      " ";
+      "Latest version:";
+      $latestVersion;
+
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+    errorActionPreference: continue
+    ignoreLASTEXITCODE: true
+    displayName: 'From MyGet feed get latest Bot.Builder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
+
+  - powershell: |
+      $packageName = "botbuilder-integration-aiohttp";
+   
+      py -m pip install yolk3k;
+      $result = py -m yolk -V $packageName;
+   
+      $array = $result -split " ";
+      $latestVersion = $array[1];
+      " ";
+      $packageName;
+      $latestVersion;
+   
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+    displayName: 'From PyPI feed get latest botbuilder package version - https://pypi.org/search/?q=botbuilder&o='
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'PyPI')) }}
+
+  - powershell: |
+     $targetVersion = "${{ parameters.versionToTest }}";
+     $targetVersion;
+     "##vso[task.setvariable variable=TargetVersion;]$targetVersion";
+    displayName: 'From user input get specific botbuilder version number'
+    condition: ${{ ne(parameters.testLatestPackage, true) }}
+
+  - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
+    displayName: 'Display env vars'
+ 
+  - task: tagBuildOrRelease@0
+    displayName: Tag Build with botbuilder version
+    inputs:
+      tags: |
+        Using botbuilder version $(TargetVersion)
+        From ${{ parameters.packageFeed }} feed 
+        Test latest = ${{ parameters.testLatestPackage }}
+
+  - powershell: |
+     # This adapted from PyPySkillBotFunctionalTest, file BotFramework-FunctionalTests\build\yaml\pythonDeploySteps.yml, task Set BotBuilder Package Version & Registry Url.
+   
+     $file = "$(SampleRootPath)/requirements.txt";
+   
+     $indexUrl = "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/pypi/simple/"
+     $extraIndexUrl = "https://pypi.org/simple/"
+   
+     $comparisonOperator = ""
+     $newVersion = ""
+     $pipInstallOption =  "--pre" # Include prerelease and development versions.
+   
+     # Add the index URL specs at the beginning of the requirements.txt file
+     $content = @(Get-Content $file)
+     Set-Content -Path $file -Value ("$pipInstallOption --index-url $indexUrl --extra-index-url $extraIndexUrl".Trim())
+     Add-Content -Path $file -Value $content
+   
+     function UpdatePackageVersion($package) {
+       # Set Package version to empty value
+       $content = @(Get-Content $file)
+       $matchinfo = Select-String -Path $file -Pattern $package
+   
+       $script = "$package $comparisonOperator $newVersion"
+   
+       # Update or add dependency
+       if($matchinfo.LineNumber -gt 0) {
+         $content[$matchinfo.LineNumber - 1] = $script
+         Set-Content -Path $file -Value $content
+     
+       } else {
+         Add-Content -Path $file -Value $script
+       }
+     }
+   
+     UpdatePackageVersion "botbuilder-integration-aiohttp"
+     UpdatePackageVersion "botbuilder-dialogs" 
+     UpdatePackageVersion "botbuilder-ai" 
+   
+     '------ $file -------'; get-content $file; '===================';
+    displayName: 'For Azure feed, set requirements.txt to get targeted botframework packages'
+    condition: ${{ eq(parameters.packageFeed, 'Azure') }}
+
+  - powershell: |
+     # This adapted from PyPySkillBotFunctionalTest, file BotFramework-FunctionalTests\build\yaml\pythonDeploySteps.yml, task Set BotBuilder Package Version & Registry Url.
+   
+     $file = "$(SampleRootPath)/requirements.txt";
+   
+     $indexUrl = "https://botbuilder.myget.org/F/botbuilderdaily_python/python/"
+     $extraIndexUrl = "https://pypi.org/simple/"
+   
+     $comparisonOperator = ""
+     $newVersion = ""
+     $pipInstallOption =  "--pre" # Include prerelease and development versions.
+   
+     # Add the index URL specs at the beginning of the requirements.txt file
+     $content = @(Get-Content $file)
+     Set-Content -Path $file -Value ("$pipInstallOption --index-url $indexUrl --extra-index-url $extraIndexUrl".Trim())
+     Add-Content -Path $file -Value $content
+   
+     function UpdatePackageVersion($package) {
+       # Set Package version to empty value
+       $content = @(Get-Content $file)
+       $matchinfo = Select-String -Path $file -Pattern $package
+   
+       $script = "$package $comparisonOperator $newVersion"
+   
+       # Update or add dependency
+       if($matchinfo.LineNumber -gt 0) {
+         $content[$matchinfo.LineNumber - 1] = $script
+         Set-Content -Path $file -Value $content
+     
+       } else {
+         Add-Content -Path $file -Value $script
+       }
+     }
+   
+     UpdatePackageVersion "botbuilder-integration-aiohttp"
+     UpdatePackageVersion "botbuilder-dialogs" 
+     UpdatePackageVersion "botbuilder-ai" 
+   
+     '------ $file -------'; get-content $file; '===================';
+    displayName: 'For MyGet feed, set requirements.txt to get targeted botframework packages'
+    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
+
+  - powershell: |
+     # This adapted from PyPySkillBotFunctionalTest, file BotFramework-FunctionalTests\build\yaml\pythonDeploySteps.yml, task Set BotBuilder Package Version & Registry Url.
+   
+     $file = "$(SampleRootPath)/requirements.txt";
+   
+     $indexUrl = "https://pypi.org/simple/"
+     $extraIndexUrl = "https://pypi.org/simple/"
+   
+     $comparisonOperator = ""
+     $newVersion = ""
+     $pipInstallOption =  "--pre" # Include prerelease and development versions.
+   
+     # Add the index URL specs at the beginning of the requirements.txt file
+     $content = @(Get-Content $file)
+     Set-Content -Path $file -Value ("$pipInstallOption --index-url $indexUrl --extra-index-url $extraIndexUrl".Trim())
+     Add-Content -Path $file -Value $content
+   
+     function UpdatePackageVersion($package) {
+       # Set Package version to empty value
+       $content = @(Get-Content $file)
+       $matchinfo = Select-String -Path $file -Pattern $package
+   
+       $script = "$package $comparisonOperator $newVersion"
+   
+       # Update or add dependency
+       if($matchinfo.LineNumber -gt 0) {
+         $content[$matchinfo.LineNumber - 1] = $script
+         Set-Content -Path $file -Value $content
+     
+       } else {
+         Add-Content -Path $file -Value $script
+       }
+     }
+   
+     UpdatePackageVersion "botbuilder-integration-aiohttp"
+     UpdatePackageVersion "botbuilder-dialogs" 
+     UpdatePackageVersion "botbuilder-ai" 
+   
+     '------ $file -------'; get-content $file; '===================';
+    displayName: 'For PyPI feed, set requirements.txt to get targeted botframework packages'
+    condition: ${{ eq(parameters.packageFeed, 'PyPI') }}
+
+  - task: UsePythonVersion@0
+    displayName: Use Python 3.x
+
+  - task: AzureCLI@2
+    displayName: 'Preexisting RG: create Azure resources. Runs in even builds.'
+    enabled: False
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+       Write-Host "`n***** Creating Azure resources using the preexisting-rg template *****";
+       Write-Host "This task runs for even-numbered builds. Build ID = $(Build.BuildId)";
+       Write-Host "************************************************************************";
+       #Set-PSDebug -Trace 1;
+     
+       az group create --location westus --name $(BotGroup);
+     
+       # set up bot channels registration, app service, app service plan
+       az deployment group create --resource-group "$(BotGroup)" --template-file "$(SampleRootPath)\deploymentTemplates\template-with-preexisting-rg.json" --parameters botId="$(AzureBotName)" appId="$(AppId)" appSecret="$(AppSecret)" newAppServicePlanName="$(AzureBotName)" appServicePlanLocation="westus" --name "$(AzureBotName)";
+
+       #Set-PSDebug -Trace 0;
+    condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 0), endsWith(variables['Build.BuildId'], 2), endsWith(variables['Build.BuildId'], 4), endsWith(variables['Build.BuildId'], 6), endsWith(variables['Build.BuildId'], 8)))
+
+  - task: AzureCLI@2
+    displayName: 'New RG: create Azure resources. '
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        Write-Host "`n***** Creating Azure resources using the new-rg template *****";
+
+        Write-Host "****************************************************************";
+
+        Set-PSDebug -Trace 1;
+
+        # set up resource group, bot channels registration, app service, app service plan
+        az deployment sub create --name "$(BotGroup)" --template-file "$(SampleRootPath)\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(AzureBotName)" botSku=S1 newAppServicePlanName="$(AzureBotName)" newWebAppName="$(AzureBotName)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus";
+
+        Set-PSDebug -Trace 0;
+
+  - task: AzureCLI@2
+    displayName: Create directline channel
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+       az bot directline create --name "$(AzureBotName)" --resource-group "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json" --debug
+
+  - task: ArchiveFiles@2
+    displayName: Zip the bot
+    inputs:
+      rootFolderOrFile: $(SampleRootPath)
+      includeRootFolder: false
+      archiveFile: $(Build.ArtifactStagingDirectory)/testbot.zip
+
+  - task: PublishPipelineArtifact@1
+    displayName: Publish zip file to Pipeline Artifacts
+    inputs:
+      path: $(Build.ArtifactStagingDirectory)
+      artifactName: zipfile
+    continueOnError: true
+
+  - task: AzureCLI@2
+    displayName: Zip deploy the bot to Azure
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(AzureBotName)" --src "$(Build.ArtifactStagingDirectory)/testbot.zip" --debug
+
+  - powershell: |
+      # Key = Direct Line channel "Secret keys" in Azure portal
+      $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
+      $key = $json.properties.properties.sites.key;
+      echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
+      echo "##vso[task.setvariable variable=BOTID;]$(AzureBotName)";
+      Write-Host "setx DIRECTLINE $key";
+      Write-Host "setx BOTID $(AzureBotName)";
+    displayName: Set DIRECTLINE key, BOTID for running tests
+
+  - task: NuGetToolInstaller@1
+    displayName: Use NuGet 5.5.1
+    inputs:
+      versionSpec: 5.5.1
+
+  - powershell: |
+      $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
+
+      $content = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
+      "@;
+
+      New-Item -Path $file -ItemType "file" -Value $content;
+      '-------------'; get-content "$file"; '==================='
+    displayName: Create nuget.config for Samples.$(SampleBotName).FunctionalTests.csproj for NuGet.org feed
+
+  - task: NuGetCommand@2
+    displayName: NuGet restore dotnet Samples.$(SampleBotName).FunctionalTests.csproj
+    inputs:
+      solution: samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
+      nugetConfigPath: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build dotnet Samples.$(SampleBotName).FunctionalTests.csproj
+    inputs:
+      projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test
+    inputs:
+      command: test
+      projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/**Tests.csproj
+      arguments: --verbosity Normal
+
+  - script: |
+      dir .. /s
+    displayName: 'Dir workspace'
+    continueOnError: true
+    condition: always()
+
+  - task: AzureCLI@2
+    displayName: Delete bot, app service, app service plan, group
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        Set-PSDebug -Trace 1;
+
+        Write-Host "1) Delete Bot:";
+        az bot delete --name $(AzureBotName) --resource-group $(BotGroup);
+
+        Write-Host "2) Delete App Service:";
+        az webapp delete --name $(AzureBotName) --resource-group $(BotGroup);
+
+        Write-Host "3) Delete App Service plan:";
+        az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes;
+
+        Write-Host "4) Delete Resource Group:";
+        az group delete --name $(BotGroup) --yes;
+
+        Set-PSDebug -Trace 0;
+    condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
+    continueOnError: True
+...

--- a/build/yaml/sample-ts-samplebot-linux-test.yml
+++ b/build/yaml/sample-ts-samplebot-linux-test.yml
@@ -1,0 +1,304 @@
+# This is used in the pipelines Sample-Ts-CoreBot-Linux-Test-yaml and Sample-Ts-EchoBot-Linux-Test-yaml.
+
+# 'Allow scripts to access the OAuth token' was selected in pipeline.  Add the following YAML to any steps requiring access:
+#       env:
+#           MY_ACCESS_TOKEN: $(System.AccessToken)
+# Variable 'AppId' is defined in Azure
+# Variable 'AppSecret' is defined in Azure
+# Variable 'AzureBotName' is defined in Azure
+# Variable 'AzureSubscription' is defined in Azure
+# Variable 'BotGroup' is defined in Azure
+# Variable 'DeleteResourceGroup' is defined in Azure
+# Variable 'MyGetPersonalAccessToken' is defined in Azure
+# Variable 'runCodesignValidationInjection' is defined in Azure
+# Variable 'SampleBotName' is defined in Azure
+# Variable 'SampleFolderName' is defined in Azure
+# Variable 'SampleRootPath' is defined in Azure
+# Variable Group 'AzureDeploymentCredsVariableGroup' is defined in Azure
+# Variable Group 'SamplesE2ETestsVariableGroup' is defined in Azure
+# Variable Group 'MyGetPersonalAccessTokenVariableGroup' is defined in Azure
+
+parameters:
+  - name: testLatestPackage
+    displayName: Test latest package version
+    type: boolean
+    default: true
+  - name: versionToTest
+    displayName: Version to test (Only if 'Test latest' is unchecked)
+    type: string
+    default: 'Example: 4.15.0-dev.20210726.c56bbf1'
+  - name: packageFeed
+    displayName: Package feed to use
+    type: string
+    default: npm
+    values:
+    - npm
+    - MyGet
+
+# Run this job every night at 2 AM (PST) on the main branch
+schedules:
+- cron: 0 9 * * *
+  displayName: Daily 2AM PST build
+  branches:
+    include:
+    - main
+  always: true
+
+# Do not run PR validation
+pr: none
+
+# Do not run CI validation
+trigger: none
+
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: main
+
+#variables:
+#- group: AzureDeploymentCredsVariableGroup
+#- group: SamplesE2ETestsVariableGroup
+#- group: MyGetPersonalAccessTokenVariableGroup
+
+jobs:
+- job: Job_1
+  displayName: Agent job 1
+  pool:
+    vmImage: windows-2019
+  steps:
+  - checkout: self
+    persistCredentials: True
+
+  - powershell: |
+      $packageName = "botbuilder";
+
+      Write-Host "Get $packageName preview version tagged 'next' from npmjs.com";
+      " "
+      "Available versions:";
+      npm view $packageName versions | Select -Last 30;
+
+      $dist = npm dist-tag ls $packageName;
+      $next = $dist.Where({$_.StartsWith("next:")});
+      [string]$latestVersion = $next.Split(':')[-1].Trim();
+
+      "Latest version:";
+      $packageName;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+    displayName: From npm feed get latest botbuilder package version  - https://www.npmjs.com/package/botbuilder
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'npm')) }}
+
+  - powershell: |
+      $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      $myGetFeedName = "botbuilder-v4-js-daily";
+      $packageName = "botbuilder-ai";
+
+      $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
+
+      Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
+      $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+
+      $package = $result.packages | Where-Object {$_.id -eq $packageName};
+      " "
+      "Available versions:";
+      $package.versions | Select -Last 30;
+
+      [string]$latestVersion = $package.versions[-1];
+      " "
+      "Latest version:";
+      $package.id;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
+    displayName: 'From MyGet feed get latest botbuilder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
+
+  - powershell: |
+     $targetVersion = "${{ parameters.versionToTest }}";
+     $targetVersion;
+     "##vso[task.setvariable variable=TargetVersion;]$targetVersion";
+    displayName: 'From user input get specific botbuilder version number'
+    condition: ${{ ne(parameters.testLatestPackage, true) }}
+
+  - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
+    displayName: 'Display env vars'
+ 
+  - task: tagBuildOrRelease@0
+    displayName: Tag Build with botbuilder version
+    inputs:
+      tags: |
+        Using botbuilder version $(TargetVersion)
+        From ${{ parameters.packageFeed }} feed 
+        Test latest = ${{ parameters.testLatestPackage }}
+
+  - powershell: |
+     # SetDependencyVersionInPackageJsonFile0.ps1
+      $path = "$(SampleRootPath)/package.json";
+      $packages = @('botbuilder','botbuilder-ai','botbuilder-dialogs','botbuilder-testing');
+      $newVersion = "$(TargetVersion)";
+
+      $content = Get-ChildItem -Path "$path" | Get-Content -Raw
+
+      foreach ($package in $packages) {
+          $find = "$package`": `"\S*`"";
+          $replace = "$package`": `"$newVersion`"";
+          $content = $content -Replace "$find", "$replace";
+      }
+
+      Set-Content -Path $path -Value $content;
+      '-------------'; get-content $path; '===================';
+    displayName: Set botbuilder version reference in package.json
+
+  - powershell: |
+        Set-Location -Path "$(SampleRootPath)"
+
+        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://registry.npmjs.com/"
+    displayName: Create .npmrc for npm feed - https://www.npmjs.com/search?q=botbuilder
+    condition: ${{ eq(parameters.packageFeed, 'npm') }}
+
+  - powershell: |
+        Set-Location -Path "$(SampleRootPath)"
+
+        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
+    displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
+    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
+
+  - task: Npm@1
+    displayName: npm install $(SampleFolderName)
+    inputs:
+      workingDir: $(SampleRootPath)
+      verbose: false
+
+  - task: AzureCLI@2
+    displayName: 'create group, create resources, generate web.config (uses dotnet template)'
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        Set-PSDebug -Trace 1;
+     
+        az group create --location westus --name $(BotGroup);
+     
+        # set up bot channels registration, app service, app service plan
+        az deployment group create --resource-group "$(BotGroup)" --template-file "$(SampleRootPath)\deploymentTemplates\linux\template.json" --parameters appId="$(AppId)" appSecret="$(AppSecret)" botName="$(AzureBotName)" --name "$(AzureBotName)";
+     
+        # Generate web.config for bot deploy
+        az bot prepare-deploy --code-dir "$(SampleRootPath)" --lang Javascript
+     
+        Set-PSDebug -Trace 0;
+
+  - powershell: |
+      Set-PSDebug -Trace 1;
+      # Copy Azure deploy scripts for Linux
+      Move-Item -Path $(SampleRootPath)\deploymentScripts\linux\* -Destination $(SampleRootPath)\;
+      Set-PSDebug -Trace 0;
+    displayName: Move .deployment, deploy.sh scripts into position
+
+  - script: |
+      echo on
+      git config --global user.name "SampleTs$(SampleBotName)LinuxTestPipeline"
+      git config --global user.email BotBuilderTs@Pipeline.com
+      git init
+   
+      git add .
+      git commit -m "Add bot source code"
+      git remote add azure https://$(AzureDeploymentUser):$(AzureDeploymentPassword)@$(AzureBotName).scm.azurewebsites.net:443/$(AzureBotName).git
+   
+      git push azure master
+    workingDirectory: '$(System.DefaultWorkingDirectory)/samples/javascript_nodejs/$(SampleFolderName)'
+    displayName: 'Deploy the bot to Azure'
+
+  - task: AzureCLI@2
+    displayName: Create DirectLine channel
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: batch
+      scriptLocation: inlineScript
+      inlineScript: call az bot directline create --name "$(AzureBotName)" --resource-group "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json" --debug
+
+  - powershell: |
+      # Key = Direct Line channel "Secret keys" in Azure portal
+      $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
+      $key = $json.properties.properties.sites.key;
+      echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
+      echo "##vso[task.setvariable variable=BOTID;]$(AzureBotName)";
+      Write-Host "setx DIRECTLINE $key";
+      Write-Host "setx BOTID $(AzureBotName)";
+    displayName: Set DIRECTLINE key, BOTID for running tests
+
+  - task: NuGetToolInstaller@1
+    displayName: Use NuGet 5.5.1
+    inputs:
+      versionSpec: 5.5.1
+
+  - powershell: |
+      $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
+
+      $content = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
+
+      "@;
+
+      New-Item -Path $file -ItemType "file" -Value $content;
+        '-------------'; get-content "$file"; '==================='
+    displayName: Create nuget.config for Samples.$(SampleBotName).FunctionalTests.csproj for NuGet.org feed
+
+  - task: NuGetCommand@2
+    displayName: NuGet restore dotnet Samples.$(SampleBotName).FunctionalTests.csproj
+    inputs:
+      solution: samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
+      nugetConfigPath: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build dotnet Samples.$(SampleBotName).FunctionalTests.csproj
+    inputs:
+      projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test
+    inputs:
+      command: test
+      projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/**Tests.csproj
+      arguments: --verbosity Normal
+
+  - script: |
+      dir .. /s
+    displayName: 'Dir workspace'
+    continueOnError: true
+    condition: always()
+
+  - task: AzureCLI@2
+    displayName: Delete bot, app service, app service plan, group
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        Set-PSDebug -Trace 1;
+
+        Write-Host "1) Delete Bot:";
+        az bot delete --name $(AzureBotName) --resource-group $(BotGroup);
+
+        Write-Host "2) Delete App Service:";
+        az webapp delete --name $(AzureBotName) --resource-group $(BotGroup);
+
+        Write-Host "3) Delete App Service plan:";
+        az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes;
+
+        Write-Host "4) Delete Resource Group:";
+        az group delete --name $(BotGroup) --yes;
+
+        Set-PSDebug -Trace 0;
+    condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
+    continueOnError: True
+
+...

--- a/build/yaml/sample-ts-samplebot-win-test.yml
+++ b/build/yaml/sample-ts-samplebot-win-test.yml
@@ -1,0 +1,344 @@
+# This is used in the pipelines Sample-Ts-CoreBot-Win-Test-yaml and Sample-Ts-EchoBot-Win-Test-yaml.
+
+# 'Allow scripts to access the OAuth token' was selected in pipeline.  Add the following YAML to any steps requiring access:
+#       env:
+#           MY_ACCESS_TOKEN: $(System.AccessToken)
+# Variable 'AppId' is defined in Azure
+# Variable 'AppSecret' is defined in Azure
+# Variable 'AzureBotName' is defined in Azure
+# Variable 'AzureSubscription' is defined in Azure
+# Variable 'BotGroup' is defined in Azure
+# Variable 'DeleteResourceGroup' is defined in Azure
+# Variable 'MyGetPersonalAccessToken' is defined in Azure
+# Variable 'runCodesignValidationInjection' is defined in Azure
+# Variable 'SampleBotName' is defined in Azure
+# Variable 'SampleFolderName' is defined in Azure
+# Variable 'SampleRootPath' is defined in Azure
+# Variable Group 'SamplesE2ETestsVariableGroup' is defined in Azure
+# Variable Group 'MyGetPersonalAccessTokenVariableGroup' is defined in Azure
+
+parameters:
+  - name: testLatestPackage
+    displayName: Test latest package version
+    type: boolean
+    default: true
+  - name: versionToTest
+    displayName: Version to test (Only if 'Test latest' is unchecked)
+    type: string
+    default: 'Example: 4.15.0-dev.20210726.c56bbf1'
+  - name: packageFeed
+    displayName: Package feed to use
+    type: string
+    default: npm
+    values:
+    - npm
+    - MyGet
+
+# Run this job every night at 2 AM (PST) on the main branch
+schedules:
+- cron: 0 9 * * *
+  displayName: Daily 2AM PST build
+  branches:
+    include:
+    - main
+  always: true
+
+# Do not run PR validation
+pr: none
+
+# Do not run CI validation
+trigger: none
+
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: main
+
+#variables:
+#- group: SamplesE2ETestsVariableGroup
+#- group: MyGetPersonalAccessTokenVariableGroup
+
+jobs:
+- job: Job_1
+  displayName: Agent job 1
+  pool:
+    vmImage: windows-2019
+  steps:
+  - checkout: self
+    persistCredentials: True
+
+  - powershell: |
+      $packageName = "botbuilder";
+
+      Write-Host "Get $packageName preview version tagged 'next' from npmjs.com";
+      " "
+      "Available versions:";
+      npm view $packageName versions | Select -Last 30;
+
+      $dist = npm dist-tag ls $packageName;
+      $next = $dist.Where({$_.StartsWith("next:")});
+      [string]$latestVersion = $next.Split(':')[-1].Trim();
+
+      "Latest version:";
+      $packageName;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";
+    displayName: From npm feed get latest botbuilder package version  - https://www.npmjs.com/package/botbuilder
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'npm')) }}
+
+  - powershell: |
+      $myGetPersonalAccessToken = "$(MyGetPersonalAccessToken)";
+      $myGetFeedName = "botbuilder-v4-js-daily";
+      $packageName = "botbuilder-ai";
+
+      $url = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
+
+      Write-Host "Get latest $packageName version number from MyGet $myGetFeedName";
+      $result = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json";
+
+      $package = $result.packages | Where-Object {$_.id -eq $packageName};
+      " "
+      "Available versions:";
+      $package.versions | Select -Last 30;
+
+      [string]$latestVersion = $package.versions[-1];
+      " "
+      "Latest version:";
+      $package.id;
+      $latestVersion;
+      "##vso[task.setvariable variable=TargetVersion;]$latestVersion";    
+    displayName: 'From MyGet feed get latest botbuilder version number - https://botbuilder.myget.org/gallery/botbuilder-v4-dotnet-daily'
+    condition: ${{ and(eq(parameters.testLatestPackage, true), eq(parameters.packageFeed, 'MyGet')) }}
+
+  - powershell: |
+     $targetVersion = "${{ parameters.versionToTest }}";
+     $targetVersion;
+     "##vso[task.setvariable variable=TargetVersion;]$targetVersion";
+    displayName: 'From user input get specific botbuilder version number'
+    condition: ${{ ne(parameters.testLatestPackage, true) }}
+
+  - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
+    displayName: 'Display env vars'
+ 
+  - task: tagBuildOrRelease@0
+    displayName: Tag Build with botbuilder version
+    inputs:
+      tags: |
+        Using botbuilder version $(TargetVersion)
+        From ${{ parameters.packageFeed }} feed 
+        Test latest = ${{ parameters.testLatestPackage }}
+
+  - powershell: |
+     # SetDependencyVersionInPackageJsonFile0.ps1
+      $path = "$(SampleRootPath)/package.json";
+      $packages = @('botbuilder','botbuilder-ai','botbuilder-dialogs','botbuilder-testing');
+      $newVersion = "$(TargetVersion)";
+
+      $content = Get-ChildItem -Path "$path" | Get-Content -Raw
+
+      foreach ($package in $packages) {
+          $find = "$package`": `"\S*`"";
+          $replace = "$package`": `"$newVersion`"";
+          $content = $content -Replace "$find", "$replace";
+      }
+
+      Set-Content -Path $path -Value $content;
+      '-------------'; get-content $path; '===================';
+    displayName: Set botbuilder version reference in package.json
+
+  - powershell: |
+        Set-Location -Path "$(SampleRootPath)"
+
+        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://registry.npmjs.com/"
+    displayName: Create .npmrc for npm feed - https://www.npmjs.com/search?q=botbuilder
+    condition: ${{ eq(parameters.packageFeed, 'npm') }}
+
+  - powershell: |
+        Set-Location -Path "$(SampleRootPath)"
+
+        New-Item -Path . -Name ".npmrc" -ItemType "file" -Value "registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
+    displayName: Create .npmrc for MyGet feed - https://botbuilder.myget.org/feed/Packages/botbuilder-v4-js-daily
+    condition: ${{ eq(parameters.packageFeed, 'MyGet') }}
+
+  - task: Npm@1
+    displayName: npm install $(SampleFolderName)
+    inputs:
+      workingDir: $(SampleRootPath)
+      verbose: false
+
+  - powershell: |
+      $file = "$(SampleRootPath)\package.json";
+   
+      $content = Get-Content -Raw $file | ConvertFrom-Json
+      $content.scripts.start = 'node ./lib/index.js'
+      $content | ConvertTo-Json | Set-Content $file
+   
+      '-------------'; get-content $file; '==================='
+    displayName: 'Fix start-up command script for Win deploy'
+
+  - powershell: |
+      Set-PSDebug -Trace 1;
+
+      move-item -path $(SampleRootPath)/deploymentScripts/windows/* -destination $(SampleRootPath);
+
+      $DirToCompress = "$(SampleRootPath)";
+      $DirtoExclude =@("node_modules", "deploymentTemplates", "deploymentScripts");
+      $files = Get-ChildItem -Path $DirToCompress -Exclude $DirtoExclude;
+      $ZipFileDestination ="$(SampleRootPath)/testbot.zip";
+
+      Compress-Archive -Path $files -DestinationPath $ZipFileDestination;
+
+      Set-PSDebug -Trace 0;
+    displayName: Set up deploy scripts, zip the bot
+
+  - task: CopyFiles@2
+    displayName: 'Copy testbot.zip to: $(Build.ArtifactStagingDirectory)'
+    inputs:
+      SourceFolder: $(SampleRootPath)
+      Contents: testbot.zip
+      TargetFolder: $(Build.ArtifactStagingDirectory)
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: testbot-zip'
+    inputs:
+      ArtifactName: testbot-zip
+
+  - task: AzureCLI@2
+    displayName: 'Preexisting RG: create Azure resources. Runs in even builds.'
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        Write-Host "`n***** Creating Azure resources using the preexisting-rg template *****";
+        Write-Host "This task runs for even-numbered builds. Build ID = $(Build.BuildId)";
+        Write-Host "************************************************************************";
+        Set-PSDebug -Trace 1;
+     
+        az group create --location westus --name $(BotGroup);
+     
+        # set up bot channels registration, app service, app service plan
+        az deployment group create --resource-group "$(BotGroup)" --template-file "$(SampleRootPath)\DeploymentTemplates\template-with-preexisting-rg.json" --parameters appId="$(AppId)" appSecret="$(AppSecret)" botId="$(AzureBotName)" newWebAppName="$(AzureBotName)" newAppServicePlanName="$(AzureBotName)" appServicePlanLocation="westus" --name "$(AzureBotName)";
+     
+        Set-PSDebug -Trace 0;
+    condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 0), endsWith(variables['Build.BuildId'], 2), endsWith(variables['Build.BuildId'], 4), endsWith(variables['Build.BuildId'], 6), endsWith(variables['Build.BuildId'], 8)))
+
+  - task: AzureCLI@2
+    displayName: 'New RG: create Azure resources. Runs in odd builds.'
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        Write-Host "`n***** Creating Azure resources using the new-rg template *****";
+        Write-Host "This task runs for odd-numbered builds. Build ID = $(Build.BuildId)";
+        Write-Host "****************************************************************";
+        Set-PSDebug -Trace 1;
+
+        # set up resource group, bot channels registration, app service, app service plan
+        az deployment sub create --name "$(BotGroup)" --template-file "$(SampleRootPath)\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(AzureBotName)" botSku=F0 newAppServicePlanName="$(AzureBotName)" newWebAppName="$(AzureBotName)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus";
+     
+        Set-PSDebug -Trace 0;
+    condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 1), endsWith(variables['Build.BuildId'], 3), endsWith(variables['Build.BuildId'], 5), endsWith(variables['Build.BuildId'], 7), endsWith(variables['Build.BuildId'], 9)))
+
+  - task: AzureCLI@2
+    displayName: 'Deploy bot, create directline channel '
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        # Generate web.config for bot deploy
+        az bot prepare-deploy --code-dir "$(SampleRootPath)" --lang Javascript
+
+        az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(AzureBotName)" --src "$(Build.ArtifactStagingDirectory)\testbot.zip" --debug
+
+        az bot directline create --name "$(AzureBotName)" --resource-group "$(BotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json" --debug
+
+  - powershell: |
+      # Key = Direct Line channel "Secret keys" in Azure portal
+      $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json;
+      $key = $json.properties.properties.sites.key;
+      echo "##vso[task.setvariable variable=DIRECTLINE;]$key";
+      echo "##vso[task.setvariable variable=BOTID;]$(AzureBotName)";
+      Write-Host "setx DIRECTLINE $key";
+      Write-Host "setx BOTID $(AzureBotName)";
+    displayName: Set DIRECTLINE key, BOTID for running tests
+
+  - task: NuGetToolInstaller@1
+    displayName: Use NuGet 5.5.1
+    inputs:
+      versionSpec: 5.5.1
+
+  - powershell: |
+      $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
+
+      $content = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+        </packageSources>
+        <activePackageSource>
+          <add key="All" value="(Aggregate source)" />
+        </activePackageSource>
+      </configuration>
+
+      "@;
+
+      New-Item -Path $file -ItemType "file" -Value $content;
+        '-------------'; get-content "$file"; '==================='
+    displayName: Create nuget.config for Samples.$(SampleBotName).FunctionalTests.csproj for NuGet.org feed
+
+  - task: NuGetCommand@2
+    displayName: NuGet restore dotnet Samples.$(SampleBotName).FunctionalTests.csproj
+    inputs:
+      solution: samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
+      selectOrConfig: config
+      nugetConfigPath: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build dotnet Samples.$(SampleBotName).FunctionalTests.csproj
+    inputs:
+      projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/Samples.$(SampleBotName).FunctionalTests.csproj
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test
+    inputs:
+      command: test
+      projects: $(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/**Tests.csproj
+      arguments: --verbosity Normal
+
+  - script: |
+      dir .. /s
+    displayName: 'Dir workspace'
+    continueOnError: true
+    condition: always()
+
+  - task: AzureCLI@2
+    displayName: Delete bot, app service, app service plan, group
+    inputs:
+      azureSubscription: 'FUSE Temporary'
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        Set-PSDebug -Trace 1;
+
+        Write-Host "1) Delete Bot:";
+        az bot delete --name $(AzureBotName) --resource-group $(BotGroup);
+
+        Write-Host "2) Delete App Service:";
+        az webapp delete --name $(AzureBotName) --resource-group $(BotGroup);
+
+        Write-Host "3) Delete App Service plan:";
+        az appservice plan delete --name $(AzureBotName) --resource-group $(BotGroup) --yes;
+
+        Write-Host "4) Delete Resource Group:";
+        az group delete --name $(BotGroup) --yes;
+
+        Set-PSDebug -Trace 0;
+    condition: and(succeededOrFailed(), ne(variables['DeleteResourceGroup'], 'false'))
+    continueOnError: True
+
+...

--- a/experimental/generation/generator/packages/cli/.npmrc
+++ b/experimental/generation/generator/packages/cli/.npmrc
@@ -1,2 +1,0 @@
-@microsoft:registry=https://botbuilder.myget.org/F/botframework-cli/npm/
-registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/

--- a/experimental/generation/generator/packages/library/.npmrc
+++ b/experimental/generation/generator/packages/library/.npmrc
@@ -1,2 +1,0 @@
-@microsoft:registry=https://botbuilder.myget.org/F/botframework-cli/npm/
-registry=https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/

--- a/experimental/generation/runbot/nuget.config
+++ b/experimental/generation/runbot/nuget.config
@@ -1,6 +1,6 @@
 <configuration>
-  <packageSources>
+  <!--<packageSources>
     <clear />
     <add key="MyGet" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" />
-  </packageSources>
+  </packageSources>-->
 </configuration>

--- a/experimental/orchestrator/Composer/SchoolNavigator2/SchoolNavigator2/NuGet.config
+++ b/experimental/orchestrator/Composer/SchoolNavigator2/SchoolNavigator2/NuGet.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <packageSources>
+  <!--<packageSources>
     <clear />
     <add key="BotBuilder.myget.org" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" protocolVersion="3"/>
-  </packageSources>
+  </packageSources>-->
 </configuration>


### PR DESCRIPTION
Fixes #3589

This allows tests to be run against SDK v 4.11.3.

This run testing 4.11.3 succeeded: https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=277538&view=results

## Changes:

Add builds/yaml folder from main branch.
Remove/comment out references to external feeds so Nuget Security Analysis does not fail the builds.