### PR TITLE
[#3326][JS,TS] Update Teams sample 58 to use SendMessageToTeamsChannelAsync

### DIFF
--- a/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/bots/teamsStartNewThreadInChannel.js
+++ b/samples/javascript_nodejs/58.teams-start-new-thread-in-channel/bots/teamsStartNewThreadInChannel.js
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 const {
-    TurnContext,
     MessageFactory,
     TeamsActivityHandler,
-    teamsGetChannelId
+    teamsGetChannelId,
+    TeamsInfo
 } = require('botbuilder');
 
 class TeamsStartNewThreadInChannel extends TeamsActivityHandler {
@@ -14,36 +14,15 @@ class TeamsStartNewThreadInChannel extends TeamsActivityHandler {
 
         this.onMessage(async (context, next) => {
             const teamsChannelId = teamsGetChannelId(context.activity);
-            const message = MessageFactory.text('This will be the first message in a new thread');
-            const newConversation = await this.teamsCreateConversation(context, teamsChannelId, message);
+            const activity = MessageFactory.text('This will be the first message in a new thread');
+            const [reference] = await TeamsInfo.sendMessageToTeamsChannel(context, activity, teamsChannelId, process.env.MicrosoftAppId);
 
-            await context.adapter.continueConversationAsync(process.env.MicrosoftAppId, newConversation[0], async turnContext => {
+            await context.adapter.continueConversationAsync(process.env.MicrosoftAppId, reference, async turnContext => {
                 await turnContext.sendActivity(MessageFactory.text('This will be the first response to the new thread'));
             });
 
             await next();
         });
-    }
-
-    async teamsCreateConversation(context, teamsChannelId, message) {
-        const conversationParameters = {
-            isGroup: true,
-            channelData: {
-                channel: {
-                    id: teamsChannelId
-                }
-            },
-
-            activity: message
-        };
-
-        const connectorFactory = context.turnState.get(context.adapter.ConnectorFactoryKey);
-        const connectorClient = await connectorFactory.create(context.activity.serviceUrl);
-
-        const conversationResourceResponse = await connectorClient.conversations.createConversation(conversationParameters);
-        const conversationReference = TurnContext.getConversationReference(context.activity);
-        conversationReference.conversation.id = conversationResourceResponse.id;
-        return [conversationReference, conversationResourceResponse.activityId];
     }
 }
 

--- a/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/src/teamsStartNewThreadInChannel.ts
+++ b/samples/typescript_nodejs/58.teams-start-new-thread-in-channel/src/teamsStartNewThreadInChannel.ts
@@ -3,56 +3,26 @@
 
 import {
     Activity,
-    ChannelAccount,
-    CloudAdapter,
-    ConversationReference,
-    ConversationParameters,
     MessageFactory,
     TeamsActivityHandler,
     teamsGetChannelId,
-    TurnContext
+    TeamsInfo
 } from 'botbuilder';
 
 export class TeamsStartNewThreadInChannel extends TeamsActivityHandler {
     constructor() {
         super();
-        this.onMessage( async ( context: TurnContext, next ): Promise<void> => {
-            const teamsChannelId = teamsGetChannelId( context.activity );
-            const channelAccount = context.activity.from as ChannelAccount;
-            const message = MessageFactory.text( 'This will be the first message in a new thread' );
-            const newConversation = await this.teamsCreateConversation( context, channelAccount, teamsChannelId, message );
 
-            await context.adapter.continueConversationAsync(
-                process.env.MicrosoftAppId,
-                newConversation[ 0 ],
-                async ( t ) => {
-                    await t.sendActivity( MessageFactory.text( 'This will be the first response to the new thread' ) );
-                });
+        this.onMessage(async (context, next): Promise<void> => {
+            const teamsChannelId = teamsGetChannelId(context.activity);
+            const activity = MessageFactory.text('This will be the first message in a new thread') as Activity;
+            const [reference] = await TeamsInfo.sendMessageToTeamsChannel(context, activity, teamsChannelId, process.env.MicrosoftAppId);
+
+            await context.adapter.continueConversationAsync(process.env.MicrosoftAppId, reference, async (turnContext) => {
+                await turnContext.sendActivity(MessageFactory.text('This will be the first response to the new thread'));
+            });
 
             await next();
         });
-    }
-
-    public async teamsCreateConversation( context: TurnContext, channelAccount: ChannelAccount, teamsChannelId: string, message: Partial<Activity> ): Promise<any> {
-        const conversationParameters = {
-            bot: channelAccount,
-            channelData: {
-                channel: {
-                    id: teamsChannelId
-                }
-            },
-            isGroup: true,
-
-            activity: message
-        } as ConversationParameters;
-
-        const botAdapter = context.adapter as CloudAdapter;
-        const connectorFactory = context.turnState.get(botAdapter.ConnectorFactoryKey);
-        const connectorClient = await connectorFactory.create(context.activity.serviceUrl);
-
-        const conversationResourceResponse = await connectorClient.conversations.createConversation( conversationParameters );
-        const conversationReference = TurnContext.getConversationReference( context.activity ) as ConversationReference;
-        conversationReference.conversation.id = conversationResourceResponse.id;
-        return [ conversationReference, conversationResourceResponse.activityId ];
     }
 }


### PR DESCRIPTION
Fixes #3326

> **Note:** We created the issue [botbuilder-js#4144](https://github.com/microsoft/botbuilder-js/issues/4144) to fix the problem when the `sendMessageToTeamsChannel` is executed, it doesn't return the new conversation reference.

## Description
This PR updates the JavaScript and TypeScript Teams 58 samples to use the `TeamsInfo.sendMessageToTeamsChannel` method when the `onMessage` is executed.

### Detailed Changes
- Replaces the manual creation of a conversation using the `TeamsInfo.SendMessageToTeamsChannelAsync` method instead.

## Testing
The following images show the bot working, but responding the message to a different conversation.
![image](https://user-images.githubusercontent.com/62260472/156784560-362d500d-3307-4ef5-9d03-382be19bb08a.png)