### PR TITLE
feat: Update Node Samples to SDK 4.20.0 and restify 10.0.0 for Compatibility with Node 18

### DIFF
--- a/samples/javascript_nodejs/01.console-echo/README.md
+++ b/samples/javascript_nodejs/01.console-echo/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/02.echo-bot/README.md
+++ b/samples/javascript_nodejs/02.echo-bot/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/02.echo-bot/package.json
+++ b/samples/javascript_nodejs/02.echo-bot/package.json
@@ -16,9 +16,9 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.17.0",
+        "botbuilder": "~4.20.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/03.welcome-users/README.md
+++ b/samples/javascript_nodejs/03.welcome-users/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/03.welcome-users/package.json
+++ b/samples/javascript_nodejs/03.welcome-users/package.json
@@ -16,9 +16,9 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.17.0",
+        "botbuilder": "~4.20.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/05.multi-turn-prompt/README.md
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/05.multi-turn-prompt/package.json
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/package.json
@@ -16,11 +16,11 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.17.0",
-        "botbuilder-dialogs": "~4.17.0",
+        "botbuilder": "~4.20.0",
+        "botbuilder-dialogs": "~4.20.0",
         "dotenv": "^8.2.0",
         "path": "^0.12.7",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/06.using-cards/README.md
+++ b/samples/javascript_nodejs/06.using-cards/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/06.using-cards/package.json
+++ b/samples/javascript_nodejs/06.using-cards/package.json
@@ -16,10 +16,10 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.17.0",
-        "botbuilder-dialogs": "~4.17.0",
+        "botbuilder": "~4.20.0",
+        "botbuilder-dialogs": "~4.20.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/07.using-adaptive-cards/README.md
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/07.using-adaptive-cards/package.json
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/package.json
@@ -16,9 +16,9 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.17.0",
+        "botbuilder": "~4.20.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/08.suggested-actions/README.md
+++ b/samples/javascript_nodejs/08.suggested-actions/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/08.suggested-actions/package.json
+++ b/samples/javascript_nodejs/08.suggested-actions/package.json
@@ -16,9 +16,9 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.17.0",
+        "botbuilder": "~4.20.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/12.customQABot/README.md
+++ b/samples/javascript_nodejs/12.customQABot/README.md
@@ -9,6 +9,13 @@ This bot has been created using the [Bot Framework SDK][BF], it shows how to cre
 ## Prerequisites
 - This project requires a [Language service resource](https://aka.ms/create-language-resource) with Custom question answering enabled.
 
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
+
+    ```bash
+    # determine node version
+    node --version
+    ```
+
 ### Configure knowledge base of the project
 - See the [quickstart][Quickstart] to create a Custom question answering project. You will need this project's name to be used as `ProjectName` in [.env file](.env).
 - Go to [Language Studio][LS] and open the created project.

--- a/samples/javascript_nodejs/12.customQABot/package.json
+++ b/samples/javascript_nodejs/12.customQABot/package.json
@@ -16,10 +16,10 @@
     "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
   },
   "dependencies": {
-    "botbuilder": "~4.18.1",
-    "botbuilder-ai": "~4.18.1",
+    "botbuilder": "~4.20.0",
+    "botbuilder-ai": "~4.20.0",
     "dotenv": "^8.2.0",
-    "restify": "~8.6.0"
+    "restify": "~10.0.0"
   },
   "devDependencies": {
     "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/13.core-bot/README.md
+++ b/samples/javascript_nodejs/13.core-bot/README.md
@@ -17,7 +17,7 @@ This sample **requires** prerequisites in order to run.
 
 This bot uses [LUIS](https://www.luis.ai), an AI based cognitive service, to implement language understanding.
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/13.core-bot/package.json
+++ b/samples/javascript_nodejs/13.core-bot/package.json
@@ -17,13 +17,13 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.17.0",
-        "botbuilder-ai": "~4.17.0",
-        "botbuilder-dialogs": "~4.17.0",
-        "botbuilder-testing": "~4.17.0",
+        "botbuilder": "~4.20.0",
+        "botbuilder-ai": "~4.20.0",
+        "botbuilder-dialogs": "~4.20.0",
+        "botbuilder-testing": "~4.20.0",
         "dotenv": "^8.2.0",
         "moment-timezone": "~0.5.33",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/15.handling-attachments/README.md
+++ b/samples/javascript_nodejs/15.handling-attachments/README.md
@@ -9,7 +9,7 @@ upload files to Teams from a bot and how to receive a file sent to a bot as an a
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/15.handling-attachments/package.json
+++ b/samples/javascript_nodejs/15.handling-attachments/package.json
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "axios": "^0.21.2",
-    "botbuilder": "~4.17.0",
+    "botbuilder": "~4.20.0",
     "dotenv": "^8.2.0",
-    "restify": "~8.6.0"
+    "restify": "~10.0.0"
   },
   "devDependencies": {
     "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/16.proactive-messages/README.md
+++ b/samples/javascript_nodejs/16.proactive-messages/README.md
@@ -15,7 +15,7 @@ all users who have previously messaged the bot.
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/16.proactive-messages/package.json
+++ b/samples/javascript_nodejs/16.proactive-messages/package.json
@@ -16,13 +16,13 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.17.0",
-        "botbuilder-dialogs": "~4.17.0",
+        "botbuilder": "~4.20.0",
+        "botbuilder-dialogs": "~4.20.0",
         "dotenv": "^8.2.0",
         "fetch-ponyfill": "^7.0.0",
         "moment": "^2.29.1",
         "path": "^0.12.7",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/17.multilingual-bot/README.md
+++ b/samples/javascript_nodejs/17.multilingual-bot/README.md
@@ -21,7 +21,7 @@ The API uses the most modern neural machine translation technology, as well as o
 
 This sample **requires** prerequisites in order to run.
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/17.multilingual-bot/package.json
+++ b/samples/javascript_nodejs/17.multilingual-bot/package.json
@@ -16,10 +16,10 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.17.0",
+        "botbuilder": "~4.20.0",
         "dotenv": "^8.2.0",
         "node-fetch": "^2.6.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/18.bot-authentication/README.md
+++ b/samples/javascript_nodejs/18.bot-authentication/README.md
@@ -10,7 +10,7 @@ NOTE: Microsoft Teams currently differs slightly in the way auth is integrated w
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/18.bot-authentication/package.json
+++ b/samples/javascript_nodejs/18.bot-authentication/package.json
@@ -16,10 +16,10 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.17.0",
-        "botbuilder-dialogs": "~4.17.0",
+        "botbuilder": "~4.20.0",
+        "botbuilder-dialogs": "~4.20.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/19.custom-dialogs/README.md
+++ b/samples/javascript_nodejs/19.custom-dialogs/README.md
@@ -8,7 +8,7 @@ BotFramework provides a built-in base class called `Dialog`. By subclassing `Dia
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/19.custom-dialogs/package.json
+++ b/samples/javascript_nodejs/19.custom-dialogs/package.json
@@ -16,10 +16,10 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.17.0",
-        "botbuilder-dialogs": "~4.17.0",
+        "botbuilder": "~4.20.0",
+        "botbuilder-dialogs": "~4.20.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/21.corebot-app-insights/README.md
+++ b/samples/javascript_nodejs/21.corebot-app-insights/README.md
@@ -19,7 +19,7 @@ This sample **requires** prerequisites in order to run.
 This bot uses [LUIS](https://www.luis.ai), an AI based cognitive service, to implement language understanding
 and [Application Insights](https://docs.microsoft.com/azure/azure-monitor/app/cloudservices), an extensible Application Performance Management (APM) service for web developers on multiple platforms.
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/21.corebot-app-insights/package.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/package.json
@@ -17,13 +17,13 @@
   "license": "MIT",
   "dependencies": {
     "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-    "botbuilder": "~4.17.0",
-    "botbuilder-ai": "~4.17.0",
-    "botbuilder-applicationinsights": "~4.17.0",
-    "botbuilder-dialogs": "~4.17.0",
+    "botbuilder": "~4.20.0",
+    "botbuilder-ai": "~4.20.0",
+    "botbuilder-applicationinsights": "~4.20.0",
+    "botbuilder-dialogs": "~4.20.0",
     "dotenv": "^8.2.0",
     "path": "^0.12.7",
-    "restify": "~8.6.0"
+    "restify": "~10.0.0"
   },
   "devDependencies": {
     "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/23.facebook-events/README.md
+++ b/samples/javascript_nodejs/23.facebook-events/README.md
@@ -8,7 +8,7 @@ More information about configuring a bot for Facebook Messenger can be found her
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/23.facebook-events/package.json
+++ b/samples/javascript_nodejs/23.facebook-events/package.json
@@ -16,10 +16,10 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.17.0",
-        "botbuilder-dialogs": "~4.17.0",
+        "botbuilder": "~4.20.0",
+        "botbuilder-dialogs": "~4.20.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/README.md
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/README.md
@@ -11,7 +11,7 @@ application setup for use in Azure Bot Service. The [scopes](https://developer.m
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/package.json
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/package.json
@@ -17,11 +17,11 @@
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "~2.0.0",
-        "botbuilder": "~4.17.0",
-        "botbuilder-dialogs": "~4.17.0",
+        "botbuilder": "~4.20.0",
+        "botbuilder-dialogs": "~4.20.0",
         "dotenv": "^8.2.0",
         "isomorphic-fetch": "^3.0.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/43.complex-dialog/README.md
+++ b/samples/javascript_nodejs/43.complex-dialog/README.md
@@ -4,7 +4,7 @@ This sample creates a complex conversation with dialogs.
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/43.complex-dialog/package.json
+++ b/samples/javascript_nodejs/43.complex-dialog/package.json
@@ -12,10 +12,10 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "botbuilder": "~4.17.0",
-        "botbuilder-dialogs": "~4.17.0",
+        "botbuilder": "~4.20.0",
+        "botbuilder-dialogs": "~4.20.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/44.prompt-for-user-input/README.md
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/README.md
@@ -6,7 +6,7 @@ The bot maintains user state to track the user's answers.
 
 ## Prerequisites
 
-- Node.js version 10.14.1 or higher.
+- Node.js version 16.16.0 or higher.
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/44.prompt-for-user-input/package.json
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/package.json
@@ -13,9 +13,9 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-suite": "1.1.4",
-        "botbuilder": "~4.17.0",
+        "botbuilder": "~4.20.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/45.state-management/README.md
+++ b/samples/javascript_nodejs/45.state-management/README.md
@@ -6,7 +6,7 @@ The bot maintains user state to track the user's answers.
 
 ## Prerequisites
 
-- Node.js version 10.14.1 or higher.
+- Node.js version 16.16.0 or higher.
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/45.state-management/package.json
+++ b/samples/javascript_nodejs/45.state-management/package.json
@@ -12,9 +12,9 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "botbuilder": "~4.17.0",
+        "botbuilder": "~4.20.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/47.inspection/README.md
+++ b/samples/javascript_nodejs/47.inspection/README.md
@@ -12,7 +12,7 @@ More details are available [here](https://github.com/microsoft/BotFramework-Emul
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/47.inspection/package.json
+++ b/samples/javascript_nodejs/47.inspection/package.json
@@ -16,9 +16,9 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.17.0",
+        "botbuilder": "~4.20.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/48.customQABot-all-features/README.md
+++ b/samples/javascript_nodejs/48.customQABot-all-features/README.md
@@ -13,6 +13,12 @@ This bot was created using [Bot Framework][BF].
 
 ## Prerequisites
 - This project requires a [Language resource](https://aka.ms/create-language-resource) with Custom question answering enabled.
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
+
+    ```bash
+    # determine node version
+    node --version
+    ```
 
 ### Configure knowledge base of the project
 - Follow instructions [here][Quickstart] to create a Custom question answering project. You will need this project's name to be used as `ProjectName` in [.env file](.env).

--- a/samples/javascript_nodejs/48.customQABot-all-features/package.json
+++ b/samples/javascript_nodejs/48.customQABot-all-features/package.json
@@ -20,7 +20,7 @@
     "botbuilder-ai": "~4.20.0",
     "botbuilder-dialogs": "~4.20.0",
     "dotenv": "^8.2.0",
-    "restify": "~8.6.0"
+    "restify": "~10.0.0"
   },
   "devDependencies": {
     "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/README.md
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/package.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/package.json
@@ -16,10 +16,10 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.17.0",
-        "botframework-connector": "~4.17.0",
+        "botbuilder": "~4.20.0",
+        "botframework-connector": "~4.20.0",
         "dotenv": "~8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/package.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/package.json
@@ -16,10 +16,10 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.17.0",
-        "botframework-connector": "~4.17.0",
+        "botbuilder": "~4.20.0",
+        "botframework-connector": "~4.20.0",
         "dotenv": "~8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/81.skills-skilldialog/README.md
+++ b/samples/javascript_nodejs/81.skills-skilldialog/README.md
@@ -6,7 +6,7 @@ This bot has been created using the [Bot Framework](https://dev.botframework.com
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher.
+- [Node.js](https://nodejs.org) version 16.16.0 or higher.
 
     ```bash
     # Determine node version.

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/package.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/package.json
@@ -16,10 +16,10 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.17.0",
-        "botbuilder-dialogs": "~4.17.0",
+        "botbuilder": "~4.20.0",
+        "botbuilder-dialogs": "~4.20.0",
         "dotenv": "~8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/package.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/package.json
@@ -17,11 +17,11 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "~1.1.4",
-        "botbuilder": "~4.17.0",
-        "botbuilder-ai": "~4.17.0",
-        "botbuilder-dialogs": "~4.17.0",
+        "botbuilder": "~4.20.0",
+        "botbuilder-ai": "~4.20.0",
+        "botbuilder-dialogs": "~4.20.0",
         "dotenv": "~8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/README.md
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher.
+- [Node.js](https://nodejs.org) version 16.16.0 or higher.
 
     ```bash
     # Determine node version.

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/package.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/package.json
@@ -16,11 +16,11 @@
         "url": "https://github.com/Microsoft/BotBuilder-Samples.git"
     },
     "dependencies": {
-        "botbuilder": "~4.17.0",
-        "botbuilder-dialogs": "~4.17.0",
-        "botbuilder-lg": "~4.17.0",
+        "botbuilder": "~4.20.0",
+        "botbuilder-dialogs": "~4.20.0",
+        "botbuilder-lg": "~4.20.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/package.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/package.json
@@ -17,13 +17,13 @@
     },
     "dependencies": {
         "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-        "botbuilder": "~4.17.0",
-        "botbuilder-ai": "~4.17.0",
-        "botbuilder-dialogs": "~4.17.0",
-        "botbuilder-testing": "~4.17.0",
-        "botbuilder-lg": "~4.17.0",
+        "botbuilder": "~4.20.0",
+        "botbuilder-ai": "~4.20.0",
+        "botbuilder-dialogs": "~4.20.0",
+        "botbuilder-testing": "~4.20.0",
+        "botbuilder-lg": "~4.20.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/README.md
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) version 10.14 or higher
+- [Node.js](https://nodejs.org) version 16.16.0 or higher
 
     ```bash
     # determine node version

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/package.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/package.json
@@ -16,10 +16,10 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "botbuilder": "~4.17.0",
+        "botbuilder": "~4.20.0",
         "dotenv": "^8.2.0",
         "math-random": "^2.0.1",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",


### PR DESCRIPTION
Fixes #3901 

With Node 16 soon to be EOL, the Node samples should all be updated to run on Node 18 out of the box. Additionally, we have seen repeated issues opened by customers unable to use Node 18 when starting with the sample bots.

Previously, We were unable to update all of the samples since BotBuilder-JS versions 4.19.3 and prior did not support restify 10.0.0, which is the minimum supported version of restify for Node 18. With the general release of BotBuilder-JS version 4.20.0 containing fixes for this issue, it is now possible to update the samples for Node 18.

## Proposed Changes
  - Update all Bot Builder packages in all Node samples to `4.20.0`
  - Update restify in all applicable Node samples to `10.0.0`

These changes should not impact the continued use of Node 16 up until the EOL date.

## Testing
Tested a series of samples. They functioned correctly on Node 18 and Node 16.