### PR TITLE
[JavaScript] Update restify dependency in new samples

### DIFF
--- a/samples/javascript_nodejs/84.bot-authentication-certificate/package.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/package.json
@@ -21,7 +21,7 @@
         "@azure/keyvault-secrets": "^4.7.0",
         "botbuilder": "~4.21.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",

--- a/samples/javascript_nodejs/85.bot-authentication-sni/package.json
+++ b/samples/javascript_nodejs/85.bot-authentication-sni/package.json
@@ -21,7 +21,7 @@
         "@azure/keyvault-secrets": "^4.7.0",
         "botbuilder": "^4.21.0",
         "dotenv": "^8.2.0",
-        "restify": "~8.6.0"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",


### PR DESCRIPTION
#minor

## Proposed Changes
This PR upgrades `restify` to version "~10.0.0" in the remaining two samples `84.bot-authentication-certificate` and `85.bot-authentication-sni`. With this update, the samples will run on Node 18 without issues.

## Testing
Here we can see one of the samples working after the changes.
![image](https://github.com/southworks/BotBuilder-Samples/assets/44245136/adaafbb0-50b8-4ae0-9e86-37649a417853)

