### PR TITLE
fix: Update restify Dependency to v10.0.0 in Node Samples to Fix Incompatibility with Node v18.x

### DIFF
--- a/samples/javascript_nodejs/02.echo-bot/package.json
+++ b/samples/javascript_nodejs/02.echo-bot/package.json
@@ -18,7 +18,7 @@
     "dependencies": {
         "botbuilder": "~4.17.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/03.welcome-users/package.json
+++ b/samples/javascript_nodejs/03.welcome-users/package.json
@@ -18,7 +18,7 @@
     "dependencies": {
         "botbuilder": "~4.17.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/05.multi-turn-prompt/package.json
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/package.json
@@ -20,7 +20,7 @@
         "botbuilder-dialogs": "~4.17.0",
         "dotenv": "^8.2.0",
         "path": "^0.12.7",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/06.using-cards/package.json
+++ b/samples/javascript_nodejs/06.using-cards/package.json
@@ -19,7 +19,7 @@
         "botbuilder": "~4.17.0",
         "botbuilder-dialogs": "~4.17.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/07.using-adaptive-cards/package.json
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/package.json
@@ -18,7 +18,7 @@
     "dependencies": {
         "botbuilder": "~4.17.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/08.suggested-actions/package.json
+++ b/samples/javascript_nodejs/08.suggested-actions/package.json
@@ -18,7 +18,7 @@
     "dependencies": {
         "botbuilder": "~4.17.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/12.customQABot/package.json
+++ b/samples/javascript_nodejs/12.customQABot/package.json
@@ -19,7 +19,7 @@
     "botbuilder": "~4.17.0",
     "botbuilder-ai": "~4.17.0",
     "dotenv": "^8.2.0",
-    "restify": "~8.6.0"
+    "restify": "~10.0.0"
   },
   "devDependencies": {
     "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/13.core-bot/package.json
+++ b/samples/javascript_nodejs/13.core-bot/package.json
@@ -23,7 +23,7 @@
         "botbuilder-testing": "~4.17.0",
         "dotenv": "^8.2.0",
         "moment-timezone": "~0.5.33",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/15.handling-attachments/package.json
+++ b/samples/javascript_nodejs/15.handling-attachments/package.json
@@ -19,7 +19,7 @@
     "axios": "^0.21.2",
     "botbuilder": "~4.17.0",
     "dotenv": "^8.2.0",
-    "restify": "~8.6.0"
+    "restify": "~10.0.0"
   },
   "devDependencies": {
     "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/16.proactive-messages/package.json
+++ b/samples/javascript_nodejs/16.proactive-messages/package.json
@@ -22,7 +22,7 @@
         "fetch-ponyfill": "^7.0.0",
         "moment": "^2.29.1",
         "path": "^0.12.7",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/17.multilingual-bot/package.json
+++ b/samples/javascript_nodejs/17.multilingual-bot/package.json
@@ -19,7 +19,7 @@
         "botbuilder": "~4.17.0",
         "dotenv": "^8.2.0",
         "node-fetch": "^2.6.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/18.bot-authentication/package.json
+++ b/samples/javascript_nodejs/18.bot-authentication/package.json
@@ -19,7 +19,7 @@
         "botbuilder": "~4.17.0",
         "botbuilder-dialogs": "~4.17.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/19.custom-dialogs/package.json
+++ b/samples/javascript_nodejs/19.custom-dialogs/package.json
@@ -19,7 +19,7 @@
         "botbuilder": "~4.17.0",
         "botbuilder-dialogs": "~4.17.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/21.corebot-app-insights/package.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/package.json
@@ -23,7 +23,7 @@
     "botbuilder-dialogs": "~4.17.0",
     "dotenv": "^8.2.0",
     "path": "^0.12.7",
-    "restify": "~8.6.0"
+    "restify": "~10.0.0"
   },
   "devDependencies": {
     "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/23.facebook-events/package.json
+++ b/samples/javascript_nodejs/23.facebook-events/package.json
@@ -19,7 +19,7 @@
         "botbuilder": "~4.17.0",
         "botbuilder-dialogs": "~4.17.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/package.json
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/package.json
@@ -21,7 +21,7 @@
         "botbuilder-dialogs": "~4.17.0",
         "dotenv": "^8.2.0",
         "isomorphic-fetch": "^3.0.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/43.complex-dialog/package.json
+++ b/samples/javascript_nodejs/43.complex-dialog/package.json
@@ -15,7 +15,7 @@
         "botbuilder": "~4.17.0",
         "botbuilder-dialogs": "~4.17.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/44.prompt-for-user-input/package.json
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/package.json
@@ -15,7 +15,7 @@
         "@microsoft/recognizers-text-suite": "1.1.4",
         "botbuilder": "~4.17.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/45.state-management/package.json
+++ b/samples/javascript_nodejs/45.state-management/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
         "botbuilder": "~4.17.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/47.inspection/package.json
+++ b/samples/javascript_nodejs/47.inspection/package.json
@@ -18,7 +18,7 @@
     "dependencies": {
         "botbuilder": "~4.17.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/48.customQABot-all-features/package.json
+++ b/samples/javascript_nodejs/48.customQABot-all-features/package.json
@@ -20,7 +20,7 @@
     "botbuilder-ai": "~4.17.0",
     "botbuilder-dialogs": "~4.17.0",
     "dotenv": "^8.2.0",
-    "restify": "~8.6.0"
+    "restify": "~10.0.0"
   },
   "devDependencies": {
     "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/package.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/package.json
@@ -19,7 +19,7 @@
         "botbuilder": "~4.17.0",
         "botframework-connector": "~4.17.0",
         "dotenv": "~8.2.0",
-        "restify": "~10.0.0"
+        "restify": "~8.6.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/package.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/package.json
@@ -19,7 +19,7 @@
         "botbuilder": "~4.17.0",
         "botframework-connector": "~4.17.0",
         "dotenv": "~8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/package.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/package.json
@@ -19,7 +19,7 @@
         "botbuilder": "~4.17.0",
         "botframework-connector": "~4.17.0",
         "dotenv": "~8.2.0",
-        "restify": "~10.0.0"
+        "restify": "~8.6.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/package.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/package.json
@@ -19,7 +19,7 @@
         "botbuilder": "~4.17.0",
         "botframework-connector": "~4.17.0",
         "dotenv": "~8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/package.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/package.json
@@ -16,10 +16,10 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.17.0",
-        "botbuilder-dialogs": "~4.17.0",
+        "botbuilder": "~4.18.0",
+        "botbuilder-dialogs": "~4.18.0",
         "dotenv": "~8.2.0",
-        "restify": "~10.0.0"
+        "restify": "~8.6.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/package.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/package.json
@@ -19,7 +19,7 @@
         "botbuilder": "~4.17.0",
         "botbuilder-dialogs": "~4.17.0",
         "dotenv": "~8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/package.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/package.json
@@ -16,10 +16,10 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.18.0",
-        "botbuilder-dialogs": "~4.18.0",
+        "botbuilder": "~4.17.0",
+        "botbuilder-dialogs": "~4.17.0",
         "dotenv": "~8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/package.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/package.json
@@ -21,7 +21,7 @@
         "botbuilder-ai": "~4.17.0",
         "botbuilder-dialogs": "~4.17.0",
         "dotenv": "~8.2.0",
-        "restify": "~10.0.0"
+        "restify": "~8.6.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/package.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/package.json
@@ -21,7 +21,7 @@
         "botbuilder-ai": "~4.17.0",
         "botbuilder-dialogs": "~4.17.0",
         "dotenv": "~8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/package.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/package.json
@@ -20,7 +20,7 @@
         "botbuilder-dialogs": "~4.17.0",
         "botbuilder-lg": "~4.17.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/package.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/package.json
@@ -20,7 +20,7 @@
         "botbuilder-dialogs": "~4.17.0",
         "botbuilder-lg": "~4.17.0",
         "dotenv": "^8.2.0",
-        "restify": "~10.0.0"
+        "restify": "~8.6.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/package.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/package.json
@@ -23,7 +23,7 @@
         "botbuilder-testing": "~4.17.0",
         "botbuilder-lg": "~4.17.0",
         "dotenv": "^8.2.0",
-        "restify": "~10.0.0"
+        "restify": "~8.6.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/package.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/package.json
@@ -23,7 +23,7 @@
         "botbuilder-testing": "~4.17.0",
         "botbuilder-lg": "~4.17.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/package.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/package.json
@@ -19,7 +19,7 @@
         "botbuilder": "~4.17.0",
         "dotenv": "^8.2.0",
         "math-random": "^2.0.1",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",


### PR DESCRIPTION
All of our Node samples currently require restify `8.6.0`. This version of restify is incompatible with the latest stable `18.x` releases of Node due to ambiguity in the names of certain getter functions caused by new features in Node 18. Updating all samples to restify `10.0.0` (which resolves this incompatibility with Node 18) should fix any issues with the samples failing to run under Node 18.

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->
<!-- If you are introducing a new sample, make sure that the sample adheres to sample guidelines -->

  - Update restify in all Node samples to version `10.0.0`

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
- Successfully ran bots after updates.
- Does not break bots on Node 16.x