### PR TITLE
Fix Sample DotNet Linux E2E test intermittent test failures

### DIFF
--- a/samples/csharp_dotnetcore/tests/Samples.CoreBot.FunctionalTests/DirectLineClientTests.cs
+++ b/samples/csharp_dotnetcore/tests/Samples.CoreBot.FunctionalTests/DirectLineClientTests.cs
@@ -28,6 +28,15 @@ namespace Samples.CoreBot.FunctionalTests
             await StartBotConversationAsync(input);
 
             var botAnswer = await StartBotConversationAsync(input);
+
+            int retries = 4;
+            if (String.IsNullOrWhiteSpace(botAnswer) && retries-- > 0)
+            {
+                // Wait half a second before retrying.
+                await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
+                botAnswer = await StartBotConversationAsync(input);
+            }
+
             Assert.IsTrue(!String.IsNullOrWhiteSpace(botAnswer) && botAnswer.Contains("travel", StringComparison.OrdinalIgnoreCase),
                 $"Expected: A message containing 'travel'. Actual:<{botAnswer}>.");
         }
@@ -98,8 +107,8 @@ namespace Samples.CoreBot.FunctionalTests
 
                 if (answer.Equals(string.Empty))
                 {
-                    // Wait for one second before polling the bot again.
-                    await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+                    // Wait for half a second before polling the bot again.
+                    await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
                 }
             }
 

--- a/samples/csharp_dotnetcore/tests/Samples.CoreBot.FunctionalTests/DirectLineClientTests.cs
+++ b/samples/csharp_dotnetcore/tests/Samples.CoreBot.FunctionalTests/DirectLineClientTests.cs
@@ -30,7 +30,7 @@ namespace Samples.CoreBot.FunctionalTests
             var botAnswer = await StartBotConversationAsync(input);
 
             int retries = 4;
-            if (String.IsNullOrWhiteSpace(botAnswer) && retries-- > 0)
+            while (String.IsNullOrWhiteSpace(botAnswer) && retries-- > 0)
             {
                 Console.WriteLine("Retrying StartBotConversationAsync()");
                 // Wait half a second before retrying.

--- a/samples/csharp_dotnetcore/tests/Samples.CoreBot.FunctionalTests/DirectLineClientTests.cs
+++ b/samples/csharp_dotnetcore/tests/Samples.CoreBot.FunctionalTests/DirectLineClientTests.cs
@@ -32,6 +32,7 @@ namespace Samples.CoreBot.FunctionalTests
             int retries = 4;
             if (String.IsNullOrWhiteSpace(botAnswer) && retries-- > 0)
             {
+                Console.WriteLine("Retrying StartBotConversationAsync()");
                 // Wait half a second before retrying.
                 await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
                 botAnswer = await StartBotConversationAsync(input);
@@ -107,6 +108,7 @@ namespace Samples.CoreBot.FunctionalTests
 
                 if (answer.Equals(string.Empty))
                 {
+                    Console.WriteLine("  Retrying GetActivitiesAsync()");
                     // Wait for half a second before polling the bot again.
                     await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
                 }

--- a/samples/csharp_dotnetcore/tests/Samples.EchoBot.FunctionalTests/DirectLineClientTests.cs
+++ b/samples/csharp_dotnetcore/tests/Samples.EchoBot.FunctionalTests/DirectLineClientTests.cs
@@ -32,6 +32,14 @@ namespace Samples.EchoBot.FunctionalTests
 
             var botAnswer = await StartBotConversationAsync();
 
+            int retries = 4;
+            if (String.IsNullOrWhiteSpace(botAnswer) && retries-- > 0)
+            {
+                // Wait half a second before retrying.
+                await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
+                botAnswer = await StartBotConversationAsync(input);
+            }
+
             Assert.AreEqual($"Echo: {input}", botAnswer);
         }
 
@@ -99,8 +107,8 @@ namespace Samples.EchoBot.FunctionalTests
 
                 if (answer.Equals(string.Empty))
                 {
-                    // Wait for one second before polling the bot again.
-                    await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+                    // Wait for half a second before polling the bot again.
+                    await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
                 }
             }
 

--- a/samples/csharp_dotnetcore/tests/Samples.EchoBot.FunctionalTests/DirectLineClientTests.cs
+++ b/samples/csharp_dotnetcore/tests/Samples.EchoBot.FunctionalTests/DirectLineClientTests.cs
@@ -38,7 +38,7 @@ namespace Samples.EchoBot.FunctionalTests
                 Console.WriteLine("Retrying StartBotConversationAsync()");
                 // Wait half a second before retrying.
                 await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
-                botAnswer = await StartBotConversationAsync(input);
+                botAnswer = await StartBotConversationAsync();
             }
 
             Assert.AreEqual($"Echo: {input}", botAnswer);

--- a/samples/csharp_dotnetcore/tests/Samples.EchoBot.FunctionalTests/DirectLineClientTests.cs
+++ b/samples/csharp_dotnetcore/tests/Samples.EchoBot.FunctionalTests/DirectLineClientTests.cs
@@ -35,6 +35,7 @@ namespace Samples.EchoBot.FunctionalTests
             int retries = 4;
             if (String.IsNullOrWhiteSpace(botAnswer) && retries-- > 0)
             {
+                Console.WriteLine("Retrying StartBotConversationAsync()");
                 // Wait half a second before retrying.
                 await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
                 botAnswer = await StartBotConversationAsync(input);
@@ -107,6 +108,7 @@ namespace Samples.EchoBot.FunctionalTests
 
                 if (answer.Equals(string.Empty))
                 {
+                    Console.WriteLine("  Retrying GetActivitiesAsync()");
                     // Wait for half a second before polling the bot again.
                     await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
                 }

--- a/samples/csharp_dotnetcore/tests/Samples.EchoBot.FunctionalTests/DirectLineClientTests.cs
+++ b/samples/csharp_dotnetcore/tests/Samples.EchoBot.FunctionalTests/DirectLineClientTests.cs
@@ -33,7 +33,7 @@ namespace Samples.EchoBot.FunctionalTests
             var botAnswer = await StartBotConversationAsync();
 
             int retries = 4;
-            if (String.IsNullOrWhiteSpace(botAnswer) && retries-- > 0)
+            while (String.IsNullOrWhiteSpace(botAnswer) && retries-- > 0)
             {
                 Console.WriteLine("Retrying StartBotConversationAsync()");
                 // Wait half a second before retrying.


### PR DESCRIPTION
Fixes #minor

## Proposed Changes
[Sample-DotNet-CoreBot-Linux-Test-yaml](https://dev.azure.com/FuseLabs/SDK_v4/_build?definitionId=1375&_a=summary) and Sample-DotNet-EchoBot-Linux-Test-yaml fail intermittently - 1 out of 5 times. 

Add retries to SendDirectLineMessage tests.
