### PR TITLE
Fixing issue with duplicate '/' which is causing blank task module

### DIFF
--- a/samples/csharp_dotnetcore/54.teams-task-module/Bots/TeamsTaskModuleBot.cs
+++ b/samples/csharp_dotnetcore/54.teams-task-module/Bots/TeamsTaskModuleBot.cs
@@ -42,11 +42,11 @@ namespace Microsoft.BotBuilderSamples.Bots
             switch (value)
             {
                 case TaskModuleIds.YouTube:
-                    taskInfo.Url = taskInfo.FallbackUrl = _baseUrl + "/" + TaskModuleIds.YouTube;
+                    taskInfo.Url = taskInfo.FallbackUrl = _baseUrl + TaskModuleIds.YouTube;
                     SetTaskInfo(taskInfo, TaskModuleUIConstants.YouTube);
                     break;
                 case TaskModuleIds.CustomForm:
-                    taskInfo.Url = taskInfo.FallbackUrl = _baseUrl + "/" + TaskModuleIds.CustomForm;
+                    taskInfo.Url = taskInfo.FallbackUrl = _baseUrl + TaskModuleIds.CustomForm;
                     SetTaskInfo(taskInfo, TaskModuleUIConstants.CustomForm);
                     break;
                 case TaskModuleIds.AdaptiveCard:


### PR DESCRIPTION
Fixes issue with blank Task Module pop-up. 

## Proposed Changes
We are already adding '/' for the base URL in [constructor](https://github.com/microsoft/BotBuilder-Samples/blob/main/samples/csharp_dotnetcore/54.teams-task-module/Bots/TeamsTaskModuleBot.cs#L27). Removed code which adds double '/' in base URL.
<img width="363" alt="image" src="https://user-images.githubusercontent.com/31851992/162254965-090ce807-561a-4fc1-bcc9-e2580a797c47.png">
