### PR TITLE
Fix bug related to channelId

### DIFF
--- a/samples/csharp_dotnetcore/57.teams-conversation-bot/Bots/TeamsConversationBot.cs
+++ b/samples/csharp_dotnetcore/57.teams-conversation-bot/Bots/TeamsConversationBot.cs
@@ -158,7 +158,7 @@ namespace Microsoft.BotBuilderSamples.Bots
 
         private async Task MessageAllMembersAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
-            var teamsChannelId = turnContext.Activity.TeamsGetChannelId();
+            var channelId = turnContext.Activity.ChannelId;
             var serviceUrl = turnContext.Activity.ServiceUrl;
             var credentials = new MicrosoftAppCredentials(_appId, _appPassword);
             ConversationReference conversationReference = null;
@@ -179,7 +179,7 @@ namespace Microsoft.BotBuilderSamples.Bots
 
                 await ((CloudAdapter)turnContext.Adapter).CreateConversationAsync(
                     credentials.MicrosoftAppId,
-                    teamsChannelId,
+                    channelId,
                     serviceUrl,
                     credentials.OAuthScope,
                     conversationParameters,


### PR DESCRIPTION
Fixing a bug that used to pass teamsChannelId instead of chanelId when calling CreateConversationAsync. 
CreateConversationAsync requires the ChannelId which comes from  turnContext.Activity.ChannelId and has the value "msteams". The teamsChannelId is the Id of a channel in a team when the conversation is happening. (19:b6ce1b0...)

Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->
<!-- If you are introducing a new sample, make sure that the sample adheres to sample guidelines -->

  - 
  -
  -


## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->