### PR TITLE
Update README.md for Orchestrator Sample

### DIFF
--- a/samples/csharp_dotnetcore/14.nlp-with-orchestrator/README.md
+++ b/samples/csharp_dotnetcore/14.nlp-with-orchestrator/README.md
@@ -18,7 +18,7 @@ This bot uses Orchestrator to route user utterances to multiple LUIS models and 
 | OS      | Version             | Architectures   |
 | ------- | ------------------- | --------------- |
 | Windows | 10 (1607+)          | ia32 (x86), x64 |
-| MacOS   | 10.14+              | x64             |
+| MacOS   | 10.15+              | x64             |
 | Linux   | Ubuntu 18.04, 20.04 | x64             |
 
 This sample **requires** prerequisites in order to run.

--- a/samples/javascript_nodejs/14.nlp-with-orchestrator/README.md
+++ b/samples/javascript_nodejs/14.nlp-with-orchestrator/README.md
@@ -18,7 +18,7 @@ This bot uses Orchestrator to route user utterances to multiple LUIS models and 
 | OS      | Version    | Architectures   |
 | ------- | ---------- | --------------- |
 | Windows | 10 (1607+) | ia32 (x86), x64 |
-| MacOS | 10.14+ | x64 |
+| MacOS | 10.15+ | x64 |
 | Linux | Ubuntu 18.04, 20.04 | x64|
 
 


### PR DESCRIPTION
Update README.md for Orchestrator example.

Mac OS 10.14 is now out of support.  10.15 is supported.


