### PR TITLE
[Core Bot Sample] Add welcomeCard as Content so it will be accessible when published

### DIFF
--- a/samples/csharp_dotnetcore/13.core-bot/CoreBot.csproj
+++ b/samples/csharp_dotnetcore/13.core-bot/CoreBot.csproj
@@ -6,14 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Remove="Cards\welcomeCard.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Include="Cards\welcomeCard.json" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.15.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.15.0" />


### PR DESCRIPTION
Resolves ICM

This PR resolves an ICM for the following issue: 

Recently I was working on a sample where I have identified that the Cards folder associated with the core bot sample is not getting published causing error in the bot when a call to adaptive card is made.

We need help to fix the same


[TROUBLESHOOTING STEPS]

Tried deploying the sample :

https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/csharp_dotnetcore/13.core-bot

Uploaded Image

When we see on kudu console the folder cards itself is not published

 
However when the below sample is tested the resources folder is getting published

Uploaded Image

 