### PR TITLE
[#3617] Update README in generators folder to point to new locations

### DIFF
--- a/generators/README.md
+++ b/generators/README.md
@@ -1,29 +1,33 @@
 # Overview
 
-This folder contains code generators for Microsoft **Bot Framework V4 SDK** - [dotnet SDK][10], [JS SDK][11].
+The code generators for Microsoft **Bot Framework V4 SDK** have been moved to the SDK repositories.  
+They can be found following these links:
 
-Currently there are three code generator options to choose from.  They are:
+| Language | Generator | Location |
+| -------- | ------------------ |------------------|
+| C# | .NET Core SDK Templates | [botbuilder-dotnet][1] |
+| C# | Visual Studio Extension | [botbuilder-dotnet][2] |
+| JavaScript, TypeScript | Yeoman Generator | [botbuilder-js][3] |
+| Python | Cookiecutter | [botbuilder-python][4] |
+| Java | Yeoman Generator | [botbuilder-java][5] |
 
-## Supported Code Generators
-
-| Generator | Language Support | OS Support |
-| --------- | ---------------- | ---------- |
-| [.NET Core SDK Templates][1] | C# | `dotnet new` for Windows, macOS, Linux |
-| [Yeoman Generator][2]    | Javascript, TypeScript | Windows, macOS, Linux |
-| [Visual Studio Extension][3] | C# | Visual Studio for Windows |
 
 ## Help Me Choose a Generator
-
 Which code generator to use largely depends on the development tools and programming language you use. The table below can help you decide:
 
 | Language | Programming Editor | OS Support | Code Generator |
 | -------- | ------------------ | ---------- | --------- |
-| C# | Visual Studio | Windows| [Visual Studio Extension][3] |
+| C# | Visual Studio | Windows| [Visual Studio Extension][2] |
 | C# | VS Code, Atom, Textmate | Windows, macOS, Linux | [.NET Core SDK Templates][1] |
-| JavaScript, TypeScript |  VS Code, Atom, Textmate | Windows, macOS, Linux | [Yeoman Generator][2] |
+| JavaScript, TypeScript |  VS Code, Atom, Textmate | Windows, macOS, Linux | [Yeoman Generator][3] |
+| Python |  VS Code, Atom, Textmate | Windows, macOS, Linux | [Cookiecutter][4] |
+| Java |  VS Code, Atom, Textmate | Windows, macOS, Linux | [Yeoman Generator][5] |
 
-[1]: https://github.com/Microsoft/BotBuilder-Samples/tree/master/generators/dotnet-templates
-[2]: https://github.com/Microsoft/BotBuilder-Samples/tree/master/generators/generator-botbuilder
-[3]: https://github.com/Microsoft/BotBuilder-Samples/tree/master/generators/vsix-vs-win/BotBuilderVSIX-V4
-[10]: https://github.com/Microsoft/botbuilder-dotnet
-[11]: https://github.com//microsoft/botbuilder-js
+
+
+[1]: https://github.com/microsoft/botbuilder-dotnet/tree/main/generators/dotnet-templates
+[2]: https://github.com/microsoft/botbuilder-dotnet/tree/main/generators/vsix-vs-win/BotBuilderVSIX-V4
+[3]: https://github.com/microsoft/botbuilder-js/tree/main/generators
+[4]: https://github.com/microsoft/botbuilder-python/tree/main/generators
+[5]: https://github.com/microsoft/botbuilder-java/tree/main/generators
+


### PR DESCRIPTION
Fixes #3617

## Proposed Changes
This PR updates the README file in the [generators](https://github.com/microsoft/BotBuilder-Samples/blob/main/generators/README.md) folder to point to the generators' new locations in each of the SDK repositories.


## Testing
This image shows a preview of the updated README.
![image](https://user-images.githubusercontent.com/44245136/146041898-fd35d505-1243-44ef-af70-ad7292b0d1a4.png)