### PR TITLE
[#3526] Update JS samples to 4.15.0 (part 2/2)

### DIFF
--- a/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.js
@@ -17,10 +17,10 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-ai": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
-        "botbuilder-testing": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-ai": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
+        "botbuilder-testing": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "^8.5.1"
     },

--- a/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.ts
@@ -38,10 +38,10 @@
     },
     "dependencies": {
       "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-      "botbuilder": "~4.15.0-rc0",
-      "botbuilder-ai": "~4.15.0-rc0",
-      "botbuilder-dialogs": "~4.15.0-rc0",
-      "botbuilder-testing": "~4.15.0-rc0",
+      "botbuilder": "~4.15.0",
+      "botbuilder-ai": "~4.15.0",
+      "botbuilder-dialogs": "~4.15.0",
+      "botbuilder-testing": "~4.15.0",
       "dotenv": "^8.2.0",
       "replace": "~1.2.0",
       "restify": "~8.5.1"

--- a/generators/generator-botbuilder/generators/app/templates/core/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/core/package.json.js
@@ -17,9 +17,9 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-ai": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-ai": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
         "dotenv": "~8.2.0",
         "restify": "~8.5.1"
     },

--- a/generators/generator-botbuilder/generators/app/templates/core/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/package.json.ts
@@ -19,9 +19,9 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-ai": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-ai": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
         "dotenv": "~8.2.0",
         "replace": "~1.2.0",
         "restify": "~8.5.1"

--- a/generators/generator-botbuilder/generators/app/templates/echo/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/echo/package.json.js
@@ -16,7 +16,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
         "dotenv": "~8.2.0",
         "restify": "~8.5.1"
     },

--- a/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
@@ -18,7 +18,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
         "dotenv": "~8.2.0",
         "replace": "~1.2.0",
         "restify": "~8.5.1"

--- a/generators/generator-botbuilder/generators/app/templates/empty/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/empty/package.json.js
@@ -16,7 +16,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
         "restify": "~8.5.1"
     },
     "devDependencies": {

--- a/generators/generator-botbuilder/generators/app/templates/empty/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/empty/package.json.ts
@@ -18,7 +18,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
         "replace": "~1.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/51.teams-messaging-extensions-action/package.json
+++ b/samples/javascript_nodejs/51.teams-messaging-extensions-action/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/package.json
+++ b/samples/javascript_nodejs/52.teams-messaging-extensions-search-auth-config/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@microsoft/microsoft-graph-client": "~2.0.0",
     "axios": "^0.21.2",
-    "botbuilder": "~4.15.0-rc0",
+    "botbuilder": "~4.15.0",
     "dotenv": "^8.2.0",
     "restify": "~8.5.1"
   },

--- a/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/package.json
+++ b/samples/javascript_nodejs/53.teams-messaging-extensions-action-preview/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/54.teams-task-module/package.json
+++ b/samples/javascript_nodejs/54.teams-task-module/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/55.teams-link-unfurling/package.json
+++ b/samples/javascript_nodejs/55.teams-link-unfurling/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/56.teams-file-upload/package.json
+++ b/samples/javascript_nodejs/56.teams-file-upload/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "axios": "^0.21.2",
-    "botbuilder": "~4.15.0-rc0",
+    "botbuilder": "~4.15.0",
     "dotenv": "^8.2.0",
     "restify": "~8.5.1"
   },

--- a/samples/javascript_nodejs/57.teams-conversation-bot/package.json
+++ b/samples/javascript_nodejs/57.teams-conversation-bot/package.json
@@ -18,7 +18,7 @@
     "dependencies": {
         "adaptive-expressions": "^4.14.1",
         "adaptivecards-templating": "^2.1.0",
-        "botbuilder": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/package.json
+++ b/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/package.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
-        "botframework-connector": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botframework-connector": "~4.15.0",
         "dotenv": "~8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/package.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
-        "botframework-connector": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botframework-connector": "~4.15.0",
         "dotenv": "~8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/package.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/package.json
@@ -16,8 +16,8 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
         "dotenv": "~8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/package.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/package.json
@@ -17,9 +17,9 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "~1.1.4",
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-ai": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-ai": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
         "dotenv": "~8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/package.json
+++ b/samples/javascript_nodejs/language-generation/05.a.multi-turn-prompt-with-language-fallback/package.json
@@ -16,9 +16,9 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
-        "botbuilder-lg": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
+        "botbuilder-lg": "~4.15.0",
         "dotenv": "^8.2.0",
         "path": "^0.12.7",
         "restify": "~8.5.1"

--- a/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/package.json
+++ b/samples/javascript_nodejs/language-generation/05.multi-turn-prompt/package.json
@@ -16,9 +16,9 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
-        "botbuilder-lg": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
+        "botbuilder-lg": "~4.15.0",
         "dotenv": "^8.2.0",
         "path": "^0.12.7",
         "restify": "~8.5.1"

--- a/samples/javascript_nodejs/language-generation/06.using-cards/package.json
+++ b/samples/javascript_nodejs/language-generation/06.using-cards/package.json
@@ -16,9 +16,9 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
-        "botbuilder-lg": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
+        "botbuilder-lg": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/language-generation/13.core-bot/package.json
+++ b/samples/javascript_nodejs/language-generation/13.core-bot/package.json
@@ -17,11 +17,11 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-ai": "~4.15.0-rc0",
-        "botbuilder-dialogs": "~4.15.0-rc0",
-        "botbuilder-testing": "~4.15.0-rc0",
-        "botbuilder-lg": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-ai": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
+        "botbuilder-testing": "~4.15.0",
+        "botbuilder-lg": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },

--- a/samples/javascript_nodejs/language-generation/20.custom-functions/package.json
+++ b/samples/javascript_nodejs/language-generation/20.custom-functions/package.json
@@ -16,9 +16,9 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.15.0-rc0",
-        "botbuilder-lg": "~4.15.0-rc0",
-        "adaptive-expressions": "~4.15.0-rc0",
+        "botbuilder": "~4.15.0",
+        "botbuilder-lg": "~4.15.0",
+        "adaptive-expressions": "~4.15.0",
         "dotenv": "^8.2.0",
         "restify": "~8.5.1"
     },


### PR DESCRIPTION
Addresses #3526

## Description
This PR updated the JS samples and generators to the 4.15.0 version of the botbuilder packages.

### Detailed Changes
This PR includes the following samples:

- 51.teams-messaging-extensions-action
- 52.teams-messaging-extensions-search-auth-config
- 53.teams-messaging-extensions-action-preview
- 54.teams-task-module
- 55.teams-link-unfurling
- 56.teams-file-upload
- 57.teams-conversation-bot
- 58.teams-start-new-thread-in-channel
- 80.skills-simple-bot-to-bot
- 81.skills-skilldialog

language-generation folder:
- 05.a.multi-turn-prompt-with-language-fallback
- 05.multi-turn-prompt
- 06.using-cards
- 13.core-bot
- 20.custom-functions

Generators (JS and TS):
- Core
- Echo
- Empty

## Testing
The following images show some of the bots working as expected
![image](https://user-images.githubusercontent.com/44245136/142062113-5bdf361c-01bb-4ce6-90b6-3e52f90fc3f8.png)
