### PR TITLE
Update Sample 21 + README to add sample code for enabling activity and personal info logging

### DIFF
--- a/samples/python/21.corebot-app-insights/README.md
+++ b/samples/python/21.corebot-app-insights/README.md
@@ -31,8 +31,8 @@ Application Insights resource creation steps can be found [here](https://docs.mi
 
 You must include the instrumentation key in the `config.py` file, as well is in the designated field in your Azure Bot resource.
 
-### Application Insights Activity and Personal Information Logging
-To log activity and personal info logging, extra code is needed in `app.py` after the creation of the telemetry client. This code is *already present* in the sample, but must be unconmmented in order to function. It is important to note that due to privacy concerns, in a real-world application you **must** obtain user consent prior to logging this information.
+### Add Activity and Personal Information logging for Application Insights
+To log activity and personal information, extra code is needed in `app.py` after the creation of the telemetry client. This code is *already present* in the sample, but must be unconmmented in order to function. It is important to note that due to privacy concerns, in a real-world application you **must** obtain user consent prior to logging this information.
 
 The required code is as follows:
 ```python

--- a/samples/python/21.corebot-app-insights/README.md
+++ b/samples/python/21.corebot-app-insights/README.md
@@ -29,6 +29,17 @@ If you wish to create a LUIS application via the CLI, these steps can be found i
 
 Application Insights resource creation steps can be found [here](https://docs.microsoft.com/azure/azure-monitor/app/create-new-resource).
 
+You must include the instrumentation key in the `config.py` file, as well is in the designated field in your Azure Bot resource.
+
+### Application Insights Activity and Personal Information Logging
+To log activity and personal info logging, extra code is needed in `app.py` after the creation of the telemetry client. This code is *already present* in the sample, but must be unconmmented in order to function. It is important to note that due to privacy concerns, in a real-world application you **must** obtain user consent prior to logging this information.
+
+The required code is as follows:
+```python
+TELEMETRY_LOGGER_MIDDLEWARE = TelemetryLoggerMiddleware(telemetry_client=TELEMETRY_CLIENT, log_personal_information=True)
+ADAPTER.use(TELEMETRY_LOGGER_MIDDLEWARE)
+```
+
 ## To try this sample
 
 - Clone the repository

--- a/samples/python/21.corebot-app-insights/app.py
+++ b/samples/python/21.corebot-app-insights/app.py
@@ -17,6 +17,7 @@ from botbuilder.core import (
     ConversationState,
     MemoryStorage,
     UserState,
+    TelemetryLoggerMiddleware,
 )
 from botbuilder.core.integration import aiohttp_error_middleware
 from botbuilder.schema import Activity
@@ -56,6 +57,10 @@ INSTRUMENTATION_KEY = CONFIG.APPINSIGHTS_INSTRUMENTATION_KEY
 TELEMETRY_CLIENT = ApplicationInsightsTelemetryClient(
     INSTRUMENTATION_KEY, telemetry_processor=AiohttpTelemetryProcessor(), client_queue_size=10
 )
+
+# Code for enabling activity logging.
+TELEMETRY_LOGGER_MIDDLEWARE = TelemetryLoggerMiddleware(telemetry_client=TELEMETRY_CLIENT, log_personal_information=True)
+ADAPTER.use(TELEMETRY_LOGGER_MIDDLEWARE)
 
 # Create dialogs and Bot
 RECOGNIZER = FlightBookingRecognizer(CONFIG)

--- a/samples/python/21.corebot-app-insights/app.py
+++ b/samples/python/21.corebot-app-insights/app.py
@@ -58,9 +58,9 @@ TELEMETRY_CLIENT = ApplicationInsightsTelemetryClient(
     INSTRUMENTATION_KEY, telemetry_processor=AiohttpTelemetryProcessor(), client_queue_size=10
 )
 
-# Code for enabling activity logging.
-TELEMETRY_LOGGER_MIDDLEWARE = TelemetryLoggerMiddleware(telemetry_client=TELEMETRY_CLIENT, log_personal_information=True)
-ADAPTER.use(TELEMETRY_LOGGER_MIDDLEWARE)
+# Code for enabling activity and personal information logging.
+# TELEMETRY_LOGGER_MIDDLEWARE = TelemetryLoggerMiddleware(telemetry_client=TELEMETRY_CLIENT, log_personal_information=True)
+# ADAPTER.use(TELEMETRY_LOGGER_MIDDLEWARE)
 
 # Create dialogs and Bot
 RECOGNIZER = FlightBookingRecognizer(CONFIG)


### PR DESCRIPTION
Fixes #3706 

## Proposed Changes
Code to enable personal info and activity logging added in `app.py` by @axelsrz. This code is commented out by default, so current default behavior is unchanged.

I added a section to the `README` discussing the code and that it must be enabled by uncommenting the specified lines. Also added a line about the instrumentation key.

## Testing
Updated sample was tested, with Application Insights successfully logging messages and activities.
![image](https://user-images.githubusercontent.com/33945547/157566882-317d7167-c3ca-47a9-866c-da373ea0a571.png)

