### PR TITLE
Fix Linux ARM deployment templates for Samples E2E tests

### DIFF
--- a/samples/csharp_dotnetcore/02.echo-bot/DeploymentTemplates/LinuxDotNet/template.json
+++ b/samples/csharp_dotnetcore/02.echo-bot/DeploymentTemplates/LinuxDotNet/template.json
@@ -92,10 +92,10 @@
       "name": "[parameters('botName')]",
       "location": "West US",
       "sku": {
-        "name": "B1",
-        "tier": "Basic",
-        "size": "B1",
-        "family": "B",
+        "name": "S1",
+        "tier": "Standard",
+        "size": "S1",
+        "family": "S",
         "capacity": 1
       },
       "kind": "linux",

--- a/samples/csharp_dotnetcore/02.echo-bot/DeploymentTemplates/LinuxDotNet/template.json
+++ b/samples/csharp_dotnetcore/02.echo-bot/DeploymentTemplates/LinuxDotNet/template.json
@@ -6,6 +6,13 @@
       "defaultValue": "nightly-build-linux",
       "type": "String"
     },
+    "botSku": {
+      "defaultValue": "F0",
+      "type": "string",
+      "metadata": {
+        "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+      }
+    },
     "appId": {
       "type": "string",
       "metadata": {
@@ -263,7 +270,7 @@
       "location": "global",
       "kind": "azurebot",
       "sku": {
-        "name": "[parameters('botName')]"
+        "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botName')]",

--- a/samples/csharp_dotnetcore/13.core-bot/DeploymentTemplates/LinuxDotNet/template.json
+++ b/samples/csharp_dotnetcore/13.core-bot/DeploymentTemplates/LinuxDotNet/template.json
@@ -92,10 +92,10 @@
       "name": "[parameters('botName')]",
       "location": "West US",
       "sku": {
-        "name": "B1",
-        "tier": "Basic",
-        "size": "B1",
-        "family": "B",
+        "name": "S1",
+        "tier": "Standard",
+        "size": "S1",
+        "family": "S",
         "capacity": 1
       },
       "kind": "linux",

--- a/samples/csharp_dotnetcore/13.core-bot/DeploymentTemplates/LinuxDotNet/template.json
+++ b/samples/csharp_dotnetcore/13.core-bot/DeploymentTemplates/LinuxDotNet/template.json
@@ -6,6 +6,13 @@
       "defaultValue": "nightly-build-linux",
       "type": "String"
     },
+    "botSku": {
+      "defaultValue": "F0",
+      "type": "string",
+      "metadata": {
+        "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+      }
+    },
     "appId": {
       "type": "string",
       "metadata": {
@@ -263,7 +270,7 @@
       "location": "global",
       "kind": "azurebot",
       "sku": {
-        "name": "[parameters('botName')]"
+        "name": "[parameters('botSku')]"
       },
       "properties": {
         "name": "[parameters('botName')]",

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/template.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/template.json
@@ -69,31 +69,31 @@
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
         "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
         "appTypeDef": {
-          "MultiTenant": {
-            "tenantId": "",
-            "msiResourceId": "",
-            "identity": { "type": "None" }
-          },
-          "SingleTenant": {
-            "tenantId": "[parameters('tenantId')]",
-            "msiResourceId": "",
-            "identity": { "type": "None" }
-          },
-          "UserAssignedMSI": {
-            "tenantId": "[parameters('tenantId')]",
-            "msiResourceId": "[variables('msiResourceId')]",
-            "identity": {
-                "type": "UserAssigned",
-                "userAssignedIdentities": {
-                    "[variables('msiResourceId')]": {}
+            "MultiTenant": {
+                "tenantId": "",
+                "msiResourceId": "",
+                "identity": { "type": "None" }
+            },
+            "SingleTenant": {
+                "tenantId": "[parameters('tenantId')]",
+                "msiResourceId": "",
+                "identity": { "type": "None" }
+            },
+            "UserAssignedMSI": {
+                "tenantId": "[parameters('tenantId')]",
+                "msiResourceId": "[variables('msiResourceId')]",
+                "identity": {
+                    "type": "UserAssigned",
+                    "userAssignedIdentities": {
+                        "[variables('msiResourceId')]": {}
+                    }
                 }
             }
-          }
         },
         "appType": {
-          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
-          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
-          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+            "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+            "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+            "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
         }
     },
     "resources": [
@@ -116,12 +116,12 @@
             "type": "Microsoft.Web/sites",
             "apiVersion": "2016-08-01",
             "name": "[parameters('botName')]",
+            "identity": "[variables('appType').identity]",
             "location": "[parameters('location')]",
             "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', parameters('botName'))]"
             ],
             "kind": "app,linux",
-            "identity": "[variables('appType').identity]",
             "properties": {
                 "enabled": true,
                 "hostNameSslStates": [

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/template.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/template.json
@@ -6,6 +6,13 @@
             "type": "string",
             "minLength": 2
         },
+        "botSku": {
+          "defaultValue": "F0",
+          "type": "string",
+          "metadata": {
+            "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+        },
         "sku": {
             "defaultValue": {
                 "name": "S1",
@@ -262,7 +269,7 @@
             "location": "global",
             "kind": "azurebot",
             "sku": {
-                "name": "[parameters('botName')]"
+                "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botName')]",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/template.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/template.json
@@ -69,31 +69,31 @@
         "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
         "msiResourceId": "[concat(subscription().id, '/resourceGroups/', parameters('existingUserAssignedMSIResourceGroupName'), '/providers/', 'Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('existingUserAssignedMSIName'))]",
         "appTypeDef": {
-          "MultiTenant": {
-            "tenantId": "",
-            "msiResourceId": "",
-            "identity": { "type": "None" }
-          },
-          "SingleTenant": {
-            "tenantId": "[parameters('tenantId')]",
-            "msiResourceId": "",
-            "identity": { "type": "None" }
-          },
-          "UserAssignedMSI": {
-            "tenantId": "[parameters('tenantId')]",
-            "msiResourceId": "[variables('msiResourceId')]",
-            "identity": {
-                "type": "UserAssigned",
-                "userAssignedIdentities": {
-                    "[variables('msiResourceId')]": {}
+            "MultiTenant": {
+                "tenantId": "",
+                "msiResourceId": "",
+                "identity": { "type": "None" }
+            },
+            "SingleTenant": {
+                "tenantId": "[parameters('tenantId')]",
+                "msiResourceId": "",
+                "identity": { "type": "None" }
+            },
+            "UserAssignedMSI": {
+                "tenantId": "[parameters('tenantId')]",
+                "msiResourceId": "[variables('msiResourceId')]",
+                "identity": {
+                    "type": "UserAssigned",
+                    "userAssignedIdentities": {
+                        "[variables('msiResourceId')]": {}
+                    }
                 }
             }
-          }
         },
         "appType": {
-          "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
-          "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
-          "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
+            "tenantId": "[variables('appTypeDef')[parameters('appType')].tenantId]",
+            "msiResourceId": "[variables('appTypeDef')[parameters('appType')].msiResourceId]",
+            "identity": "[variables('appTypeDef')[parameters('appType')].identity]"
         }
     },
     "resources": [
@@ -116,12 +116,12 @@
             "type": "Microsoft.Web/sites",
             "apiVersion": "2016-08-01",
             "name": "[parameters('botName')]",
+            "identity": "[variables('appType').identity]",
             "location": "[parameters('location')]",
             "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', parameters('botName'))]"
             ],
             "kind": "app,linux",
-            "identity": "[variables('appType').identity]",
             "properties": {
                 "enabled": true,
                 "hostNameSslStates": [

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/template.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/template.json
@@ -6,6 +6,13 @@
             "type": "string",
             "minLength": 2
         },
+        "botSku": {
+          "defaultValue": "F0",
+          "type": "string",
+          "metadata": {
+            "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+        },
         "sku": {
             "defaultValue": {
                 "name": "S1",
@@ -262,7 +269,7 @@
             "location": "global",
             "kind": "azurebot",
             "sku": {
-                "name": "[parameters('botName')]"
+                "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botName')]",

--- a/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/linux/template.json
+++ b/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/linux/template.json
@@ -43,8 +43,8 @@
             "type": "string"
         },
         "appType": {
-            "type": "string",
             "defaultValue": "MultiTenant",
+            "type": "string",
             "allowedValues": [
                 "MultiTenant",
                 "SingleTenant",

--- a/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/linux/template.json
+++ b/samples/typescript_nodejs/02.echo-bot/deploymentTemplates/linux/template.json
@@ -6,6 +6,13 @@
             "type": "string",
             "minLength": 2
         },
+        "botSku": {
+          "defaultValue": "F0",
+          "type": "string",
+          "metadata": {
+            "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+        },
         "sku": {
             "defaultValue": {
                 "name": "S1",
@@ -262,7 +269,7 @@
             "location": "global",
             "kind": "azurebot",
             "sku": {
-                "name": "[parameters('botName')]"
+                "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botName')]",

--- a/samples/typescript_nodejs/13.core-bot/deploymentTemplates/linux/template.json
+++ b/samples/typescript_nodejs/13.core-bot/deploymentTemplates/linux/template.json
@@ -43,8 +43,8 @@
             "type": "string"
         },
         "appType": {
-            "type": "string",
             "defaultValue": "MultiTenant",
+            "type": "string",
             "allowedValues": [
                 "MultiTenant",
                 "SingleTenant",

--- a/samples/typescript_nodejs/13.core-bot/deploymentTemplates/linux/template.json
+++ b/samples/typescript_nodejs/13.core-bot/deploymentTemplates/linux/template.json
@@ -6,6 +6,13 @@
             "type": "string",
             "minLength": 2
         },
+        "botSku": {
+          "defaultValue": "F0",
+          "type": "string",
+          "metadata": {
+            "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+        },
         "sku": {
             "defaultValue": {
                 "name": "S1",
@@ -262,7 +269,7 @@
             "location": "global",
             "kind": "azurebot",
             "sku": {
-                "name": "[parameters('botName')]"
+                "name": "[parameters('botSku')]"
             },
             "properties": {
                 "name": "[parameters('botName')]",


### PR DESCRIPTION
Fixes #minor

## Proposed Changes
Linux samples E2E test pipelines have been failing since 4/12.

This fixes the ARM deployment error: "Invalid sku name for ABS. Allowed values: F0, S1." Looks like the Basic SKU is no longer supported. Also the bot SKU format errors.

Fix sku settings in 6 Linux ARM templates.

This fix has been tested in the 6 corresponding Samples E2E tests for Linux, 2 each for DotNet, Js, and Ts.