### PR TITLE
Simplify sending activity to a newly created conversation

### DIFF
--- a/samples/typescript_nodejs/57.teams-conversation-bot/src/teamsConversationBot.ts
+++ b/samples/typescript_nodejs/57.teams-conversation-bot/src/teamsConversationBot.ts
@@ -171,14 +171,7 @@ export class TeamsConversationBot extends TeamsActivityHandler {
                 null,
                 convoParams,
                 async (context) => {
-                    const ref = TurnContext.getConversationReference(context.activity);
-
-                    await context.adapter.continueConversationAsync(
-                        process.env.MicrosoftAppId,
-                        ref,
-                        async (context) => {
-                            await context.sendActivity(message);
-                        });
+                    await context.sendActivity(message);
                 });
         });
 


### PR DESCRIPTION
To me it seems `continueConversationAsync` is redundant as the conversation context is newly created and available from `createConversationAsync` directly.

Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->
<!-- If you are introducing a new sample, make sure that the sample adheres to sample guidelines -->

  - Simplified code logic from the only place in BotBuilder-Samples where  `continueConversationAsync` is used.
  -
  -


## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->