### PR TITLE
Remove NuGet 5.5.1 install from pipelines

### DIFF
--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -245,11 +245,6 @@ jobs:
       '-------------'; get-content $path; '===================';
     displayName: Set Bot.Builder version reference in $(SampleBotName).csproj
 
-  - task: NuGetToolInstaller@1
-    displayName: Use NuGet 5.5.1
-    inputs:
-      versionSpec: 5.5.1
-
   - task: NuGetCommand@2
     displayName: NuGet restore $(SampleBotName).csproj
     inputs:

--- a/build/yaml/sample-dotnet-samplebot-win-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-win-test.yml
@@ -243,11 +243,6 @@ jobs:
       '-------------'; get-content $path; '===================';
     displayName: Set Bot.Builder version reference in $(SampleBotName).csproj
 
-  - task: NuGetToolInstaller@1
-    displayName: Use NuGet 5.5.1
-    inputs:
-      versionSpec: 5.5.1
-
   - task: NuGetCommand@2
     displayName: NuGet restore $(SampleBotName).csproj
     inputs:

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -255,11 +255,6 @@ jobs:
       Write-Host "setx BOTID $(AzureBotName)";
     displayName: Set DIRECTLINE key, BOTID for running tests
 
-  - task: NuGetToolInstaller@1
-    displayName: Use NuGet 5.5.1
-    inputs:
-      versionSpec: 5.5.1
-
   - powershell: |
       $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
 

--- a/build/yaml/sample-js-samplebot-win-test.yml
+++ b/build/yaml/sample-js-samplebot-win-test.yml
@@ -265,11 +265,6 @@ jobs:
       Write-Host "setx BOTID $(AzureBotName)";
     displayName: Set DIRECTLINE key, BOTID for running tests
 
-  - task: NuGetToolInstaller@1
-    displayName: Use NuGet 5.5.1
-    inputs:
-      versionSpec: 5.5.1
-
   - powershell: |
       $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
 

--- a/build/yaml/sample-py-samplebot-linux-test.yml
+++ b/build/yaml/sample-py-samplebot-linux-test.yml
@@ -378,11 +378,6 @@ jobs:
       Write-Host "setx BOTID $(AzureBotName)";
     displayName: Set DIRECTLINE key, BOTID for running tests
 
-  - task: NuGetToolInstaller@1
-    displayName: Use NuGet 5.5.1
-    inputs:
-      versionSpec: 5.5.1
-
   - powershell: |
       $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
 

--- a/build/yaml/sample-py-zipdeploy-echobot-linux-test.yml
+++ b/build/yaml/sample-py-zipdeploy-echobot-linux-test.yml
@@ -392,11 +392,6 @@ jobs:
       Write-Host "setx BOTID $(AzureBotName)";
     displayName: Set DIRECTLINE key, BOTID for running tests
 
-  - task: NuGetToolInstaller@1
-    displayName: Use NuGet 5.5.1
-    inputs:
-      versionSpec: 5.5.1
-
   - powershell: |
       $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
 

--- a/build/yaml/sample-ts-samplebot-linux-test.yml
+++ b/build/yaml/sample-ts-samplebot-linux-test.yml
@@ -255,11 +255,6 @@ jobs:
       Write-Host "setx BOTID $(AzureBotName)";
     displayName: Set DIRECTLINE key, BOTID for running tests
 
-  - task: NuGetToolInstaller@1
-    displayName: Use NuGet 5.5.1
-    inputs:
-      versionSpec: 5.5.1
-
   - powershell: |
       $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
 

--- a/build/yaml/sample-ts-samplebot-win-test.yml
+++ b/build/yaml/sample-ts-samplebot-win-test.yml
@@ -275,11 +275,6 @@ jobs:
       Write-Host "setx BOTID $(AzureBotName)";
     displayName: Set DIRECTLINE key, BOTID for running tests
 
-  - task: NuGetToolInstaller@1
-    displayName: Use NuGet 5.5.1
-    inputs:
-      versionSpec: 5.5.1
-
   - powershell: |
       $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";
 


### PR DESCRIPTION
Fixes #minor

## Proposed Changes
This lets the pipelines use a later version of NuGet.
