### PR TITLE
Fix for custom view tasks

### DIFF
--- a/samples/javascript_nodejs/51.teams-messaging-extensions-action/teamsAppManifest/manifest.json
+++ b/samples/javascript_nodejs/51.teams-messaging-extensions-action/teamsAppManifest/manifest.json
@@ -120,5 +120,8 @@
   ],
   "permissions": [
     "identity"
+  ],
+  "validDomains": [
+    "<<BASE-URL>>"
   ]
 }

--- a/samples/javascript_nodejs/51.teams-messaging-extensions-action/teamsAppManifest/manifest.json
+++ b/samples/javascript_nodejs/51.teams-messaging-extensions-action/teamsAppManifest/manifest.json
@@ -122,6 +122,6 @@
     "identity"
   ],
   "validDomains": [
-    "<<BASE-URL>>"
+    "*.ngrok.io"
   ]
 }

--- a/samples/python/51.teams-messaging-extensions-action/teams_app_manifest/manifest.json
+++ b/samples/python/51.teams-messaging-extensions-action/teams_app_manifest/manifest.json
@@ -74,5 +74,8 @@
   ],
   "permissions": [
     "identity"
+  ],
+  "validDomains": [
+    "*.ngrok.io"
   ]
 }


### PR DESCRIPTION
Fixes # N/A <!-- If this addresses a specific issue, please provide the issue number here -->

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->
<!-- If you are introducing a new sample, make sure that the sample adheres to sample guidelines -->

The current examples do not work as the `validDomains` property in the Microsoft Teams manifest are missing. All other components of the messaging extension sample work other than the "Web View" and "Static HTML" options as they both require a fetch task.
  - Adding the required property to both JS and Python samples
    - Opted to include an ngrok wildcard as that is the technology suggested by the sample README


## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
- No new tests added. Sample now works out of the box

![image](https://user-images.githubusercontent.com/17578180/149192739-86601a62-f8c1-4d9b-8ea1-b0cab473bdd9.png)

![image](https://user-images.githubusercontent.com/17578180/149192809-aab7e5ba-02a3-49a0-a8a4-5acce8322264.png)
