### PR TITLE
[C#] Return defaultAnswer from service in 49.qnamaker-all-features.

### DIFF
--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/Dialog/QnAMakerBaseDialog.cs
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/Dialog/QnAMakerBaseDialog.cs
@@ -22,7 +22,7 @@ namespace Microsoft.BotBuilderSamples.Dialog
         public const string DefaultCardNoMatchResponse = "Thanks for the feedback.";
 
         private readonly IBotServices _services;
-        private readonly string DefaultAnswer = "No QnAMaker answers found.";
+        private readonly string DefaultAnswer = "";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="QnAMakerBaseDialog"/> class.
@@ -57,7 +57,7 @@ namespace Microsoft.BotBuilderSamples.Dialog
 
         protected async override Task<QnADialogResponseOptions> GetQnAResponseOptionsAsync(DialogContext dc)
         {
-            var defaultAnswerActivity = MessageFactory.Text(this.DefaultAnswer);
+            var defaultAnswerActivity = MessageFactory.Text(DefaultAnswer);
 
             var cardNoMatchResponse = (Activity)MessageFactory.Text(DefaultCardNoMatchResponse);
 

--- a/samples/csharp_dotnetcore/49.qnamaker-all-features/Dialog/QnAMakerBaseDialog.cs
+++ b/samples/csharp_dotnetcore/49.qnamaker-all-features/Dialog/QnAMakerBaseDialog.cs
@@ -57,7 +57,7 @@ namespace Microsoft.BotBuilderSamples.Dialog
 
         protected async override Task<QnADialogResponseOptions> GetQnAResponseOptionsAsync(DialogContext dc)
         {
-            var defaultAnswerActivity = MessageFactory.Text(DefaultAnswer);
+            var defaultAnswerActivity = MessageFactory.Text(this.DefaultAnswer);
 
             var cardNoMatchResponse = (Activity)MessageFactory.Text(DefaultCardNoMatchResponse);
 


### PR DESCRIPTION
Fixes #3741

## Proposed Changes
Update sample to return default answer from service instead of "No QnAMaker answers found" when default answer is not configured in the sample.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->