### PR TITLE
Uncommenting the SUBSCRIPTION_REGION in bot configurations

### DIFF
--- a/samples/python/17.multilingual-bot/config.py
+++ b/samples/python/17.multilingual-bot/config.py
@@ -16,4 +16,4 @@ class DefaultConfig:
     APP_TYPE = os.environ.get("MicrosoftAppType", "MultiTenant")
     APP_TENANTID = os.environ.get("MicrosoftAppTenantId", "")
     SUBSCRIPTION_KEY = os.environ.get("SubscriptionKey", "")
-    # SUBSCRIPTION_REGION = os.environ.get("SubscriptionRegion", "")
+    SUBSCRIPTION_REGION = os.environ.get("SubscriptionRegion", "")


### PR DESCRIPTION
Fixes #3454
[Samples (python/17.multilingual-bot) • Fails due to, the variable SUBSCRIPTION_REGION located in the config.py file is commented.](https://github.com/microsoft/BotBuilder-Samples/issues/3454)
## Proposed Changes
  - `MicrosoftTranslator` constructor expecting both `subscription_key` & `subscription_region` and the bot is throwing error due to, the variable SUBSCRIPTION_REGION located in the config.py file is commented
  - Uncommenting the SUBSCRIPTION_REGION solved the issue.


## Testing
- Before changes:
<img width="638" alt="image" src="https://github.com/microsoft/BotBuilder-Samples/assets/164224646/ff58e624-eb96-4f17-8f12-2de7efa61846">

- After changes:
<img width="486" alt="image" src="https://github.com/microsoft/BotBuilder-Samples/assets/164224646/2bb6719d-3f3c-4cd4-ab1d-90df4cbb2632">

