### PR TITLE
Update pipelines to use latest NuGet version

### DIFF
--- a/build/yaml/sample-dotnet-samplebot-linux-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-linux-test.yml
@@ -246,9 +246,7 @@ jobs:
     displayName: Set Bot.Builder version reference in $(SampleBotName).csproj
 
   - task: NuGetToolInstaller@1
-    displayName: Use NuGet 5.5.1
-    inputs:
-      versionSpec: 5.5.1
+    displayName: "Use NuGet latest"
 
   - task: NuGetCommand@2
     displayName: NuGet restore $(SampleBotName).csproj

--- a/build/yaml/sample-dotnet-samplebot-win-test.yml
+++ b/build/yaml/sample-dotnet-samplebot-win-test.yml
@@ -244,9 +244,7 @@ jobs:
     displayName: Set Bot.Builder version reference in $(SampleBotName).csproj
 
   - task: NuGetToolInstaller@1
-    displayName: Use NuGet 5.5.1
-    inputs:
-      versionSpec: 5.5.1
+    displayName: "Use NuGet latest"
 
   - task: NuGetCommand@2
     displayName: NuGet restore $(SampleBotName).csproj

--- a/build/yaml/sample-js-samplebot-linux-test.yml
+++ b/build/yaml/sample-js-samplebot-linux-test.yml
@@ -256,9 +256,7 @@ jobs:
     displayName: Set DIRECTLINE key, BOTID for running tests
 
   - task: NuGetToolInstaller@1
-    displayName: Use NuGet 5.5.1
-    inputs:
-      versionSpec: 5.5.1
+    displayName: "Use NuGet latest"
 
   - powershell: |
       $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";

--- a/build/yaml/sample-js-samplebot-win-test.yml
+++ b/build/yaml/sample-js-samplebot-win-test.yml
@@ -266,9 +266,7 @@ jobs:
     displayName: Set DIRECTLINE key, BOTID for running tests
 
   - task: NuGetToolInstaller@1
-    displayName: Use NuGet 5.5.1
-    inputs:
-      versionSpec: 5.5.1
+    displayName: "Use NuGet latest"
 
   - powershell: |
       $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";

--- a/build/yaml/sample-py-samplebot-linux-test.yml
+++ b/build/yaml/sample-py-samplebot-linux-test.yml
@@ -379,9 +379,7 @@ jobs:
     displayName: Set DIRECTLINE key, BOTID for running tests
 
   - task: NuGetToolInstaller@1
-    displayName: Use NuGet 5.5.1
-    inputs:
-      versionSpec: 5.5.1
+    displayName: "Use NuGet latest"
 
   - powershell: |
       $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";

--- a/build/yaml/sample-py-zipdeploy-echobot-linux-test.yml
+++ b/build/yaml/sample-py-zipdeploy-echobot-linux-test.yml
@@ -393,9 +393,7 @@ jobs:
     displayName: Set DIRECTLINE key, BOTID for running tests
 
   - task: NuGetToolInstaller@1
-    displayName: Use NuGet 5.5.1
-    inputs:
-      versionSpec: 5.5.1
+    displayName: "Use NuGet latest"
 
   - powershell: |
       $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";

--- a/build/yaml/sample-ts-samplebot-linux-test.yml
+++ b/build/yaml/sample-ts-samplebot-linux-test.yml
@@ -256,9 +256,7 @@ jobs:
     displayName: Set DIRECTLINE key, BOTID for running tests
 
   - task: NuGetToolInstaller@1
-    displayName: Use NuGet 5.5.1
-    inputs:
-      versionSpec: 5.5.1
+    displayName: "Use NuGet latest"
 
   - powershell: |
       $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";

--- a/build/yaml/sample-ts-samplebot-win-test.yml
+++ b/build/yaml/sample-ts-samplebot-win-test.yml
@@ -276,9 +276,7 @@ jobs:
     displayName: Set DIRECTLINE key, BOTID for running tests
 
   - task: NuGetToolInstaller@1
-    displayName: Use NuGet 5.5.1
-    inputs:
-      versionSpec: 5.5.1
+    displayName: "Use NuGet latest"
 
   - powershell: |
       $file = "$(System.DefaultWorkingDirectory)/samples/csharp_dotnetcore/tests/Samples.$(SampleBotName).FunctionalTests/nuget.config";


### PR DESCRIPTION
Fixes #minor

## Proposed Changes
Pipelines currently use NuGet 5.5.1, an older version. This lets them use the latest.