### PR TITLE
Update com.microsoft.graph version in POM.XML

### DIFF
--- a/samples/java_springboot/46.teams-auth/pom.xml
+++ b/samples/java_springboot/46.teams-auth/pom.xml
@@ -59,7 +59,7 @@
       <dependency>
         <groupId>com.microsoft.graph</groupId>
         <artifactId>microsoft-graph</artifactId>
-        <version>2.8.9</version>
+        <version>2.9.0</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Fixes #3745 

## Proposed Changes
Update incorrect version for com.microsoft.graph from 2.8.9 which isn't a valid version to 2.9.0.

## Testing
Sample was compiled and tested to work on the 2.9.0 version of com.microsoft.graph library.