### PR TITLE
Add luisApplicationId parameter to CICD pipeline

### DIFF
--- a/composer-samples/csharp_dotnetcore/pipelines/CICDPipelineSample/build/yaml/buildAndDeploy.yaml
+++ b/composer-samples/csharp_dotnetcore/pipelines/CICDPipelineSample/build/yaml/buildAndDeploy.yaml
@@ -74,6 +74,11 @@ parameters:
   default: $(LUISAUTHORINGREGION)
   
 # LUIS Runtime (used to access LUIS while the bot is running)
+- name: luisApplicationId
+  displayName: LUIS application Id
+  type: string
+  default: $(LUISAPPLICATIONID)
+
 - name: luisEndpoint
   displayName: LUIS endpoint
   type: string
@@ -135,6 +140,7 @@ steps:
     botName: "${{ parameters.botName }}"
     microsoftAppId: "${{ parameters.microsoftAppId }}"
     microsoftAppPassword: "${{ parameters.microsoftAppPassword }}"
+    luisApplicationId: "${{ parameters.luisApplicationId }}"
     luisEndpoint: "${{ parameters.luisEndpoint }}"
     luisEndpointKey: "${{ parameters.luisEndpointKey }}"
     qnaSubscriptionKey: "${{ parameters.qnaSubscriptionKey }}"

--- a/composer-samples/csharp_dotnetcore/pipelines/CICDPipelineSample/build/yaml/templates/buildAndDeployDotNetWebApp.yaml
+++ b/composer-samples/csharp_dotnetcore/pipelines/CICDPipelineSample/build/yaml/templates/buildAndDeployDotNetWebApp.yaml
@@ -33,6 +33,10 @@ parameters:
   displayName: Bot's Microsoft app Password
   type: string
 
+- name: luisApplicationId
+  displayName: LUIS application id
+  type: string
+
 - name: luisEndpoint
   displayName: LUIS endpoint
   type: string
@@ -109,6 +113,11 @@ steps:
         {
           "name": "MicrosoftAppPassword",
           "value": "${{ parameters.microsoftAppPassword }}",
+          "slotSetting": false
+        },
+        {
+          "name": "luis__applicationid",
+          "value": "${{ parameters.luisApplicationId }}",
           "slotSetting": false
         },
         {


### PR DESCRIPTION
Fixes #minor

## Proposed Changes
That parameter deploys the luis__applicationId configuration setting to Azure, which is required for bots using LUIS to work.
