### PR TITLE
Update Samples 17 & 54

### DIFF
--- a/samples/csharp_dotnetcore/17.multilingual-bot/README.md
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/README.md
@@ -95,6 +95,9 @@ If you used the `appsettings.json` file to store your `TranslatorKey` then you'l
 - Click `+ Add new setting`
 - Add the key `TranslatorKey` with a value of the Translator Text API `Authentication key` created from the steps above
 
+### Add `TranslatorRegion` to Application Settings
+- The Translator resource requires you to specify which Azure region your Translator region is in. If you have placed your Translator resource in an Azure region other than `global`, you must specify this region for your bot to be able to query the Translator resource. If `TranslatorRegion` is left blank, the default region of `global` will be used.
+
 ## Further reading
 
 - [Bot Framework Documentation](https://docs.botframework.com)

--- a/samples/csharp_dotnetcore/17.multilingual-bot/Translation/MicrosoftTranslator.cs
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/Translation/MicrosoftTranslator.cs
@@ -22,12 +22,16 @@ namespace Microsoft.BotBuilderSamples.Translation
         private static HttpClient _client = new HttpClient();
 
         private readonly string _key;
+        private readonly string _region;
 
 
         public MicrosoftTranslator(IConfiguration configuration)
         {
             var key = configuration["TranslatorKey"];
             _key = key ?? throw new ArgumentNullException(nameof(key));
+
+            var region = configuration["TranslatorRegion"];
+            _region = region ?? "global";
         }
 
         public async Task<string> TranslateAsync(string text, string targetLocale, CancellationToken cancellationToken = default(CancellationToken))
@@ -44,6 +48,7 @@ namespace Microsoft.BotBuilderSamples.Translation
                 request.RequestUri = new Uri(uri);
                 request.Content = new StringContent(requestBody, Encoding.UTF8, "application/json");
                 request.Headers.Add("Ocp-Apim-Subscription-Key", _key);
+                request.Headers.Add("Ocp-Apim-Subscription-Region", _region);
 
                 var response = await _client.SendAsync(request, cancellationToken);
 

--- a/samples/csharp_dotnetcore/17.multilingual-bot/appsettings.json
+++ b/samples/csharp_dotnetcore/17.multilingual-bot/appsettings.json
@@ -3,5 +3,6 @@
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
   "MicrosoftAppTenantId": "",
-  "TranslatorKey": "<Your translation key here>"
+  "TranslatorKey": "<Your translation key here>",
+  "TranslatorRegion": ""
 }

--- a/samples/csharp_dotnetcore/54.teams-task-module/Bots/TeamsTaskModuleBot.cs
+++ b/samples/csharp_dotnetcore/54.teams-task-module/Bots/TeamsTaskModuleBot.cs
@@ -24,7 +24,7 @@ namespace Microsoft.BotBuilderSamples.Bots
 
         public TeamsTaskModuleBot(IConfiguration config)
         {
-            _baseUrl = config["BaseUrl"];
+            _baseUrl = config["BaseUrl"].EndsWith("/") ? config["BaseUrl"] : config["BaseUrl"] + "/";
         }
 
         protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)

--- a/samples/csharp_dotnetcore/54.teams-task-module/README.md
+++ b/samples/csharp_dotnetcore/54.teams-task-module/README.md
@@ -39,6 +39,7 @@ the Teams service needs to call into the bot.
     - __*If you don't have an Azure account*__ you can use this [Bot Framework registration](https://docs.microsoft.com/en-us/microsoftteams/platform/bots/how-to/create-a-bot-for-teams#register-your-web-service-with-the-bot-framework)
 
 1) Update the `appsettings.json` configuration for the bot to use the Microsoft App Id and App Password from the Bot Framework registration. (Note the App Password is referred to as the "client secret" in the azure portal and you can always create a new client secret anytime.)  The Task Modules using pages require the deployed bot's path in BaseUrl.
+    -  The `BaseUrl` should take the format `https://<your-bot-endpoint>/`. Do **not** include `api/messages` here. That should only be in your bot's Azure resource configuration.
 
 1) __*This step is specific to Teams.*__
     - **Edit** the `manifest.json` contained in the  `teamsAppManifest` folder to replace your Microsoft App Id (that was created when you registered your bot earlier) *everywhere* you see the place holder string `<<YOUR-MICROSOFT-APP-ID>>` (depending on the scenario the Microsoft App Id may occur multiple times in the `manifest.json`) Note: the Task Modules containing pages will require the deployed bot's domain in validDomains of the manifest.


### PR DESCRIPTION
## Proposed Changes
This PR makes changes to the Multilingual Bot and Teams Task Module samples.


To run the Multilingual bot sample, a Translator resource is needed. The Translator needs an Azure region to be specified, or the Translator endpoint will not return a successful response. Three changes were made to sample 17 to accommodate this.
- Add a `TranslatorRegion` field to `appsettings.json`.
- Update `MicrosoftTranslator.cs` to get this region and supply it in the request headers for the Translator service. Defaults the region to `global` if the field is left empty in appsettings.json.
- Update the README to explain the new field and specify default functionality.

The Teams Task Module sample requires the `BaseUrl` to be specified. I found the required formatting for the URL to be a bit confusing. Furthermore, if the trailing `/` is left out of the `BaseUrl`, the bot does not functional correctly. Two changes were made to sample 54 to address this.
- Update `TeamsTaskModuleBot.cs` to check if the trailing `/` is present, and append it if not.
- Update the README to clarify the required `BaseUrl` format.

## Testing
Rebuilt and ran both samples to spot check functionality.