### PR TITLE
Fix Python broken proactive example to use CONFIG instead of SETTINGS

### DIFF
--- a/samples/python/16.proactive-messages/app.py
+++ b/samples/python/16.proactive-messages/app.py
@@ -63,7 +63,7 @@ CONVERSATION_REFERENCES: Dict[str, ConversationReference] = dict()
 # If the channel is the Emulator, and authentication is not in use, the AppId will be null.
 # We generate a random AppId for this case only. This is not required for production, since
 # the AppId will have a value.
-APP_ID = SETTINGS.app_id if SETTINGS.app_id else uuid.uuid4()
+APP_ID = CONFIG.APP_ID if CONFIG.APP_ID else uuid.uuid4()
 
 # Create the Bot
 BOT = ProactiveBot(CONVERSATION_REFERENCES)


### PR DESCRIPTION
## Proposed Changes
The example didn't work because SETTINGS variable didn't exist in the current context (used to in previous versions of repo).
Updated the example to use CONFIG instead. Also changed app_id to uppercase APP_ID because that's what's defined in the config.