### PR TITLE
teams-file-upload-sample bug fix

### DIFF
--- a/archive/samples/python/56.teams-file-upload/app.py
+++ b/archive/samples/python/56.teams-file-upload/app.py
@@ -75,11 +75,14 @@ async def messages(req: Request) -> Response:
     invoke_response = await ADAPTER.process_activity(
         activity, auth_header, BOT.on_turn
     )
-    if invoke_response:
+    if invoke_response and invoke_response.body:
         return json_response(
             data=invoke_response.body, status=invoke_response.status
         )
-    return Response(status=HTTPStatus.OK)
+
+    status = HTTPStatus.OK if not invoke_response else invoke_response.status
+    
+    return Response(status=status)
 
 
 APP = web.Application(middlewares=[aiohttp_error_middleware])

--- a/archive/samples/python/56.teams-file-upload/bots/teams_file_bot.py
+++ b/archive/samples/python/56.teams-file-upload/bots/teams_file_bot.py
@@ -97,7 +97,7 @@ class TeamsFileUploadBot(TeamsActivityHandler):
             file_consent_card_response.upload_info.upload_url, open(file_path, "rb"), headers=headers
         )
 
-        if response.status_code != 201 and response.status_code != 200:
+        if response.status_code != 201:
             print(f"Failed to upload, status {response.status_code}, file_path={file_path}")
             await self._file_upload_failed(turn_context, "Unable to upload file.")
         else:

--- a/archive/samples/python/56.teams-file-upload/bots/teams_file_bot.py
+++ b/archive/samples/python/56.teams-file-upload/bots/teams_file_bot.py
@@ -97,7 +97,7 @@ class TeamsFileUploadBot(TeamsActivityHandler):
             file_consent_card_response.upload_info.upload_url, open(file_path, "rb"), headers=headers
         )
 
-        if response.status_code != 201:
+        if response.status_code != 201 and response.status_code != 200:
             print(f"Failed to upload, status {response.status_code}, file_path={file_path}")
             await self._file_upload_failed(turn_context, "Unable to upload file.")
         else:


### PR DESCRIPTION
Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

https://github.com/OfficeDev/Microsoft-Teams-Samples/issues/632

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->
<!-- If you are introducing a new sample, make sure that the sample adheres to sample guidelines -->

 
- ![image](https://user-images.githubusercontent.com/115390646/222629329-fe67da16-0df0-46b6-888f-a2b2ab50b5a1.png)
When the `invoke_response` is not `None` but `invoke_response.body` is `None` a json response is returned by the server with the body as `null`. This causes the `Something went wrong...` message. The correct behavior would be to return an empty body. 
- when the upload file request returns 200 response code, we should not return `file upload fail`


## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->