### PR TITLE
[#3463] Slack adapter not working as expected - Update sample' README

### DIFF
--- a/samples/csharp_dotnetcore/60.slack-adapter/README.md
+++ b/samples/csharp_dotnetcore/60.slack-adapter/README.md
@@ -34,7 +34,9 @@ Once your app has been created, you need to collect some information that will b
 
 1. Note the 'Verification Token' and the 'Signing Secret' from the **Basic Information** tab and keep them for later when we configure our bot settings.
 
-2. Navigate to the **Install App** page under the 'Settings' menu and follow the instructions to install your app into a Slack team.  Once installed, copy the 'Bot User OAuth Access Token' and, again, keep this for later when we configure out bot settings.
+2. Navigate to the **Install App** page under the 'Settings' menu and follow the instructions to install your app into a Slack team.  
+  Here you need to add at least one permission scope. Click the 'permission scope' link, scroll down to the _Scopes_ section and click on the 'Add an Oauth Scope' button under _Bot Token Scopes_. Select the `chat:write` scope.  
+  Once installed, copy the 'Bot User OAuth Access Token' and, again, keep this for later when we configure out bot settings.
 
 ### Add Slack app settings to your bot's configuration file
 


### PR DESCRIPTION
Fixes #3463

## Description
This PR updates the README file of the [60.slack-adapter sample](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/csharp_dotnetcore/60.slack-adapter) to include the new required scope in the configuration of the Slack App.
The `chat:write` scope is required for new apps to post messages.

### Detailed changes
- Added the instructions to enable the `chat:write` scope in the SlackApp.

## Testing
This image shows a sneak-peak of the updated file.
![image](https://user-images.githubusercontent.com/44245136/144248004-17d30523-6b32-4522-a487-1dab8ff14bcb.png)
