### PR TITLE
Bump log4j dependencies to 2.16.0

### DIFF
--- a/generators/java/generators/app/templates/core/project/pom.xml
+++ b/generators/java/generators/app/templates/core/project/pom.xml
@@ -70,17 +70,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/generators/java/generators/app/templates/echo/project/pom.xml
+++ b/generators/java/generators/app/templates/echo/project/pom.xml
@@ -55,17 +55,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/generators/java/generators/app/templates/empty/project/pom.xml
+++ b/generators/java/generators/app/templates/empty/project/pom.xml
@@ -55,17 +55,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/02.echo-bot/pom.xml
+++ b/samples/java_springboot/02.echo-bot/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/03.welcome-user/pom.xml
+++ b/samples/java_springboot/03.welcome-user/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/05.multi-turn-prompt/pom.xml
+++ b/samples/java_springboot/05.multi-turn-prompt/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/06.using-cards/pom.xml
+++ b/samples/java_springboot/06.using-cards/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/07.using-adaptive-cards/pom.xml
+++ b/samples/java_springboot/07.using-adaptive-cards/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/08.suggested-actions/pom.xml
+++ b/samples/java_springboot/08.suggested-actions/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/11.qnamaker/pom.xml
+++ b/samples/java_springboot/11.qnamaker/pom.xml
@@ -87,17 +87,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/13.core-bot/pom.xml
+++ b/samples/java_springboot/13.core-bot/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/14.nlp-with-dispatch/pom.xml
+++ b/samples/java_springboot/14.nlp-with-dispatch/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/15.handling-attachments/pom.xml
+++ b/samples/java_springboot/15.handling-attachments/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/samples/java_springboot/16.proactive-messages/pom.xml
+++ b/samples/java_springboot/16.proactive-messages/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/17.multilingual-bot/pom.xml
+++ b/samples/java_springboot/17.multilingual-bot/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/18.bot-authentication/pom.xml
+++ b/samples/java_springboot/18.bot-authentication/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/19.custom-dialogs/pom.xml
+++ b/samples/java_springboot/19.custom-dialogs/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/21.corebot-app-insights/pom.xml
+++ b/samples/java_springboot/21.corebot-app-insights/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/23.facebook-events/pom.xml
+++ b/samples/java_springboot/23.facebook-events/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/24.bot-authentication-msgraph/pom.xml
+++ b/samples/java_springboot/24.bot-authentication-msgraph/pom.xml
@@ -86,17 +86,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/25.message-reaction/pom.xml
+++ b/samples/java_springboot/25.message-reaction/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/42.scaleout/pom.xml
+++ b/samples/java_springboot/42.scaleout/pom.xml
@@ -70,17 +70,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/43.complex-dialog/pom.xml
+++ b/samples/java_springboot/43.complex-dialog/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/44.prompt-users-for-input/pom.xml
+++ b/samples/java_springboot/44.prompt-users-for-input/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/45.state-management/pom.xml
+++ b/samples/java_springboot/45.state-management/pom.xml
@@ -80,17 +80,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/46.teams-auth/pom.xml
+++ b/samples/java_springboot/46.teams-auth/pom.xml
@@ -87,17 +87,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/47.inspection/pom.xml
+++ b/samples/java_springboot/47.inspection/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/49.qnamaker-all-features/pom.xml
+++ b/samples/java_springboot/49.qnamaker-all-features/pom.xml
@@ -87,17 +87,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/50.teams-messaging-extensions-search/pom.xml
+++ b/samples/java_springboot/50.teams-messaging-extensions-search/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
      <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/51.teams-messaging-extensions-action/pom.xml
+++ b/samples/java_springboot/51.teams-messaging-extensions-action/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/pom.xml
+++ b/samples/java_springboot/52.teams-messaging-extensions-search-auth-config/pom.xml
@@ -86,17 +86,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/53.teams-messaging-extensions-action-preview/pom.xml
+++ b/samples/java_springboot/53.teams-messaging-extensions-action-preview/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/54.teams-task-module/pom.xml
+++ b/samples/java_springboot/54.teams-task-module/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/55.teams-link-unfurling/pom.xml
+++ b/samples/java_springboot/55.teams-link-unfurling/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/56.teams-file-upload/pom.xml
+++ b/samples/java_springboot/56.teams-file-upload/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/57.teams-conversation-bot/pom.xml
+++ b/samples/java_springboot/57.teams-conversation-bot/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/58.teams-start-new-thread-in-channel/pom.xml
+++ b/samples/java_springboot/58.teams-start-new-thread-in-channel/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/80.skills-simple-bot-to-bot/DialogRootBot/pom.xml
+++ b/samples/java_springboot/80.skills-simple-bot-to-bot/DialogRootBot/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/80.skills-simple-bot-to-bot/DialogSkillBot/pom.xml
+++ b/samples/java_springboot/80.skills-simple-bot-to-bot/DialogSkillBot/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/81.skills-skilldialog/dialog-root-bot/pom.xml
+++ b/samples/java_springboot/81.skills-skilldialog/dialog-root-bot/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/81.skills-skilldialog/dialog-skill-bot/pom.xml
+++ b/samples/java_springboot/81.skills-skilldialog/dialog-skill-bot/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/pom.xml
+++ b/samples/java_springboot/pom.xml
@@ -333,7 +333,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -345,7 +345,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/samples/java_springboot/servlet-echo/pom.xml
+++ b/samples/java_springboot/servlet-echo/pom.xml
@@ -81,12 +81,12 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Bump log4j dependencies to 2.16.0
This latest version includes additional fixes for CVE-2021-44228