### PR TITLE
Added events to send channel specific welcome message when bot is ins…

### DIFF
--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/Bots/TeamsConversationBot.cs
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/Bots/TeamsConversationBot.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json.Linq;
 using AdaptiveCards.Templating;
 using Newtonsoft.Json;
+using AdaptiveCards;
 
 namespace Microsoft.BotBuilderSamples.Bots
 {
@@ -61,6 +62,11 @@ namespace Microsoft.BotBuilderSamples.Bots
             {
                 await turnContext.SendActivityAsync(MessageFactory.Text($"Welcome to the team {teamMember.GivenName} {teamMember.Surname}."), cancellationToken);
             }
+        }
+
+        protected override async Task OnInstallationUpdateActivityAsync(ITurnContext<IInstallationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            await turnContext.SendActivityAsync(MessageFactory.Attachment(GetAdaptiveCardForChannelWelcomeMessage(turnContext.Activity.Conversation.Name)), cancellationToken);
         }
 
         private async Task CardActivityAsync(ITurnContext<IMessageActivity> turnContext, bool update, CancellationToken cancellationToken)
@@ -353,6 +359,31 @@ namespace Microsoft.BotBuilderSamples.Bots
                 var replyActivity = MessageFactory.Text(newReaction);
                 await turnContext.SendActivityAsync(replyActivity, cancellationToken);
             }
+        }
+
+        /// <summary>
+        /// Sample Adaptive card sent when bot is installed in channel.
+        /// </summary>
+        private Attachment GetAdaptiveCardForChannelWelcomeMessage(string teamName)
+        {
+            AdaptiveCard card = new AdaptiveCard(new AdaptiveSchemaVersion("1.2"))
+            {
+                Body = new List<AdaptiveElement>
+                {
+                    new AdaptiveTextBlock
+                    {
+                        Text = $"Welcome to the channel {teamName}.",
+                        Weight = AdaptiveTextWeight.Bolder,
+                        Spacing = AdaptiveSpacing.Medium,
+                    }
+                },
+            };
+
+            return new Attachment()
+            {
+                ContentType = AdaptiveCard.ContentType,
+                Content = card,
+            };
         }
     }
 }

--- a/samples/javascript_nodejs/57.teams-conversation-bot/bots/teamsConversationBot.js
+++ b/samples/javascript_nodejs/57.teams-conversation-bot/bots/teamsConversationBot.js
@@ -69,6 +69,25 @@ class TeamsConversationBot extends TeamsActivityHandler {
             }));
         });
     }
+	
+	async onInstallationUpdateActivity(context) {
+        const welcomeCard = CardFactory.adaptiveCard(this.adaptiveCardForChannel(context.activity.conversation.name));
+        await context.sendActivity({ attachments: [welcomeCard] });
+    }
+
+    adaptiveCardForChannel = (teamName) => ({
+        $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+        body: [
+            {
+                type: "TextBlock",
+                size: "Medium",
+                weight: "Bolder",
+                text: `Welcome to the channel ${teamName}.`
+            },
+        ],
+        type: "AdaptiveCard",
+        version: "1.2"
+    });
 
     async cardActivityAsync(context, isUpdate) {
         const cardActions = [


### PR DESCRIPTION


## Added changes based on new conversation update event object.

 - When the bot is installed in specific channel, a welcome card will be sent containing name of the channel where the bot is installed.

- When the bot is installed in other than general channel, then also card will be sent.

![image](https://user-images.githubusercontent.com/87962396/173121877-0a8c9148-fa71-4586-957b-6a89b79257b0.png)



