### PR TITLE
Fix Task Module HTML Page Url

### DIFF
--- a/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Bots/TeamsMessagingExtensionsActionBot.cs
+++ b/samples/csharp_dotnetcore/51.teams-messaging-extensions-action/Bots/TeamsMessagingExtensionsActionBot.cs
@@ -286,7 +286,7 @@ namespace Microsoft.BotBuilderSamples.Bots
                         Height = 200,
                         Width = 400,
                         Title = "Task Module HTML Page",
-                        Url = baseUrl + "/htmlpage.html",
+                        Url = baseUrl + "/htmlpage",
                     },
                 },
             };


### PR DESCRIPTION
Fixes #3846<!-- If this addresses a specific issue, please provide the issue number here -->

## Proposed Changes
Remove ".html" in Url:
`Url = baseUrl + "/htmlpage.html"`


## Testing

After the url change, task module html page displays the form as expected:
<img src="https://user-images.githubusercontent.com/38049078/202581509-a83208c3-828f-423f-afb9-2764c7ff5e1e.png" width="600"/>