### PR TITLE
Facebook-events: Adding botbuilder-dialogs dependency in the requirements.txt

### DIFF
--- a/samples/python/23.facebook-events/requirements.txt
+++ b/samples/python/23.facebook-events/requirements.txt
@@ -1,2 +1,3 @@
 jsonpickle==1.2
 botbuilder-integration-aiohttp>=4.15.0
+botbuilder-dialogs>=4.15.0


### PR DESCRIPTION
Fixes #3453 [Samples (python/23.facebook-events) Fails due to, missing botbuilder-dialogs dependency in the requirements.txt](https://github.com/microsoft/BotBuilder-Samples/issues/3453)

## Proposed Changes
Added missing dependency: `botbuilder-dialogs` in the requirements.txt
