### PR TITLE
Fix readme file for 57.teams-conversation-bot

### DIFF
--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/README.md
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/README.md
@@ -48,13 +48,13 @@ the Teams service needs to call into the bot.
 1) __*This step is specific to Teams.*__
     - **Edit** the `manifest.json` contained in the  `teamsAppManifest` folder to replace your Microsoft App Id (that was created when you registered your bot earlier) *everywhere* you see the place holder string `<<YOUR-MICROSOFT-APP-ID>>` (depending on the scenario the Microsoft App Id may occur multiple times in the `manifest.json`)
     - **Zip** up the contents of the `teamsAppManifest` folder to create a `manifest.zip`
-    - **Upload** the `manifest.zip` to Teams (In Teams Apps/Manage your apps click "Upload a custom app". Browse to and open the ZIP file. At the next dialog, click the Add button.)
+    - **Upload** the `manifest.zip` to Teams (In Teams Apps/Manage your apps click "Upload a custom app". Browse to and Open the .zip file. At the next dialog, click the Add button.)
 
 1) Run your bot, either from Visual Studio with `F5` or using `dotnet run` in the appropriate folder.
 
 ## Interacting with the bot
 
-You can interact with this bot by sending it a message, or selecting a command from the command list. The bot will respond to the following strings.
+You can interact with this bot in Teams by sending it a message, or selecting a command from the command list. The bot will respond to the following strings.
 
 1. **Show Welcome**
   - **Result:** The bot will send the welcome card for you to interact with

--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/README.md
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/README.md
@@ -36,9 +36,12 @@ the Teams service needs to call into the bot.
     ```
 
 1) Create [Bot Framework registration resource](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-quickstart-registration) in Azure
-    - Use the current `https` URL you were given by running ngrok. Append with the path `/api/messages` used by this sample
-    - Ensure that you've [enabled the Teams Channel](https://docs.microsoft.com/en-us/azure/bot-service/channel-connect-teams?view=azure-bot-service-4.0)
-    - __*If you don't have an Azure account*__ you can use this [Bot Framework registration](https://docs.microsoft.com/en-us/microsoftteams/platform/bots/how-to/create-a-bot-for-teams#register-your-web-service-with-the-bot-framework)
+    - For bot handle, make up a name.
+    - Select "Use existing app registration" (Create the app registration in Azure Active Directory beforehand.)
+    - __*If you don't have an Azure account*__ create an [Azure free account here](https://azure.microsoft.com/en-us/free/)
+1) In the new Azure Bot resource in the Portal, 
+    - [Enable the Teams Channel](https://docs.microsoft.com/en-us/azure/bot-service/channel-connect-teams?view=azure-bot-service-4.0)
+    - In Settings/Configuration/Messaging endpoint, enter the current `https` URL you were given by running ngrok. Append with the path `/api/messages`
 
 1) Update the `appsettings.json` configuration for the bot to use the Microsoft App Id and App Password from the Bot Framework registration. (Note the App Password is referred to as the "client secret" in the azure portal and you can always create a new client secret anytime.)
 

--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/README.md
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/README.md
@@ -48,7 +48,7 @@ the Teams service needs to call into the bot.
 1) __*This step is specific to Teams.*__
     - **Edit** the `manifest.json` contained in the  `teamsAppManifest` folder to replace your Microsoft App Id (that was created when you registered your bot earlier) *everywhere* you see the place holder string `<<YOUR-MICROSOFT-APP-ID>>` (depending on the scenario the Microsoft App Id may occur multiple times in the `manifest.json`)
     - **Zip** up the contents of the `teamsAppManifest` folder to create a `manifest.zip`
-    - **Upload** the `manifest.zip` to Teams (in Teams Apps/Manage your apps click "Upload a custom app")
+    - **Upload** the `manifest.zip` to Teams (In Teams Apps/Manage your apps click "Upload a custom app". Browse to and open the ZIP file. At the next dialog, click the Add button.)
 
 1) Run your bot, either from Visual Studio with `F5` or using `dotnet run` in the appropriate folder.
 

--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/README.md
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/README.md
@@ -48,7 +48,7 @@ the Teams service needs to call into the bot.
 1) __*This step is specific to Teams.*__
     - **Edit** the `manifest.json` contained in the  `teamsAppManifest` folder to replace your Microsoft App Id (that was created when you registered your bot earlier) *everywhere* you see the place holder string `<<YOUR-MICROSOFT-APP-ID>>` (depending on the scenario the Microsoft App Id may occur multiple times in the `manifest.json`)
     - **Zip** up the contents of the `teamsAppManifest` folder to create a `manifest.zip`
-    - **Upload** the `manifest.zip` to Teams (in the Apps view click "Upload a custom app")
+    - **Upload** the `manifest.zip` to Teams (in Teams Apps/Manage your apps click "Upload a custom app")
 
 1) Run your bot, either from Visual Studio with `F5` or using `dotnet run` in the appropriate folder.
 


### PR DESCRIPTION
Fixes #minor

As currently written, the readme instructions do not work.

- Adding the instruction `Select "Use existing app registration"` is important because the default option, 'Create new App ID', does not allow access to an App Password. Access is necessary for setting up the appsettings.json file in a later step.

- `Use the current https URL` needs to say where to use it.

- The current URL for `If you don't have an Azure account' takes you down a rabbit hole.

