### PR TITLE
Fix broken BotBuilder-Samples-DotNet-CI-PR 4.2.0.307082

### DIFF
--- a/samples/csharp_dotnetcore/54.teams-task-module/TeamsTaskModule.csproj
+++ b/samples/csharp_dotnetcore/54.teams-task-module/TeamsTaskModule.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.16.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.5" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #minor

## Proposed Changes
Update reference System.Text.Encodings.Web from v 4.7.2 to 5.0.1

Fixes build break for [BotBuilder-Samples-DotNet-CI-PR](https://dev.azure.com/FuseLabs/SDK_v4/_build?definitionId=353&_a=summary)

Errors in D:\a\1\s\samples\csharp_dotnetcore\54.teams-task-module\TeamsTaskModule.csproj
    NU1605: Detected package downgrade: System.Text.Encodings.Web from 5.0.1 to 4.7.2. Reference the package directly from the project to select a different version.
     TeamsTaskModule -> Microsoft.Bot.Builder.Integration.AspNet.Core 4.16.0 -> System.Text.Encodings.Web (>= 5.0.1)
     TeamsTaskModule -> System.Text.Encodings.Web (>= 4.7.2))
