### PR TITLE
[#3948] Update dotnet samples to target .Net 8 - CI pipeline

### DIFF
--- a/.github/workflows/ci-dotnet-samples.yml
+++ b/.github/workflows/ci-dotnet-samples.yml
@@ -72,10 +72,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: use .net 6.0.x
+      - name: use .net 8.0.x
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: "6.0.x"
+          dotnet-version: "8.0.x"
 
       - name: dotnet restore
         run: dotnet restore


### PR DESCRIPTION
Addresses #3948
#minor

## Description
This PR updates the CI pipeline to target .NET 8

## Specific Changes
- Updated `ci-dotnet-samples.yml` to target .NET 8.

## Testing
The following image shows the CI pipeline passing with a .NET 8 sample.
![imagen](https://github.com/southworks/BotBuilder-Samples/assets/62260472/2002f3bf-308f-45d0-b32f-161b66112951)