### PR TITLE
Update log4j to 2.17.1 to address CVE-2021-44832.

### DIFF
--- a/samples/java_springboot/05.multi-turn-prompt/pom.xml
+++ b/samples/java_springboot/05.multi-turn-prompt/pom.xml
@@ -81,17 +81,17 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.17.0</version>
+        <version>2.17.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.17.0</version>
+        <version>2.17.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.16.0</version>
+        <version>2.17.1</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->
N/A

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->
<!-- If you are introducing a new sample, make sure that the sample adheres to sample guidelines -->

Hello new Patch!
Update log4j to 2.17.1 to address CVE-2021-44832.
https://nvd.nist.gov/vuln/detail/CVE-2021-44832


## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
N/A