### PR TITLE
Fix the test dummy bot readme

### DIFF
--- a/composer-samples/csharp_dotnetcore/pipelines/CICDPipelineSample/BasicAssistant/BasicAssistant/README.md
+++ b/composer-samples/csharp_dotnetcore/pipelines/CICDPipelineSample/BasicAssistant/BasicAssistant/README.md
@@ -1,27 +1,4 @@
-# Welcome to your new bot
+# BasicAssistant bot
 
-This Bot Project was created using the Assistant Core template. Your bot is an assistant-style bot - it is designed as a base for a bot that will help your users accomplish multiple different tasks.
+This BasicAssistant bot is a nonfunctional test dummy. It was created using Bot Framework Composer's [Core Assistant Bot template](https://docs.microsoft.com/en-us/composer/concept-templates#core-assistant-bot-template).
 
-## Next steps
-
-### Start building your bot
-
-Composer can help guide you through getting started building your bot. From your bot settings page (the wrench icon on the left navigation rail), click on the rocket-ship icon on the top right for some quick navigation links.
-
-Another great resource if you're just getting started is the **[guided tutorial](https://docs.microsoft.com/en-us/composer/tutorial/tutorial-introduction)** in our documentation.
-
-### Connect with your users
-
-Your bot comes pre-configured to connect to our Web Chat and DirectLine channels, but there are many more places you can connect your bot to - including Microsoft Teams, Telephony, DirectLine Speech, Slack, Facebook, Outlook and more. Check out all of the places you can connect to on the bot settings page.
-
-### Publish your bot to Azure from Composer
-
-Composer can help you provision the Azure resources necessary for your bot, and publish your bot to them. To get started, create a publishing profile from your bot settings page in Composer (the wrench icon on the left navigation rail). Make sure you only provision the optional Azure resources you need!
-
-### Extend your bot with packages
-
-From Package Manager in Composer you can find useful packages to help add additional pre-built functionality you can add to your bot - everything from simple dialogs & custom actions for working with specific scenarios to custom adapters for connecting your bot to users on clients like Facebook or Slack.
-
-### Extend your bot with code
-
-You can also extend your bot with code - simply open up the folder that was generated for you in the location you chose during the creation process with your favorite IDE (like Visual Studio). You can do things like create custom actions that can be used during dialog flows, create custom middleware to pre-process (or post-process) messages, and more. See [our documentation](https://aka.ms/bf-extend-with-code) for more information.

--- a/composer-samples/csharp_dotnetcore/pipelines/CICDPipelineSample/BasicAssistant/BasicAssistant/README.md
+++ b/composer-samples/csharp_dotnetcore/pipelines/CICDPipelineSample/BasicAssistant/BasicAssistant/README.md
@@ -1,4 +1,4 @@
 # BasicAssistant bot
 
-This BasicAssistant bot is a nonfunctional test dummy. It was created using Bot Framework Composer's [Core Assistant Bot template](https://docs.microsoft.com/en-us/composer/concept-templates#core-assistant-bot-template).
+This BasicAssistant bot is a nonfunctional deployment test dummy. It was created using Bot Framework Composer's [Core Assistant Bot template](https://docs.microsoft.com/en-us/composer/concept-templates#core-assistant-bot-template).
 


### PR DESCRIPTION
Fixes #minor

## Proposed Changes
The BasicAssistant bot under the CICDPipelineSample folder is nonfunctional. This makes that clear for users.