### PR TITLE
pass the config parameter to axios to attach auth headers

### DIFF
--- a/samples/javascript_nodejs/56.teams-file-upload/services/fileService.js
+++ b/samples/javascript_nodejs/56.teams-file-upload/services/fileService.js
@@ -15,7 +15,7 @@ const geneFileName = async (fileDir) => {
 
 // Download and Save Streams into File
 const writeFile = async (contentUrl, config, filePath) => {
-    const response = await axios({ method: 'GET', url: contentUrl, responseType: 'stream' });
+    const response = await axios({ method: 'GET', url: contentUrl, ...config });
     return await new Promise((resolve, reject) => response.data.pipe(fs.createWriteStream(filePath)).once('finish', resolve).once('error', reject));
 };
 


### PR DESCRIPTION
Fixes #3610

## Proposed Changes
Headers (Bearer token) were not being set in the axios request even though they were passed as a pram to the function. Also as responseType is also set in the config variable, removing the duplicate here.

Evidence that the code works:
![image](https://user-images.githubusercontent.com/283677/143238448-3fef9622-2f74-4870-8959-6373d38e24b8.png)
