### PR TITLE
[#2980] Port SSO for skills dotnet sample to JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Samples are designed to illustrate functionality you'll need to implement to bui
 |:--:|:----------------------|:---------------------------------------------------------------------------------|:--------|:-------------|:--------|:--------
 |80|Skills&nbsp;-&nbsp;simple&nbsp;bot&nbsp;to&nbsp;bot | This sample shows how to connect a skill to a skill consumer.       | [.NET&nbsp;Core][cs#80] | [JavaScript][js#80]     |[Python][py#80] |[Java][java#80]
 |81|Skills - skill dialog       | This sample shows how to connect a skill to a skill dialog consumer.| [.NET&nbsp;Core][cs#81] | [JavaScript][js#81]     |[Python][py#81] |[Java][java#81]
-|82|Skills - SSO with CloudAdapter       | This sample shows how use SSO with skills and CloudAdapter.| [.NET&nbsp;Core][cs#82] | NA     |NA |NA
+|82|Skills - SSO with CloudAdapter       | This sample shows how use SSO with skills and CloudAdapter.| [.NET&nbsp;Core][cs#82] | [JavaScript][js#82]     |NA |NA
 ### Experimental / preview samples
 
 A [collection of **experimental** samples](./experimental) exist, intended to provide samples for features currently in preview or as a way to solicit feedback on a given design, approach, or technology being considered by the Bot Framework Team.
@@ -220,6 +220,7 @@ A [collection of **experimental** samples](./experimental) exist, intended to pr
 [js#58]:samples/javascript_nodejs/58.teams-start-new-thread-in-channel
 [js#80]:samples/javascript_nodejs/80.skills-simple-bot-to-bot
 [js#81]:samples/javascript_nodejs/81.skills-skilldialog
+[js#82]:samples/javascript_nodejs/82.skills-sso-cloudadapter
 
 [py#1]:samples/python/01.console-echo
 [py#2]:samples/python/02.echo-bot

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/README.md
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/README.md
@@ -1,0 +1,88 @@
+# SSO with Skills Sample
+
+Bot Framework v4 skills SSO sample.
+
+This bot has been created using [Bot Framework](https://dev.botframework.com), it shows how to connect a root bot with a skill bot and exchange OAuth credentials.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org) version 10.14 or higher.
+
+    ```bash
+    # Determine node version.
+    node --version
+    ```
+
+## Key concepts in this sample
+
+The solution includes a parent bot ([`rootBot`](rootBot/bots/rootBot.js)) and a skill bot ([`skillBot`](skillBot/bots/skillBot.js)) and shows how the skill bot can accept OAuth credentials from the root bot, without needing to send it's own OAuthPrompt.
+
+This is the general authentication flow:
+
+1. Root bot prompts user to authenticate with an OAuth prompt card.
+2. Authentication succeeds and the user is granted a token.
+3. User performs an action on the skill bot that requires authentication.
+4. The skill bot sends an OAuth prompt card to the root bot.
+5. The root bot intercepts the OAuth prompt card, aware that the user is already authenticated and that the user should authenticate with the skill via SSO.
+6. Instead of showing the OAuth prompt card to the user, the root bot sends a token exchange request invoke activity along with the token to the skill.
+7. The skill's OAuth prompt receives the token exchange request and uses the token from the root bot to continue authenticating.
+
+## To try this sample
+
+- Clone the repository
+
+    ```bash
+    git clone https://github.com/microsoft/botbuilder-samples.git
+    ```
+
+- Create a bot registration in the azure portal for the **SkillBot** and update the [.env](skillBot/.env) file with the `MicrosoftAppId` and `MicrosoftAppPassword` of the new bot registration.
+- Update the `SkillAppId` field in the **RootBot** [.env](rootBot/.env) with the app ID for the skill you created in the previous step.
+- Create a bot registration in the azure portal for the **RootBot** and update [.env](rootBot/.env) with the `MicrosoftAppId` and `MicrosoftAppPassword` of the new bot registration.
+- Add the RootBot `MicrosoftAppId` to the `AllowedCallers` list in the **SkillBot** [.env](skillBot/.env).
+- Create and configure an OAuth connection for **RootBot**:
+  1. Create an Azure Active Directory V2 application for the root bot following the steps described in [Create the Azure AD identity for RootBot](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-authentication-sso?view=azure-bot-service-4.0&tabs=csharp%2Ceml#create-the-azure-ad-identity-for-rootbot)
+  1. Open the **RootBot** registration in the Azure portal, navigate to the Configuration tab and add a new OAuth Connection Settings using the settings of the app you created in the previous step as described in [Create an OAuth connection for a root bot](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-authentication-sso?view=azure-bot-service-4.0&tabs=csharp%2Ceml#create-an-oauth-connection-settings)
+  1. Update the **RootBot** [.env](rootBot/.env) `ConnectionName` property with the name of the connection you created in the previous step.
+- Create and configure an OAuth connection for **SkillBot**:
+  1. Create an Azure Active Directory V2 application for the skill following the steps described in [Create the Azure AD identity for SkillBot](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-authentication-sso?view=azure-bot-service-4.0&tabs=csharp%2Ceml#create-the-azure-ad-identity-for-skillbot)
+  2. Open the **SkillBot** registration in the Azure portal, navigate to the Configuration tab and add a new OAuth Connection Settings using the settings of the app you created in the previous step as described in [Create an OAuth connection for a skill](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-authentication-sso?view=azure-bot-service-4.0&tabs=csharp%2Ceml#create-an-oauth-connection-settings-1)
+  3. Update the **SkillBot** [.env](skillBot/.env) `ConnectionName` property with the name of the connection you created in the previous step.
+- For each bot directory, `skillBot` and `rootBot` as `<botDirectory>`:
+
+- In a terminal, navigate to `samples/javascript_nodejs/82.skills-sso-cloudadapter/<botDirectory>`
+
+    ```bash
+    cd samples/javascript_nodejs/82.skills-sso-cloudadapter/<botDirectory>
+    ```
+
+- Install modules
+
+    ```bash
+    npm install
+    ```
+
+- Start the bot
+
+    ```bash
+    npm start
+    ```
+
+**Note:** leave the `MicrosoftAppType` and `MicrosoftAppTenantId` empty to try this example, see the [Implement a skill](https://docs.microsoft.com/en-us/azure/bot-service/skill-implement-skill?view=azure-bot-service-4.0&tabs=cs) article for additional information on what authentication types are supported for skills.
+
+## Testing the bot using the Bot Framework Emulator
+
+The [Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
+
+- Install the Bot Framework Emulator version 4.14.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
+
+### Connect to the bot using Bot Framework Emulator
+
+- Launch Bot Framework Emulator
+- File -> Open Bot.
+- Enter a Bot URL of `http://localhost:3978/api/messages`, the `MicrosoftAppId` and `MicrosoftAppPassword` for the `RootBot`.
+- Click `Connect`.
+- Follow the prompts to initiate the token exchange between the `SkillBot` and `RootBot`, resulting in a valid token displayed.
+
+## Deploy the bots to Azure
+
+To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](https://aka.ms/azuredeployment) for a complete list of deployment instructions.

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/.env
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/.env
@@ -1,0 +1,10 @@
+MicrosoftAppType=
+MicrosoftAppId=
+MicrosoftAppPassword=
+MicrosoftAppTenantId=
+SkillHostEndpoint=http://localhost:3978/api/skills/
+ConnectionName=
+
+SkillId=SkillBot
+SkillAppId=
+SkillEndpoint=http://localhost:39783/api/messages

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/.eslintrc.js
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/.eslintrc.js
@@ -1,0 +1,20 @@
+/* eslint-disable */
+module.exports = {
+    "extends": "standard",
+    "rules": {
+        "semi": [2, "always"],
+        "indent": [2, 4, { "SwitchCase": 1 }],
+        "no-return-await": 0,
+        "space-before-function-paren": [2, {
+            "named": "never",
+            "anonymous": "never",
+            "asyncArrow": "always"
+        }],
+        "template-curly-spacing": [2, "always"]
+    },
+    "env": {
+        "commonjs": true,
+        "node": true,
+        "mocha": true
+    }
+};

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/.gitignore
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.vscode/

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/bots/rootBot.js
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/bots/rootBot.js
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { ActivityHandler, ActivityTypes, MessageFactory } = require('botbuilder');
+const { runDialog } = require('botbuilder-dialogs');
+
+class RootBot extends ActivityHandler {
+    /**
+     *
+     * @param {ConversationState} conversationState
+     * @param {Dialog} dialog
+     */
+    constructor(conversationState, dialog) {
+        super();
+        if (!conversationState) throw new Error('[RootBot]: Missing parameter. conversationState is required');
+        if (!dialog) throw new Error('[RootBot]: Missing parameter. dialog is required');
+
+        this.conversationState = conversationState;
+        this.dialog = dialog;
+
+        this.onTurn(async (turnContext, next) => {
+            if (turnContext.activity.type !== ActivityTypes.ConversationUpdate) {
+                // Run the Dialog with the activity.
+                await runDialog(this.dialog, turnContext, this.conversationState.createProperty('DialogState'));
+            }
+
+            await next();
+        });
+
+        this.onMembersAdded(async (context, next) => {
+            const membersAdded = context.activity.membersAdded;
+            for (let cnt = 0; cnt < membersAdded.length; cnt++) {
+                // Greet anyone that was not the target (recipient) of this message.
+                if (membersAdded[cnt].id !== context.activity.recipient.id) {
+                    await context.sendActivity(MessageFactory.text('Hello and welcome!'));
+                    await runDialog(this.dialog, context, conversationState.createProperty('DialogState'));
+                }
+            }
+
+            // By calling next() you ensure that the next BotHandler is run.
+            await next();
+        });
+    }
+
+    /**
+     * Override the ActivityHandler.run() method to save state changes after the bot logic completes.
+     */
+    async run(context) {
+        await super.run(context);
+
+        // Save any state changes. The load happened during the execution of the Dialog.
+        await this.conversationState.saveChanges(context, false);
+    }
+}
+
+module.exports.RootBot = RootBot;

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/new-rg-parameters.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,54 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "appServicePlanLocation": {
+            "value": ""
+        },
+        "existingAppServicePlan": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,258 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location of the Resource Group."
+            }
+        },
+        "groupName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Resource Group."
+            }
+        },
+        "appId": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
+            }
+        },
+        "appSecret": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
+            }
+        },
+        "botId": {
+            "type": "string",
+            "metadata": {
+                "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+            }
+        },
+        "botSku": {
+            "type": "string",
+            "metadata": {
+                "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+            }
+        },
+        "newAppServicePlanName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the App Service Plan."
+            }
+        },
+        "newAppServicePlanSku": {
+            "type": "object",
+            "defaultValue": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            },
+            "metadata": {
+                "description": "The SKU of the App Service Plan. Defaults to Standard values."
+            }
+        },
+        "newAppServicePlanLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The location of the App Service Plan. Defaults to \"westus\"."
+            }
+        },
+        "newWebAppName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+            }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
+        }
+    },
+    "variables": {
+        "appServicePlanName": "[parameters('newAppServicePlanName')]",
+        "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+        "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+        "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
+    },
+    "resources": [
+        {
+            "name": "[parameters('groupName')]",
+            "type": "Microsoft.Resources/resourceGroups",
+            "apiVersion": "2018-05-01",
+            "location": "[parameters('groupLocation')]",
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "name": "storageDeployment",
+            "resourceGroup": "[parameters('groupName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {},
+                    "variables": {},
+                    "resources": [
+                        {
+                            "comments": "Create a new App Service Plan",
+                            "type": "Microsoft.Web/serverfarms",
+                            "name": "[variables('appServicePlanName')]",
+                            "apiVersion": "2018-02-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "sku": "[parameters('newAppServicePlanSku')]",
+                            "properties": {
+                                "name": "[variables('appServicePlanName')]"
+                            }
+                        },
+                        {
+                            "comments": "Create a Web App using the new App Service Plan",
+                            "type": "Microsoft.Web/sites",
+                            "apiVersion": "2015-08-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "kind": "app",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                            ],
+                            "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
+                            "properties": {
+                                "name": "[variables('webAppName')]",
+                                "serverFarmId": "[variables('appServicePlanName')]",
+                                "siteConfig": {
+                                    "appSettings": [
+                                        {
+                                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                            "value": "10.14.1"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppId",
+                                            "value": "[parameters('appId')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppPassword",
+                                            "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
+                                        }
+                                    ],
+                                    "cors": {
+                                        "allowedOrigins": [
+                                            "https://botservice.hosting.portal.azure.net",
+                                            "https://hosting.onecloud.azure-test.net/"
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "apiVersion": "2021-03-01",
+                            "type": "Microsoft.BotService/botServices",
+                            "name": "[parameters('botId')]",
+                            "location": "global",
+                            "kind": "azurebot",
+                            "sku": {
+                                "name": "[parameters('botSku')]"
+                            },
+                            "properties": {
+                                "name": "[parameters('botId')]",
+                                "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                                "endpoint": "[variables('botEndpoint')]",
+                                "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
+                            },
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                            ]
+                        }
+                    ],
+                    "outputs": {}
+                }
+            }
+        }
+    ]
+}

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,0 +1,229 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
+            }
+        },
+        "appSecret": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
+            }
+        },
+        "botId": {
+            "type": "string",
+            "metadata": {
+                "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+            }
+        },
+        "botSku": {
+            "defaultValue": "F0",
+            "type": "string",
+            "metadata": {
+                "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+            }
+        },
+        "newAppServicePlanName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The name of the new App Service Plan."
+            }
+        },
+        "newAppServicePlanSku": {
+            "type": "object",
+            "defaultValue": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            },
+            "metadata": {
+                "description": "The SKU of the App Service Plan. Defaults to Standard values."
+            }
+        },
+        "appServicePlanLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The location of the App Service Plan."
+            }
+        },
+        "existingAppServicePlan": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Name of the existing App Service Plan used to create the Web App for the bot."
+            }
+        },
+        "newWebAppName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+            }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
+        }
+    },
+    "variables": {
+        "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
+        "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+        "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
+        "resourcesLocation": "[parameters('appServicePlanLocation')]",
+        "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+        "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
+    },
+    "resources": [
+        {
+            "comments": "Create a new App Service Plan if no existing App Service Plan name was passed in.",
+            "type": "Microsoft.Web/serverfarms",
+            "condition": "[not(variables('useExistingAppServicePlan'))]",
+            "name": "[variables('servicePlanName')]",
+            "apiVersion": "2018-02-01",
+            "location": "[variables('resourcesLocation')]",
+            "sku": "[parameters('newAppServicePlanSku')]",
+            "properties": {
+                "name": "[variables('servicePlanName')]"
+            }
+        },
+        {
+            "comments": "Create a Web App using an App Service Plan",
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2015-08-01",
+            "location": "[variables('resourcesLocation')]",
+            "kind": "app",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+            ],
+            "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
+            "properties": {
+                "name": "[variables('webAppName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
+                "siteConfig": {
+                    "appSettings": [
+                        {
+                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                            "value": "10.14.1"
+                        },
+                        {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
+                            "name": "MicrosoftAppId",
+                            "value": "[parameters('appId')]"
+                        },
+                        {
+                            "name": "MicrosoftAppPassword",
+                            "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
+                        }
+                    ],
+                    "cors": {
+                        "allowedOrigins": [
+                            "https://botservice.hosting.portal.azure.net",
+                            "https://hosting.onecloud.azure-test.net/"
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2021-03-01",
+            "type": "Microsoft.BotService/botServices",
+            "name": "[parameters('botId')]",
+            "location": "global",
+            "kind": "azurebot",
+            "sku": {
+                "name": "[parameters('botSku')]"
+            },
+            "properties": {
+                "name": "[parameters('botId')]",
+                "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                "endpoint": "[variables('botEndpoint')]",
+                "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+            ]
+        }
+    ]
+}

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/dialogs/mainDialog.js
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/dialogs/mainDialog.js
@@ -1,0 +1,165 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { ActivityTypes, InputHints, MessageFactory } = require('botbuilder');
+const { ChoicePrompt, ComponentDialog, SkillDialog, WaterfallDialog } = require('botbuilder-dialogs');
+const { SsoSignInDialog } = require('./ssoSignInDialog');
+
+const MAIN_DIALOG = 'MainDialog';
+const SSO_SIGNIN_DIALOG = 'SsoSignInDialog';
+const SKILL_DIALOG = 'SkillDialog';
+const WATERFALL_DIALOG = 'WaterfallDialog';
+
+/**
+ * The main dialog for this bot. It uses a SkillDialog to call skills.
+ */
+class MainDialog extends ComponentDialog {
+    constructor(auth, conversationState, conversationIdFactory, skillsConfig) {
+        super(MAIN_DIALOG);
+
+        if (!auth) throw new Error('[MainDialog]: Missing parameter \'auth\' is required');
+        this.auth = auth.createBotFrameworkClient();
+
+        const botId = process.env.MicrosoftAppId;
+        if (!botId) throw new Error('[MainDialog]: MicrosoftAppId is not set in configuration');
+
+        this.connectionName = process.env.ConnectionName;
+        if (!this.connectionName) throw new Error('[MainDialog]: ConnectionName is not set in configuration');
+
+        // We use a single skill in this example.
+        const targetSkillId = 'SkillBot';
+        this.ssoSkill = skillsConfig.skills[targetSkillId];
+        if (!this.ssoSkill) throw new Error(`[MainDialog]: Skill with ID ${ targetSkillId } not found in configuration`);
+
+        this.activeSkillPropertyName = `${ MAIN_DIALOG }.activeSkillProperty`;
+
+        this.addDialog(new ChoicePrompt('ActionStepPrompt'))
+            .addDialog(new SsoSignInDialog(this.connectionName))
+            .addDialog(new SkillDialog(this.createSkillDialogOptions(skillsConfig, botId, conversationIdFactory, conversationState), SKILL_DIALOG));
+
+        this.addDialog(new WaterfallDialog(WATERFALL_DIALOG, [
+            this.promptActionStep.bind(this),
+            this.handleActionStep.bind(this),
+            this.promptFinalStep.bind(this)
+        ]));
+
+        // Create state property to track the active skill.
+        this.activeSkillProperty = conversationState.createProperty(this.activeSkillPropertyName);
+
+        // The initial child Dialog to run.
+        this.initialDialogId = WATERFALL_DIALOG;
+    }
+
+    /**
+     * // Helper to create a SkillDialogOptions instance for the SSO skill.
+     */
+    createSkillDialogOptions(skillsConfig, botId, conversationIdFactory, conversationState) {
+        return {
+            botId: botId,
+            conversationIdFactory: conversationIdFactory,
+            skillClient: this.auth,
+            skillHostEndpoint: skillsConfig.skillHostEndpoint,
+            conversationState: conversationState,
+            skill: this.ssoSkill
+        };
+    }
+
+    /**
+     * Render a prompt to select the action to perform with the skill.
+     */
+    async promptActionStep(stepContext) {
+        const messageText = 'What SSO action do you want to perform?';
+        const repromptMessageText = 'That was not a valid choice, please select a valid choice.';
+        const options = {
+            prompt: MessageFactory.text(messageText, messageText, InputHints.ExpectingInput),
+            retryPrompt: MessageFactory.text(repromptMessageText, repromptMessageText, InputHints.ExpectingInput),
+            choices: await this.getPromptOptions(stepContext)
+        };
+
+        return await stepContext.prompt('ActionStepPrompt', options);
+    }
+
+    /**
+     * Creates the prompt choices based on the current sign in status.
+     */
+    async getPromptOptions(stepContext) {
+        const promptChoices = [];
+        const userTokenClient = stepContext.context.turnState.get(stepContext.context.adapter.UserTokenClientKey);
+        const tokenResponse = await userTokenClient.getUserToken(
+            stepContext.context.activity.from.id,
+            this.connectionName,
+            stepContext.context.activity.channelId,
+            null
+        );
+
+        // Show different options if the user is signed in on the parent or not.
+        if (!tokenResponse || !tokenResponse.token) {
+            // User is not signed in.
+            promptChoices.push({ value: 'Login to the root bot' });
+            // Token exchange will fail when the root is not logged on and the skill should
+            // show a regular OAuthPrompt.
+            promptChoices.push({ value: 'Call Skill (without SSO)' });
+        } else {
+            // User is signed in to the parent
+            promptChoices.push({ value: 'Logout from the root bot' });
+            promptChoices.push({ value: 'Show token' });
+            promptChoices.push({ value: 'Call Skill (with SSO)' });
+        }
+        return promptChoices;
+    }
+
+    async handleActionStep(stepContext) {
+        const action = stepContext.result.value.toLowerCase();
+        const userTokenClient = stepContext.context.turnState.get(stepContext.context.adapter.UserTokenClientKey);
+
+        switch (action) {
+            case 'login to the root bot': {
+                return await stepContext.beginDialog(SSO_SIGNIN_DIALOG, null);
+            }
+            case 'logout from the root bot': {
+                const { activity } = stepContext.context;
+                await userTokenClient.signOutUser(activity.from.id, this.connectionName, activity.channelId);
+                await stepContext.context.sendActivity('You have been signed out.');
+                return await stepContext.next();
+            }
+            case 'show token': {
+                const tokenResponse = await userTokenClient.getUserToken(
+                    stepContext.context.activity.from.id,
+                    this.connectionName,
+                    stepContext.context.activity.channelId,
+                    null
+                );
+
+                if (!tokenResponse || !tokenResponse.token) {
+                    await stepContext.context.sendActivity('User has no cached token.');
+                } else {
+                    await stepContext.context.sendActivity(`Here is your current SSO token: ${ tokenResponse.token }`);
+                }
+                return await stepContext.next();
+            }
+            case 'call skill (with sso)':
+            case 'call skill (without sso)': {
+                const beginSkillActivity = {
+                    type: ActivityTypes.Event,
+                    name: 'SSO'
+                };
+                // Save active skill in state (this is use in case of errors).
+                await this.activeSkillProperty.set(stepContext.context, this.ssoSkill);
+                return await stepContext.beginDialog(SKILL_DIALOG, { activity: beginSkillActivity });
+            }
+            default: {
+                // This should never be hit since the previous prompt validates the choice.
+                throw new Error(`[MainDialog]: Unrecognized action: ${ action }`);
+            }
+        }
+    }
+
+    async promptFinalStep(stepContext) {
+        // Clear active skill in state.
+        await this.activeSkillProperty.delete(stepContext.context);
+
+        // Restart the dialog (we will exit when the user says end).
+        return await stepContext.replaceDialog(this.initialDialogId, null);
+    }
+}
+module.exports.MainDialog = MainDialog;

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/dialogs/ssoSignInDialog.js
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/dialogs/ssoSignInDialog.js
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { ComponentDialog, WaterfallDialog, OAuthPrompt } = require('botbuilder-dialogs');
+
+const SSO_SIGNIN_DIALOG = 'SsoSignInDialog';
+const OAUTH_PROMPT = 'OAuthPrompt';
+const WATERFALL_DIALOG = 'WaterfallDialog';
+
+/**
+ * Helps prepare the host for SSO operations and provides helpers to check the status and invoke the skill.
+ */
+class SsoSignInDialog extends ComponentDialog {
+    constructor(connectionName) {
+        super(SSO_SIGNIN_DIALOG);
+
+        this.addDialog(new OAuthPrompt(OAUTH_PROMPT, {
+            connectionName: connectionName,
+            text: 'Sign in to the root bot using Azure AD for SSO',
+            title: 'Sign In'
+        }));
+
+        this.addDialog(new WaterfallDialog(WATERFALL_DIALOG, [
+            this.signInStep.bind(this),
+            this.displayTokenStep.bind(this)
+        ]));
+
+        this.initialDialogId = WATERFALL_DIALOG;
+    }
+
+    /**
+     * @param {import('botbuilder-dialogs').WaterfallStepContext} stepContext
+     */
+    async signInStep(stepContext) {
+        return stepContext.beginDialog(OAUTH_PROMPT);
+    }
+
+    /**
+     * @param {import('botbuilder-dialogs').WaterfallStepContext} stepContext
+     */
+    async displayTokenStep(stepContext) {
+        if (!stepContext.result.token) {
+            await stepContext.context.sendActivity('No token was provided.');
+        } else {
+            await stepContext.context.sendActivity(`Here is your token: ${ stepContext.result.token }`);
+        }
+        return stepContext.endDialog();
+    }
+}
+
+module.exports.SsoSignInDialog = SsoSignInDialog;

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/index.js
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/index.js
@@ -1,0 +1,208 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// index.js is used to setup and configure your bot.
+
+// Import required packages.
+const path = require('path');
+const restify = require('restify');
+
+// Import required bot services.
+// See https://aka.ms/bot-services to learn more about the different parts of a bot.
+const {
+    ActivityTypes,
+    ChannelServiceRoutes,
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    ConversationState,
+    createBotFrameworkAuthenticationFromConfiguration,
+    InputHints,
+    MemoryStorage,
+    SkillConversationIdFactory,
+    TurnContext
+} = require('botbuilder');
+const {
+    allowedCallersClaimsValidator,
+    AuthenticationConfiguration,
+    AuthenticationConstants
+} = require('botframework-connector');
+
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
+// This bot's main dialog.
+const { RootBot } = require('./bots/rootBot');
+const { MainDialog } = require('./dialogs/mainDialog');
+const { TokenExchangeSkillHandler } = require('./TokenExchangeSkillHandler');
+
+// Import Skills modules.
+const { SkillsConfiguration } = require('./skillsConfiguration');
+
+// Load skills configuration.
+const skillsConfig = new SkillsConfiguration();
+
+const allowedSkills = Object.values(skillsConfig.skills).map(skill => skill.appId);
+
+const claimsValidators = allowedCallersClaimsValidator(allowedSkills);
+
+// If the MicrosoftAppTenantId is specified in the environment config, add the tenant as a valid JWT token issuer for Bot to Skill conversation.
+// The token issuer for MSI and single tenant scenarios will be the tenant where the bot is registered.
+let validTokenIssuers = [];
+const { MicrosoftAppTenantId } = process.env;
+
+if (MicrosoftAppTenantId) {
+    // For SingleTenant/MSI auth, the JWT tokens will be issued from the bot's home tenant.
+    // Therefore, these issuers need to be added to the list of valid token issuers for authenticating activity requests.
+    validTokenIssuers = [
+        `${ AuthenticationConstants.ValidTokenIssuerUrlTemplateV1 }${ MicrosoftAppTenantId }/`,
+        `${ AuthenticationConstants.ValidTokenIssuerUrlTemplateV2 }${ MicrosoftAppTenantId }/v2.0/`,
+        `${ AuthenticationConstants.ValidGovernmentTokenIssuerUrlTemplateV1 }${ MicrosoftAppTenantId }/`,
+        `${ AuthenticationConstants.ValidGovernmentTokenIssuerUrlTemplateV2 }${ MicrosoftAppTenantId }/v2.0/`
+    ];
+}
+
+// Define our authentication configuration.
+const authConfig = new AuthenticationConfiguration([], claimsValidators, validTokenIssuers);
+
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
+});
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory, authConfig);
+
+// Create adapter, passing in authConfig so that we can use skills.
+// See https://aka.ms/about-bot-adapter to learn more about adapters.
+const adapter = new CloudAdapter(botFrameworkAuthentication);
+
+// Use the logger middleware to log messages. The default logger argument for LoggerMiddleware is Node's console.log().
+const { LoggerMiddleware } = require('./middleware/loggerMiddleware');
+adapter.use(new LoggerMiddleware());
+
+// Catch-all for errors.
+const onTurnErrorHandler = async (context, error) => {
+    // This check writes out errors to the console log, instead of to app insights.
+    // NOTE: In production environment, you should consider logging this to Azure
+    //       application insights. See https://aka.ms/bottelemetry for telemetry
+    //       configuration instructions.
+    console.error(`\n [onTurnError] unhandled error: ${ error }`);
+
+    await sendErrorMessage(context, error);
+    await endSkillConversation(context);
+    await clearConversationState(context);
+};
+
+async function sendErrorMessage(context, error) {
+    try {
+        // Send a message to the user.
+        let onTurnErrorMessage = 'The bot encountered an error or bug.';
+        await context.sendActivity(onTurnErrorMessage, onTurnErrorMessage, InputHints.IgnoringInput);
+
+        onTurnErrorMessage = 'To continue to run this bot, please fix the bot source code.';
+        await context.sendActivity(onTurnErrorMessage, onTurnErrorMessage, InputHints.ExpectingInput);
+
+        // Send a trace activity, which will be displayed in Bot Framework Emulator.
+        await context.sendTraceActivity(
+            'OnTurnError Trace',
+            `${ error }`,
+            'https://www.botframework.com/schemas/error',
+            'TurnError'
+        );
+    } catch (err) {
+        console.error(`\n [onTurnError] Exception caught in sendErrorMessage: ${ err }`);
+    }
+}
+
+async function endSkillConversation(context) {
+    try {
+        // Inform the active skill that the conversation is ended so that it has a chance to clean up.
+        // Note: the root bot manages the ActiveSkillPropertyName, which has a value while the root bot
+        // has an active conversation with a skill.
+        const activeSkill = await conversationState.createProperty(mainDialog.ActiveSkillPropertyName).get(context);
+        if (activeSkill) {
+            const botId = process.env.MicrosoftAppId;
+
+            let endOfConversation = {
+                type: ActivityTypes.EndOfConversation,
+                code: 'RootSkillError'
+            };
+            endOfConversation = TurnContext.applyConversationReference(
+                endOfConversation, TurnContext.getConversationReference(context.activity), true);
+
+            await conversationState.saveChanges(context, true);
+            skillClient.createBotFrameworkClient();
+            await skillClient.postActivity(botId, activeSkill.appId, activeSkill.skillEndpoint, skillsConfig.skillHostEndpoint, endOfConversation.conversation.id, endOfConversation);
+        }
+    } catch (err) {
+        console.error(`\n [onTurnError] Exception caught on attempting to send EndOfConversation : ${ err }`);
+    }
+}
+
+async function clearConversationState(context) {
+    try {
+        // Delete the conversationState for the current conversation to prevent the
+        // bot from getting stuck in a error-loop caused by being in a bad state.
+        // ConversationState should be thought of as similar to "cookie-state" for a Web page.
+        await conversationState.delete(context);
+    } catch (err) {
+        console.error(`\n [onTurnError] Exception caught on attempting to Delete ConversationState : ${ err }`);
+    }
+}
+
+// Set the onTurnError for the singleton CloudAdapter.
+adapter.onTurnError = onTurnErrorHandler;
+
+// Define a state store for your bot. See https://aka.ms/about-bot-state to learn more about using MemoryStorage.
+// A bot requires a state store to persist the dialog and user state between messages.
+
+// For local development, in-memory storage is used.
+// CAUTION: The Memory Storage used here is for local bot debugging only. When the bot
+// is restarted, anything stored in memory will be gone.
+const memoryStorage = new MemoryStorage();
+const conversationState = new ConversationState(memoryStorage);
+
+// Create the conversationIdFactory.
+const conversationIdFactory = new SkillConversationIdFactory(new MemoryStorage());
+
+// Create the skill client.
+const skillClient = botFrameworkAuthentication;
+
+// Create the main dialog.
+const mainDialog = new MainDialog(skillClient, conversationState, conversationIdFactory, skillsConfig);
+const bot = new RootBot(conversationState, mainDialog);
+
+// Create HTTP server.
+// maxParamLength defaults to 100, which is too short for the conversationId created in skillConversationIdFactory.
+// See: https://github.com/microsoft/BotBuilder-Samples/issues/2194.
+const server = restify.createServer({ maxParamLength: 1000 });
+server.use(restify.plugins.bodyParser());
+
+server.listen(process.env.port || process.env.PORT || 3978, function() {
+    console.log(`\n${ server.name } listening to ${ server.url }`);
+    console.log('\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator');
+    console.log('\nTo talk to your bot, open the emulator select "Open Bot"');
+});
+
+// Listen for incoming activities and route them to your bot main dialog.
+server.post('/api/messages', async (req, res) => {
+    // Route received a request to adapter for processing
+    await adapter.process(req, res, (context) => bot.run(context));
+});
+
+// Create and initialize the skill classes.
+const handler = new TokenExchangeSkillHandler(adapter, (context) => bot.run(context), conversationIdFactory, skillClient, skillsConfig);
+const skillEndpoint = new ChannelServiceRoutes(handler);
+skillEndpoint.register(server, '/api/skills');
+
+// Listen for Upgrade requests for Streaming.
+server.on('upgrade', async (req, socket, head) => {
+    // Create an adapter scoped to this WebSocket connection to allow storing session data.
+    const streamingAdapter = new CloudAdapter(botFrameworkAuthentication);
+
+    // Set onTurnError for the CloudAdapter created for each connection.
+    streamingAdapter.onTurnError = onTurnErrorHandler;
+
+    await streamingAdapter.process(req, socket, head, (context) => bot.run(context));
+});

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/middleware/loggerMiddleware.js
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/middleware/loggerMiddleware.js
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { ActivityTypes } = require('botbuilder');
+
+/**
+ * Logs user and bot messages. It filters out ContinueConversation events coming from skill responses.
+ */
+class LoggerMiddleware {
+    // This defaults to using Node's console.log() method if a logger isn't passed in.
+    constructor(logger = console) {
+        this.logger = logger;
+    }
+
+    async onTurn(turnContext, next) {
+        // Note: Skill responses will show as ContinueConversation events; we don't log those.
+        // We only log incoming messages from users.
+        if (turnContext.activity.type === ActivityTypes.Event && turnContext.activity.name !== 'continueConversation') {
+            const message = `User said: "${ turnContext.activity.text }" Type: "${ turnContext.activity.type }" Name: "${ turnContext.activity.name }"`;
+            this.logger.log(message);
+        }
+
+        // Register outgoing handler.
+        turnContext.onSendActivities(this.outgoingHandler.bind(this));
+
+        // Continue processing messages.
+        await next();
+    }
+
+    async outgoingHandler(turnContext, activities, next) {
+        activities.forEach((activity) => {
+            const message = `Bot said: "${ activity.text }" Type: "${ activity.type }" Name: "${ activity.name }"`;
+            this.logger.log(message);
+        });
+
+        await next();
+    }
+}
+
+module.exports.LoggerMiddleware = LoggerMiddleware;

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/package.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/package.json
@@ -1,0 +1,35 @@
+{
+    "name": "skill-to-skill-root-bot",
+    "version": "1.0.0",
+    "description": "A bot that demonstrates the connection between bots and the exchange of OAuth credentials (Root Bot)",
+    "author": "Microsoft",
+    "license": "MIT",
+    "main": "index.js",
+    "scripts": {
+        "start": "node ./index.js",
+        "watch": "nodemon ./index.js",
+        "lint": "eslint .",
+        "test": "nyc mocha tests/**/*.test.js"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
+    },
+    "dependencies": {
+        "botbuilder": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
+        "dotenv": "~8.2.0",
+        "restify": "~8.6.0"
+    },
+    "devDependencies": {
+        "eslint": "^7.0.0",
+        "eslint-config-standard": "^14.1.1",
+        "eslint-plugin-import": "^2.20.2",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-promise": "^4.2.1",
+        "eslint-plugin-standard": "^4.0.1",
+        "mocha": "^7.1.2",
+        "nodemon": "~2.0.4",
+        "nyc": "^15.0.1"
+    }
+}

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/skillsConfiguration.js
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/skillsConfiguration.js
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+/**
+ * A helper class that loads Skills information from configuration.
+ */
+class SkillsConfiguration {
+    constructor() {
+        this.skillsData = {};
+
+        // Note: we only have one skill in this sample but we could load more if needed.
+        const botFrameworkSkill = {
+            id: process.env.SkillId,
+            appId: process.env.SkillAppId,
+            skillEndpoint: process.env.SkillEndpoint
+        };
+
+        this.skillsData[botFrameworkSkill.id] = botFrameworkSkill;
+
+        this.skillHostEndpointValue = process.env.SkillHostEndpoint;
+        if (!this.skillHostEndpointValue) {
+            throw new Error('[SkillsConfiguration]: Missing configuration parameter. SkillHostEndpoint is required');
+        }
+    }
+
+    get skills() {
+        return this.skillsData;
+    }
+
+    get skillHostEndpoint() {
+        return this.skillHostEndpointValue;
+    }
+}
+
+module.exports.SkillsConfiguration = SkillsConfiguration;

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/tokenExchangeSkillHandler.js
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/tokenExchangeSkillHandler.js
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { ActivityEx, ActivityTypes, CardFactory, CloudSkillHandler, tokenExchangeOperationName, TurnContext } = require('botbuilder');
+const { JwtTokenValidation } = require('botframework-connector');
+const { v4 } = require('uuid');
+
+/**
+ * A specialized import('botbuilder').SkillHandler} that can handle token exchanges for SSO.
+ */
+class TokenExchangeSkillHandler extends CloudSkillHandler {
+    constructor(adapter, logic, conversationIdFactory, auth, skillsConfiguration, logger = null) {
+        super(adapter, logic, conversationIdFactory, auth);
+        if (!adapter) throw new Error('[TokenExchangeSkillHandler]: Missing parameter \'adapter\' is required');
+        if (!auth) throw new Error('[TokenExchangeSkillHandler]: Missing parameter \'auth\' is required');
+        if (!conversationIdFactory) throw new Error('[TokenExchangeSkillHandler]: Missing parameter \'conversationIdFactory\' is required');
+        if (!skillsConfiguration) throw new Error('[TokenExchangeSkillHandler]: Missing parameter \'skillsConfiguration\' is required');
+
+        this.adapter = adapter;
+        this.auth = auth;
+        this.conversationIdFactory = conversationIdFactory;
+        this.skillsConfig = skillsConfiguration;
+
+        this.botId = process.env.MicrosoftAppId;
+        this.connectionName = process.env.ConnectionName;
+        this.logger = logger;
+    }
+
+    async onSendToConversation(claimsIdentity, conversationId, activity) {
+        if (await this.interceptOAuthCards(claimsIdentity, activity)) {
+            return { id: v4() };
+        }
+        return await super.onSendToConversation(claimsIdentity, conversationId, activity);
+    }
+
+    async onReplyToActivity(claimsIdentity, conversationId, activityId, activity) {
+        if (await this.interceptOAuthCards(claimsIdentity, activity)) {
+            return { id: v4() };
+        }
+        return await super.onReplyToActivity(claimsIdentity, conversationId, activityId, activity);
+    }
+
+    getCallingSkill(claimsIdentity) {
+        const appId = JwtTokenValidation.getAppIdFromClaims(claimsIdentity.claims);
+        if (!appId) {
+            return null;
+        }
+        return Object.values(this.skillsConfig.skills).find(skill => skill.appId === appId);
+    }
+
+    async interceptOAuthCards(claimsIdentity, activity) {
+        const oauthCardAttachment = activity.attachments ? activity.attachments.find(attachment => attachment.contentType === CardFactory.contentTypes.oauthCard) : null;
+        if (oauthCardAttachment) {
+            const targetSkill = this.getCallingSkill(claimsIdentity);
+
+            if (targetSkill) {
+                const oauthCard = oauthCardAttachment.content;
+
+                if (oauthCard && oauthCard.tokenExchangeResource && oauthCard.tokenExchangeResource.uri) {
+                    const tokenClient = await this.auth.createUserTokenClient(claimsIdentity);
+                    const context = new TurnContext(this.adapter, activity);
+                    context.turnState.push('BotIdentity', claimsIdentity);
+
+                    // Azure AD token exchange
+                    try {
+                        const result = await tokenClient.exchangeToken(activity.recipient.id, this.connectionName, activity.channelId, { uri: oauthCard.tokenExchangeResource.uri });
+                        if (result && result.token) {
+                            // If token above is null, then SSO has failed and hence we return false.
+                            // If not, send an invoke to the skill with the token.
+                            return await this.sendTokenExchangeInvokeToSkill(activity, oauthCard.tokenExchangeResource.id, result.token, oauthCard.connectionName, targetSkill);
+                        }
+                    } catch (exception) {
+                        // Show oauth card if token exchange fails.
+                        // A common cause for hitting this section of the code is when then user hasn't provided consent to the skill app.
+                        this.logger.log('Unable to get SSO token for OAuthCard, exception was ', exception);
+                        return false;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    async sendTokenExchangeInvokeToSkill(incomingActivity, id, token, connectionName, targetSkill) {
+        const activity = ActivityEx.createReply(incomingActivity);
+        activity.type = ActivityTypes.Invoke;
+        activity.name = tokenExchangeOperationName;
+        activity.value = {
+            id: id,
+            token: token,
+            connectionName: connectionName
+        };
+
+        const skillConversationReference = await this.conversationIdFactory.getSkillConversationReference(incomingActivity.conversation.id);
+        activity.conversation = incomingActivity.conversation;
+        activity.serviceUrl = skillConversationReference.conversationReference.serviceUrl;
+
+        // Route the activity to the skill
+        const botFrameworkClient = this.auth.createBotFrameworkClient();
+        const response = await botFrameworkClient.postActivity(this.botId, targetSkill.appId, targetSkill.skillEndpoint, this.skillsConfig.skillHostEndpoint, activity.conversation.id, activity);
+
+        // Check response status: true if success, false if failure
+        return response.status >= 200 && response.status <= 299;
+    }
+}
+
+module.exports.TokenExchangeSkillHandler = TokenExchangeSkillHandler;

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/.env
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/.env
@@ -1,0 +1,8 @@
+MicrosoftAppType=
+MicrosoftAppId=
+MicrosoftAppPassword=
+MicrosoftAppTenantId=
+ConnectionName=
+
+AllowedCallers=*
+

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/.eslintrc.js
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/.eslintrc.js
@@ -1,0 +1,20 @@
+/* eslint-disable */
+module.exports = {
+    "extends": "standard",
+    "rules": {
+        "semi": [2, "always"],
+        "indent": [2, 4, { "SwitchCase": 1 }],
+        "no-return-await": 0,
+        "space-before-function-paren": [2, {
+            "named": "never",
+            "anonymous": "never",
+            "asyncArrow": "always"
+        }],
+        "template-curly-spacing": [2, "always"]
+    },
+    "env": {
+        "commonjs": true,
+        "node": true,
+        "mocha": true
+    }
+};

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/.gitignore
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.vscode/

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/bots/skillBot.js
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/bots/skillBot.js
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { ActivityHandler } = require('botbuilder');
+const { runDialog } = require('botbuilder-dialogs');
+
+class SkillBot extends ActivityHandler {
+    /**
+     *
+     * @param {ConversationState} conversationState
+     * @param {Dialog} dialog
+     */
+    constructor(conversationState, dialog) {
+        super();
+        if (!conversationState) throw new Error('[SkillBot]: Missing parameter. conversationState is required');
+        if (!dialog) throw new Error('[SkillBot]: Missing parameter. dialog is required');
+
+        this.conversationState = conversationState;
+        this.dialog = dialog;
+
+        this.onTurn(async (context, next) => {
+            await runDialog(this.dialog, context, this.conversationState.createProperty('DialogState'));
+
+            await next();
+        });
+    }
+
+    /**
+     * Override the ActivityHandler.run() method to save state changes after the bot logic completes.
+     */
+    async run(context) {
+        await super.run(context);
+
+        // Save any state changes. The load happened during the execution of the Dialog.
+        await this.conversationState.saveChanges(context, false);
+    }
+}
+
+module.exports.SkillBot = SkillBot;

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/new-rg-parameters.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/new-rg-parameters.json
@@ -1,0 +1,54 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "value": ""
+        },
+        "groupName": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "newAppServicePlanLocation": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/preexisting-rg-parameters.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/preexisting-rg-parameters.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        },
+        "appType": {
+            "value": "MultiTenant"
+        },
+        "botId": {
+            "value": ""
+        },
+        "botSku": {
+            "value": ""
+        },
+        "newAppServicePlanName": {
+            "value": ""
+        },
+        "newAppServicePlanSku": {
+            "value": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            }
+        },
+        "appServicePlanLocation": {
+            "value": ""
+        },
+        "existingAppServicePlan": {
+            "value": ""
+        },
+        "newWebAppName": {
+            "value": ""
+        },
+        "tenantId": {
+            "value": ""
+        },
+        "existingUserAssignedMSIName": {
+            "value": ""
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "value": ""
+        }
+    }
+}

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/template-with-new-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/template-with-new-rg.json
@@ -1,0 +1,258 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location of the Resource Group."
+            }
+        },
+        "groupName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Resource Group."
+            }
+        },
+        "appId": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
+            }
+        },
+        "appSecret": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
+            }
+        },
+        "botId": {
+            "type": "string",
+            "metadata": {
+                "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+            }
+        },
+        "botSku": {
+            "type": "string",
+            "metadata": {
+                "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+            }
+        },
+        "newAppServicePlanName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the App Service Plan."
+            }
+        },
+        "newAppServicePlanSku": {
+            "type": "object",
+            "defaultValue": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            },
+            "metadata": {
+                "description": "The SKU of the App Service Plan. Defaults to Standard values."
+            }
+        },
+        "newAppServicePlanLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The location of the App Service Plan. Defaults to \"westus\"."
+            }
+        },
+        "newWebAppName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+            }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
+        }
+    },
+    "variables": {
+        "appServicePlanName": "[parameters('newAppServicePlanName')]",
+        "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+        "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+        "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
+    },
+    "resources": [
+        {
+            "name": "[parameters('groupName')]",
+            "type": "Microsoft.Resources/resourceGroups",
+            "apiVersion": "2018-05-01",
+            "location": "[parameters('groupLocation')]",
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "name": "storageDeployment",
+            "resourceGroup": "[parameters('groupName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {},
+                    "variables": {},
+                    "resources": [
+                        {
+                            "comments": "Create a new App Service Plan",
+                            "type": "Microsoft.Web/serverfarms",
+                            "name": "[variables('appServicePlanName')]",
+                            "apiVersion": "2018-02-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "sku": "[parameters('newAppServicePlanSku')]",
+                            "properties": {
+                                "name": "[variables('appServicePlanName')]"
+                            }
+                        },
+                        {
+                            "comments": "Create a Web App using the new App Service Plan",
+                            "type": "Microsoft.Web/sites",
+                            "apiVersion": "2015-08-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "kind": "app",
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                            ],
+                            "name": "[variables('webAppName')]",
+                            "identity": "[variables('appType').identity]",
+                            "properties": {
+                                "name": "[variables('webAppName')]",
+                                "serverFarmId": "[variables('appServicePlanName')]",
+                                "siteConfig": {
+                                    "appSettings": [
+                                        {
+                                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                            "value": "10.14.1"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppType",
+                                            "value": "[parameters('appType')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppId",
+                                            "value": "[parameters('appId')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppPassword",
+                                            "value": "[parameters('appSecret')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppTenantId",
+                                            "value": "[variables('appType').tenantId]"
+                                        }
+                                    ],
+                                    "cors": {
+                                        "allowedOrigins": [
+                                            "https://botservice.hosting.portal.azure.net",
+                                            "https://hosting.onecloud.azure-test.net/"
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "apiVersion": "2021-03-01",
+                            "type": "Microsoft.BotService/botServices",
+                            "name": "[parameters('botId')]",
+                            "location": "global",
+                            "kind": "azurebot",
+                            "sku": {
+                                "name": "[parameters('botSku')]"
+                            },
+                            "properties": {
+                                "name": "[parameters('botId')]",
+                                "displayName": "[parameters('botId')]",
+                                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                                "endpoint": "[variables('botEndpoint')]",
+                                "msaAppId": "[parameters('appId')]",
+                                "msaAppTenantId": "[variables('appType').tenantId]",
+                                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                                "msaAppType": "[parameters('appType')]",
+                                "luisAppIds": [],
+                                "schemaTransformationVersion": "1.3",
+                                "isCmekEnabled": false,
+                                "isIsolated": false
+                            },
+                            "dependsOn": [
+                                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+                            ]
+                        }
+                    ],
+                    "outputs": {}
+                }
+            }
+        }
+    ]
+}

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/template-with-preexisting-rg.json
@@ -1,0 +1,229 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appId": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings."
+            }
+        },
+        "appSecret": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"."
+            }
+        },
+        "appType": {
+            "type": "string",
+            "defaultValue": "MultiTenant",
+            "allowedValues": [
+              "MultiTenant",
+              "SingleTenant",
+              "UserAssignedMSI"
+            ],
+            "metadata": {
+                "description": "Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\"."
+            }
+        },
+        "botId": {
+            "type": "string",
+            "metadata": {
+                "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+            }
+        },
+        "botSku": {
+            "defaultValue": "F0",
+            "type": "string",
+            "metadata": {
+                "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+            }
+        },
+        "newAppServicePlanName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The name of the new App Service Plan."
+            }
+        },
+        "newAppServicePlanSku": {
+            "type": "object",
+            "defaultValue": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            },
+            "metadata": {
+                "description": "The SKU of the App Service Plan. Defaults to Standard values."
+            }
+        },
+        "appServicePlanLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The location of the App Service Plan."
+            }
+        },
+        "existingAppServicePlan": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Name of the existing App Service Plan used to create the Web App for the bot."
+            }
+        },
+        "newWebAppName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+            }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]",
+            "metadata": {
+                "description": "The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"."
+            }
+        },
+        "existingUserAssignedMSIName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"."
+            }
+        },
+        "existingUserAssignedMSIResourceGroupName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"."
+            }
+        }
+    },
+    "variables": {
+        "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
+        "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+        "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
+        "resourcesLocation": "[parameters('appServicePlanLocation')]",
+        "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+        "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
+        "appTypeDef": {
+          "MultiTenant": {
+            "tenantId": "",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "SingleTenant": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "",
+            "identity": { "type": "None" }
+          },
+          "UserAssignedMSI": {
+            "tenantId": "[parameters('tenantId')]",
+            "msiResourceId": "[variables('msiResourceId')]",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[variables('msiResourceId')]": {}
+                }
+            }
+          }
+        },
+        "appType": {
+          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+        }
+    },
+    "resources": [
+        {
+            "comments": "Create a new App Service Plan if no existing App Service Plan name was passed in.",
+            "type": "Microsoft.Web/serverfarms",
+            "condition": "[not(variables('useExistingAppServicePlan'))]",
+            "name": "[variables('servicePlanName')]",
+            "apiVersion": "2018-02-01",
+            "location": "[variables('resourcesLocation')]",
+            "sku": "[parameters('newAppServicePlanSku')]",
+            "properties": {
+                "name": "[variables('servicePlanName')]"
+            }
+        },
+        {
+            "comments": "Create a Web App using an App Service Plan",
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2015-08-01",
+            "location": "[variables('resourcesLocation')]",
+            "kind": "app",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+            ],
+            "name": "[variables('webAppName')]",
+            "identity": "[variables('appType').identity]",
+            "properties": {
+                "name": "[variables('webAppName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
+                "siteConfig": {
+                    "appSettings": [
+                        {
+                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                            "value": "10.14.1"
+                        },
+                        {
+                            "name": "MicrosoftAppType",
+                            "value": "[parameters('appType')]"
+                        },
+                        {
+                            "name": "MicrosoftAppId",
+                            "value": "[parameters('appId')]"
+                        },
+                        {
+                            "name": "MicrosoftAppPassword",
+                            "value": "[parameters('appSecret')]"
+                        },
+                        {
+                            "name": "MicrosoftAppTenantId",
+                            "value": "[variables('appType').tenantId]"
+                        }
+                    ],
+                    "cors": {
+                        "allowedOrigins": [
+                            "https://botservice.hosting.portal.azure.net",
+                            "https://hosting.onecloud.azure-test.net/"
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2021-03-01",
+            "type": "Microsoft.BotService/botServices",
+            "name": "[parameters('botId')]",
+            "location": "global",
+            "kind": "azurebot",
+            "sku": {
+                "name": "[parameters('botSku')]"
+            },
+            "properties": {
+                "name": "[parameters('botId')]",
+                "displayName": "[parameters('botId')]",
+                "iconUrl": "https://docs.botframework.com/static/devportal/client/images/bot-framework-default.png",
+                "endpoint": "[variables('botEndpoint')]",
+                "msaAppId": "[parameters('appId')]",
+                "msaAppTenantId": "[variables('appType').tenantId]",
+                "msaAppMSIResourceId": "[variables('appType').msiResourceId]",
+                "msaAppType": "[parameters('appType')]",
+                "luisAppIds": [],
+                "schemaTransformationVersion": "1.3",
+                "isCmekEnabled": false,
+                "isIsolated": false
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+            ]
+        }
+    ]
+}

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/dialogs/activityRouterDialog.js
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/dialogs/activityRouterDialog.js
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { ActivityTypes, InputHints, MessageFactory } = require('botbuilder');
+const { ComponentDialog, DialogTurnStatus, WaterfallDialog } = require('botbuilder-dialogs');
+const { SsoSkillDialog } = require('./ssoSkillDialog');
+
+const ACTIVITY_ROUTER_DIALOG = 'ActivityRouterDialog';
+const WATERFALL_DIALOG = 'WaterfallDialog';
+const SSO_SKILL_DIALOG = 'SsoSkillDialog';
+
+/**
+ * A root dialog that can route activities sent to the skill to different sub-dialogs.
+ */
+class ActivityRouterDialog extends ComponentDialog {
+    constructor() {
+        super(ACTIVITY_ROUTER_DIALOG);
+
+        this.addDialog(new SsoSkillDialog(process.env.ConnectionName))
+            .addDialog(new WaterfallDialog(WATERFALL_DIALOG, [
+                this.processActivity.bind(this)
+            ]));
+
+        // The initial child Dialog to run.
+        this.initialDialogId = WATERFALL_DIALOG;
+    }
+
+    async processActivity(stepContext) {
+        // A skill can send trace activities, if needed.
+        const traceActivity = {
+            type: ActivityTypes.Trace,
+            timestamp: new Date(),
+            text: 'ActivityRouterDialog.processActivity()',
+            label: `Got activityType: ${ stepContext.context.activity.type }`
+        };
+        await stepContext.context.sendActivity(traceActivity);
+
+        // In this simple skill, we only handle SSO events
+        if (stepContext.context.activity.type === ActivityTypes.Event && stepContext.context.activity.name === 'SSO') {
+            return await stepContext.beginDialog(SSO_SKILL_DIALOG);
+        }
+
+        // We didn't get an activity type we can handle.
+        await stepContext.context.sendActivity(MessageFactory.text(`Unrecognized ActivityType: ${ stepContext.context.activity.type }.`, undefined, InputHints.IgnoringInput));
+        return { status: DialogTurnStatus.complete };
+    }
+}
+
+module.exports.ActivityRouterDialog = ActivityRouterDialog;

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/dialogs/ssoSkillDialog.js
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/dialogs/ssoSkillDialog.js
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { MessageFactory, InputHints } = require('botbuilder');
+const { ComponentDialog, ChoicePrompt, ChoiceFactory, DialogTurnStatus, WaterfallDialog } = require('botbuilder-dialogs');
+const { SsoSkillSignInDialog } = require('./ssoSkillSignInDialog');
+
+const ACTION_PROMPT = 'ActionStepPrompt';
+const WATERFALL_DIALOG = 'WaterfallDialog';
+const SSO_SKILL_DIALOG = 'SsoSkillDialog';
+const SSO_SIGNIN_DIALOG = 'SsoSkillSignInDialog';
+
+class SsoSkillDialog extends ComponentDialog {
+    /**
+     * @param {string} connectionName
+     */
+    constructor(connectionName) {
+        super(SSO_SKILL_DIALOG);
+
+        if (!connectionName) throw new Error('[SsoSkillDialog]: \'connectionName\' is not set in configuration.');
+        this.connectionName = connectionName;
+
+        this.addDialog(new SsoSkillSignInDialog(connectionName))
+            .addDialog(new ChoicePrompt(ACTION_PROMPT))
+            .addDialog(new WaterfallDialog(WATERFALL_DIALOG, [
+                this.promptActionStep.bind(this),
+                this.handleActionStep.bind(this),
+                this.promptFinalStep.bind(this)
+            ]));
+
+        this.initialDialogId = WATERFALL_DIALOG;
+    }
+
+    /**
+     * @param {import('botbuilder-dialogs').WaterfallStepContext} stepContext
+     */
+    async promptActionStep(stepContext) {
+        const messageText = 'What SSO action would you like to perform on the skill?';
+        const repromptMessageText = 'That was not a valid choice, please select a valid choice.';
+
+        return stepContext.prompt(ACTION_PROMPT, {
+            prompt: MessageFactory.text(messageText, messageText, InputHints.ExpectingInput),
+            retryPrompt: MessageFactory.text(repromptMessageText, repromptMessageText, InputHints.ExpectingInput),
+            choices: await this.getPromptChoices(stepContext)
+        });
+    }
+
+    /**
+     * @param {import('botbuilder-dialogs').WaterfallStepContext} stepContext
+     */
+    async getPromptChoices(stepContext) {
+        // Try to get the token for the current user to determine if it is logged in or not.
+        const choices = new Set();
+        const userTokenClient = stepContext.context.turnState.get(stepContext.context.adapter.UserTokenClientKey);
+        const tokenResponse = await userTokenClient.getUserToken(
+            stepContext.context.activity.from.id,
+            this.connectionName,
+            stepContext.context.activity.channelId,
+            null
+        );
+
+        // Present different choices depending on the user's sign in status.
+        if (!tokenResponse || !tokenResponse.token) {
+            choices.add('Login to the skill');
+        } else {
+            choices.add('Logout from the skill');
+            choices.add('Show token');
+        }
+
+        choices.add('End');
+
+        return ChoiceFactory.toChoices([...choices]);
+    }
+
+    /**
+     * @param {import('botbuilder-dialogs').WaterfallStepContext} stepContext
+     */
+    async handleActionStep(stepContext) {
+        const action = stepContext.result.value.toLowerCase();
+        const userTokenClient = stepContext.context.turnState.get(stepContext.context.adapter.UserTokenClientKey);
+
+        switch (action) {
+            case 'login to the skill': {
+                // The SsoSkillSignInDialog will just show the user token if the user logged on to the root bot.
+                return stepContext.beginDialog(SSO_SIGNIN_DIALOG);
+            }
+            case 'logout from the skill': {
+                // This will just clear the token from the skill.
+                const { activity } = stepContext.context;
+                await userTokenClient.signOutUser(activity.from.id, this.connectionName, activity.channelId);
+                await stepContext.context.sendActivity('You have been signed out.');
+                return stepContext.next();
+            }
+            case 'show token': {
+                const tokenResponse = await userTokenClient.getUserToken(
+                    stepContext.context.activity.from.id,
+                    this.connectionName,
+                    stepContext.context.activity.channelId,
+                    null
+                );
+
+                if (!tokenResponse || !tokenResponse.token) {
+                    await stepContext.context.sendActivity('User has no cached token.');
+                } else {
+                    await stepContext.context.sendActivity(`Here is your current SSO token: ${ tokenResponse.token }`);
+                }
+
+                return stepContext.next();
+            }
+            case 'end': {
+                // Ends the interaction with the skill.
+                return { status: DialogTurnStatus.complete };
+            }
+            default: {
+                // This should never be hit since the previous prompt validates the choice.
+                throw new Error(`Unrecognized action: ${ action }`);
+            }
+        }
+    }
+
+    /**
+     * @param {import('botbuilder-dialogs').WaterfallStepContext} stepContext
+     */
+    async promptFinalStep(stepContext) {
+        // Restart the dialog (we will exit when the user says end).
+        return stepContext.replaceDialog(this.initialDialogId);
+    }
+}
+
+module.exports.SsoSkillDialog = SsoSkillDialog;

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/dialogs/ssoSkillSignInDialog.js
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/dialogs/ssoSkillSignInDialog.js
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { ComponentDialog, OAuthPrompt, WaterfallDialog } = require('botbuilder-dialogs');
+
+const OAUTH_PROMPT = 'OAuthPrompt';
+const WATERFALL_DIALOG = 'WaterfallDialog';
+const SSO_SIGNIN_DIALOG = 'SsoSkillSignInDialog';
+
+class SsoSkillSignInDialog extends ComponentDialog {
+    /**
+     * @param {string} connectionName
+     */
+    constructor(connectionName) {
+        super(SSO_SIGNIN_DIALOG);
+
+        this.addDialog(new OAuthPrompt(OAUTH_PROMPT, {
+            connectionName: connectionName,
+            text: 'Sign in to the Skill using Azure AD',
+            title: 'Sign In'
+        }));
+
+        this.addDialog(new WaterfallDialog(WATERFALL_DIALOG, [
+            this.signInStep.bind(this),
+            this.displayToken.bind(this)
+        ]));
+
+        this.initialDialogId = WATERFALL_DIALOG;
+    }
+
+    /**
+     * @param {import('botbuilder-dialogs').WaterfallStepContext} stepContext
+     */
+    async signInStep(stepContext) {
+    // This prompt won't show if the user is signed in to the root using SSO.
+        return stepContext.beginDialog(OAUTH_PROMPT);
+    }
+
+    /**
+     * @param {import('botbuilder-dialogs').WaterfallStepContext} stepContext
+     */
+    async displayToken(stepContext) {
+        const { result } = stepContext;
+        if (!result || !result.token) {
+            await stepContext.context.sendActivity('No token was provided for the skill.');
+        } else {
+            await stepContext.context.sendActivity(`Here is your token for the skill: ${ result.token }`);
+        }
+
+        return stepContext.endDialog();
+    }
+}
+
+module.exports.SsoSkillSignInDialog = SsoSkillSignInDialog;

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/index.js
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/index.js
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// index.js is used to setup and configure your bot.
+
+// Import required packages.
+const path = require('path');
+
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
+
+const restify = require('restify');
+
+// Import required bot services.
+// See https://aka.ms/bot-services to learn more about the different parts of a bot.
+const {
+    ActivityTypes,
+    CloudAdapter,
+    ConfigurationServiceClientCredentialFactory,
+    ConversationState,
+    createBotFrameworkAuthenticationFromConfiguration,
+    InputHints,
+    MemoryStorage
+} = require('botbuilder');
+const {
+    allowedCallersClaimsValidator,
+    AuthenticationConfiguration,
+    AuthenticationConstants
+} = require('botframework-connector');
+
+// This bot's main dialog.
+const { SkillBot } = require('./bots/skillBot');
+const { ActivityRouterDialog } = require('./dialogs/activityRouterDialog');
+const { SsoSaveStateMiddleware } = require('./middleware/ssoSaveStateMiddleware');
+
+const allowedCallers = (process.env.AllowedCallers || '').split(',').filter((val) => val) || [];
+
+const claimsValidators = allowedCallersClaimsValidator(allowedCallers);
+
+// If the MicrosoftAppTenantId is specified in the environment config, add the tenant as a valid JWT token issuer for Bot to Skill conversation.
+// The token issuer for MSI and single tenant scenarios will be the tenant where the bot is registered.
+let validTokenIssuers = [];
+const { MicrosoftAppTenantId } = process.env;
+
+if (MicrosoftAppTenantId) {
+    // For SingleTenant/MSI auth, the JWT tokens will be issued from the bot's home tenant.
+    // Therefore, these issuers need to be added to the list of valid token issuers for authenticating activity requests.
+    validTokenIssuers = [
+        `${ AuthenticationConstants.ValidTokenIssuerUrlTemplateV1 }${ MicrosoftAppTenantId }/`,
+        `${ AuthenticationConstants.ValidTokenIssuerUrlTemplateV2 }${ MicrosoftAppTenantId }/v2.0/`,
+        `${ AuthenticationConstants.ValidGovernmentTokenIssuerUrlTemplateV1 }${ MicrosoftAppTenantId }/`,
+        `${ AuthenticationConstants.ValidGovernmentTokenIssuerUrlTemplateV2 }${ MicrosoftAppTenantId }/v2.0/`
+    ];
+}
+
+// Define our authentication configuration.
+const authConfig = new AuthenticationConfiguration([], claimsValidators, validTokenIssuers);
+
+const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
+    MicrosoftAppId: process.env.MicrosoftAppId,
+    MicrosoftAppPassword: process.env.MicrosoftAppPassword,
+    MicrosoftAppType: process.env.MicrosoftAppType,
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId
+});
+
+const botFrameworkAuthentication = createBotFrameworkAuthenticationFromConfiguration(null, credentialsFactory, authConfig);
+
+// Create adapter, passing in authConfig so that we can use skills.
+// See https://aka.ms/about-bot-adapter to learn more about adapters.
+const adapter = new CloudAdapter(botFrameworkAuthentication);
+
+// Catch-all for errors.
+const onTurnErrorHandler = async (context, error) => {
+    // This check writes out errors to the console log, instead of to app insights.
+    // NOTE: In a production environment, you should consider logging this to Azure
+    //       application insights.  See https://aka.ms/bottelemetry for telemetry
+    //       configuration instructions.
+    console.error(`\n [onTurnError] unhandled error: ${ error }`);
+
+    await sendErrorMessage(context, error);
+    await sendEoCToParent(context, error);
+    await clearConversationState(context);
+};
+
+async function sendErrorMessage(context, error) {
+    try {
+        // Send a message to the user.
+        let onTurnErrorMessage = 'The skill encountered an error or bug.';
+        await context.sendActivity(onTurnErrorMessage, onTurnErrorMessage, InputHints.ExpectingInput);
+
+        onTurnErrorMessage = 'To continue to run this bot, please fix the bot source code.';
+        await context.sendActivity(onTurnErrorMessage, onTurnErrorMessage, InputHints.ExpectingInput);
+
+        // Send a trace activity, which will be displayed in the Bot Framework Emulator.
+        // Note: we return the entire exception in the value property to help the developer;
+        // this should not be done in production.
+        await context.sendTraceActivity('OnTurnError Trace', error.toString(), 'https://www.botframework.com/schemas/error', 'TurnError');
+    } catch (err) {
+        console.error(`\n [onTurnError] Exception caught in sendErrorMessage: ${ err }`);
+    }
+}
+
+async function sendEoCToParent(context, error) {
+    try {
+        // Send an EndOfConversation activity to the skill caller with the error to end the conversation,
+        // and let the caller decide what to do.
+        const endOfConversation = {
+            type: ActivityTypes.EndOfConversation,
+            code: 'SkillError',
+            text: error.toString()
+        };
+        await context.sendActivity(endOfConversation);
+    } catch (err) {
+        console.error(`\n [onTurnError] Exception caught in sendEoCToParent: ${ err }`);
+    }
+}
+
+async function clearConversationState(context) {
+    try {
+        // Delete the conversationState for the current conversation to prevent the
+        // bot from getting stuck in a error-loop caused by being in a bad state.
+        // ConversationState should be thought of as similar to "cookie-state" for a Web page.
+        await conversationState.delete(context);
+    } catch (err) {
+        console.error(`\n [onTurnError] Exception caught on attempting to Delete ConversationState : ${ err }`);
+    }
+}
+
+// Set the onTurnError for the singleton CloudAdapter.
+adapter.onTurnError = onTurnErrorHandler;
+
+// Define a state store for your bot. See https://aka.ms/about-bot-state to learn more about using MemoryStorage.
+// A bot requires a state store to persist the dialog and user state between messages.
+
+// For local development, in-memory storage is used.
+// CAUTION: The Memory Storage used here is for local bot debugging only. When the bot
+// is restarted, anything stored in memory will be gone.
+const memoryStorage = new MemoryStorage();
+const conversationState = new ConversationState(memoryStorage);
+
+adapter.use(new SsoSaveStateMiddleware(conversationState));
+
+// Create the activity router dialog.
+const activityRouterDialog = new ActivityRouterDialog();
+const bot = new SkillBot(conversationState, activityRouterDialog);
+
+// Create HTTP server.
+const server = restify.createServer();
+server.use(restify.plugins.bodyParser());
+
+server.listen(process.env.port || process.env.PORT || 39783, function() {
+    console.log(`\n${ server.name } listening to ${ server.url }`);
+    console.log('\nGet Bot Framework Emulator: https://aka.ms/botframework-emulator');
+    console.log('\nTo talk to your bot, open the emulator select "Open Bot"');
+});
+
+// Expose the manifest.
+server.get('/manifest/*', restify.plugins.serveStatic({ directory: './manifest', appendRequestPath: false }));
+
+// Listen for incoming activities and route them to your bot main dialog.
+server.post('/api/messages', async (req, res) => {
+    // Route received a request to adapter for processing
+    await adapter.process(req, res, (context) => bot.run(context));
+});
+
+// Listen for Upgrade requests for Streaming.
+server.on('upgrade', async (req, socket, head) => {
+    // Create an adapter scoped to this WebSocket connection to allow storing session data.
+    const streamingAdapter = new CloudAdapter(botFrameworkAuthentication);
+
+    // Set onTurnError for the CloudAdapter created for each connection.
+    streamingAdapter.onTurnError = onTurnErrorHandler;
+
+    await streamingAdapter.process(req, socket, head, (context) => bot.run(context));
+});

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/manifest/dialogchildbot-manifest-1.0.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/manifest/dialogchildbot-manifest-1.0.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+  "$id": "skillBot",
+  "name": "Skill bot to demonstrate SSO",
+  "version": "1.0",
+  "description": "This is a sample skill that uses SSO if the caller bot supports it.",
+  "publisherName": "Microsoft",
+  "privacyUrl": "https://ssoskillbot.contoso.com/privacy.html",
+  "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+  "license": "",
+  "iconUrl": "https://ssoskillbot.contoso.com/icon.png",
+  "tags": [
+    "sample",
+    "sso"
+  ],
+  "endpoints": [
+    {
+      "name": "default",
+      "protocol": "BotFrameworkV3",
+      "description": "Default endpoint for the skill.",
+      "endpointUrl": "https://ssoskillbot.contoso.com/api/messages",
+      "msAppId": "00000000-0000-0000-0000-000000000000"
+    }
+  ],
+  "activities": {
+    "StartSSODialog": {
+      "description": "Starts an SSO dialog.",
+      "type": "event",
+      "name": "SSO"
+    }
+  }
+}

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/middleware/ssoSaveStateMiddleware.js
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/middleware/ssoSaveStateMiddleware.js
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { CardFactory } = require('botbuilder');
+
+class SsoSaveStateMiddleware {
+    /**
+     * @param {import('botbuilder').ConversationState} conversationState
+     */
+    constructor(conversationState) {
+        this.conversationState = conversationState;
+    }
+
+    /**
+     * @param {import('botbuilder').TurnContext} turnContext
+     */
+    async onTurn(turnContext, next) {
+        // Register outgoing handler.
+        turnContext.onSendActivities(this.outgoingHandler.bind(this));
+
+        // Continue processing messages.
+        await next();
+    }
+
+    /**
+     * @param {import('botbuilder').TurnContext} turnContext
+     * @param {Partial<import('botbuilder').Activity>[]} activities
+     * @param {Function} next
+     */
+    async outgoingHandler(turnContext, activities, next) {
+        for (const activity of activities) {
+            if (!!activity.attachments && activity.attachments.some(attachment => attachment.contentType === CardFactory.contentTypes.oauthCard)) {
+                this.conversationState.saveChanges(turnContext);
+            }
+        }
+
+        return next();
+    }
+}
+
+module.exports.SsoSaveStateMiddleware = SsoSaveStateMiddleware;

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/package.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/package.json
@@ -1,0 +1,37 @@
+{
+    "name": "skill-to-skill-skill-bot",
+    "version": "1.0.0",
+    "description": "A bot that demonstrates the connection between bots and the exchange of OAuth credentials (Skill Bot)",
+    "author": "Microsoft",
+    "license": "MIT",
+    "main": "index.js",
+    "scripts": {
+        "start": "node ./index.js",
+        "watch": "nodemon ./index.js",
+        "lint": "eslint .",
+        "test": "nyc mocha tests/**/*.test.js"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
+    },
+    "dependencies": {
+        "@microsoft/recognizers-text-data-types-timex-expression": "~1.1.4",
+        "botbuilder": "~4.15.0",
+        "botbuilder-ai": "~4.15.0",
+        "botbuilder-dialogs": "~4.15.0",
+        "dotenv": "~8.2.0",
+        "restify": "~8.6.0"
+    },
+    "devDependencies": {
+        "eslint": "^7.0.0",
+        "eslint-config-standard": "^14.1.1",
+        "eslint-plugin-import": "^2.20.2",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-promise": "^4.2.1",
+        "eslint-plugin-standard": "^4.0.1",
+        "mocha": "^7.1.2",
+        "nodemon": "~1.19.4",
+        "nyc": "^15.0.1"
+    }
+}


### PR DESCRIPTION
Fixes #2980

> **Note: There's an [issue in the SDK](https://github.com/microsoft/botbuilder-js/issues/4137) that needs to be solved for these samples to work properly (PR #4138).**


## Description
This PR ports the 82.skills-sso-cloudadapter from .NET # 3673 to JS.

### Detailed Changes
- Added the **_82.skills-sso-cloudadapter/rootbot_**.
- Added the **_82.skills-sso-cloudadapter/skillbot_**.
- Added a README file with the instructions to configure and test de samples.
- Updated root README to include the link to the new JS samples.

## Testing
Here we can see the SSO token exchange between the bots working.
![image](https://user-images.githubusercontent.com/44245136/156427349-28d490a4-a60d-403e-a890-cb1fc834aa4c.png)
