### PR TITLE
[#3286] Add linting checks to CI - JavaScript

### DIFF
--- a/.github/workflows/ci-javascript-samples.yml
+++ b/.github/workflows/ci-javascript-samples.yml
@@ -1,0 +1,102 @@
+name: ci-javascript-samples
+
+env:
+  ROOT_FOLDER: BotBuilder-Samples/samples/
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "samples/**/*.js"
+      - "samples/**/*.ts"
+
+jobs:
+  generate:
+    name: detect and generate bot matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: git diff
+        uses: technote-space/get-diff-action@v4
+        with:
+          PATTERNS: samples/**/*.+(ts|js)
+          ABSOLUTE: true
+
+      - name: generate matrix
+        id: set-matrix
+        shell: pwsh
+        if: env.GIT_DIFF
+        run: |
+          function UpSearchFolder {
+            param ([String] $path, [String] $file)
+
+            while ($path -and !(Test-Path (Join-Path $path $file))) {
+              $path = Split-Path $path -Parent
+            }
+
+            return $path
+          }
+
+          $paths = @("${{ env.GIT_DIFF_FILTERED }}" -replace "'", "" -split " ")
+          $rootFolder = "${{ env.ROOT_FOLDER }}"
+          $pkg = "package.json"
+
+          $result = $paths | ForEach-Object { UpSearchFolder -path $_ -file $pkg } | Get-Unique | ForEach-Object {
+            $folder = $_
+            $json = Get-Content -Raw -Path (Join-Path $folder $pkg) | ConvertFrom-Json
+            $files = @($paths | Where-Object { $_.StartsWith($folder) })
+            return @{ 
+              name = $folder.Substring($folder.IndexOf($rootFolder) + $rootFolder.Length);
+              scripts = @($json.scripts | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name);
+              folder = $folder;
+              files = $files
+            } 
+          }
+
+          "Generated matrix:"
+          ConvertTo-Json @($result)
+
+          $matrix = ConvertTo-Json -Compress @($result)
+
+          echo "::set-output name=matrix::$($matrix)"
+
+  build:
+    needs: generate
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: 
+        include: ${{fromJSON(needs.generate.outputs.matrix)}}
+      fail-fast: false
+
+    name: bot - ${{ matrix.name }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: use node 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+
+      - name: yarn install
+        run: yarn install
+        working-directory: ${{ matrix.folder }}
+
+      - name: yarn build
+        if: ${{ contains(matrix.scripts, 'build') }}
+        run: yarn build
+        working-directory: ${{ matrix.folder }}
+
+      - name: yarn lint
+        run: |
+          if ${{ endsWith(matrix.files[0], '.js') }}; then
+            yarn eslint ${{ join(matrix.files, ' ') }}
+          else
+            yarn tslint ${{ join(matrix.files, ' ') }}
+          fi
+        working-directory: ${{ matrix.folder }}


### PR DESCRIPTION
Addresses #3286

## Description
This PR adds the new `ci-javascript-samples.yml` pipeline to the GitHub `workflow` process, including the steps to detect and identify the modified files from a PR, generating a matrix that includes the steps to install, build (only TypeScript) and lint each bot.

### Detailed Changes
- Adding the new `ci-javascript-samples.yml` pipeline into the GitHub workflows.
- The pipeline is separated into two main jobs:
  - `generate`: Will search all `.ts and .js` files modified in the PR, and categorize them, generating the bot matrix.
  - `build`: Will create jobs based on the generated matrix, and for each bot's job will execute the `install`, `build` (only TypeScript) and `lint` commands.
    - The `lint` step will be evaluated only for the modified files.

## Testing
The following images show when the checks fail and when they pass.
![imagen](https://user-images.githubusercontent.com/62260472/172391129-c59d0c91-4fbf-4309-b750-66d77ea594bb.png)
![imagen](https://user-images.githubusercontent.com/62260472/172391717-942ed91b-23d8-41c0-a42e-b3b8eb185269.png)