### PR TITLE
[#3948] Update dotnet samples to target .Net 8 - CQA samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ A [collection of **experimental** samples](./experimental) exist, intended to pr
 [cs#43]:samples/csharp_dotnetcore/43.complex-dialog
 [cs#44]:samples/csharp_dotnetcore/44.prompt-users-for-input
 [cs#45]:samples/csharp_dotnetcore/45.state-management
+[cs#48]:samples/csharp_dotnetcore/48.customQABot-all-features
 [cs#60]:samples/csharp_dotnetcore/60.slack-adapter
 [cs#61]:samples/csharp_dotnetcore/61.facebook-adapter
 [cs#62]:samples/csharp_dotnetcore/62.webex-adapter

--- a/samples/csharp_dotnetcore/12.customQABot/CustomQABot.csproj
+++ b/samples/csharp_dotnetcore/12.customQABot/CustomQABot.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.22.3" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.22.4" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/csharp_dotnetcore/48.customQABot-all-features/CustomQABotAllFeatures.csproj
+++ b/samples/csharp_dotnetcore/48.customQABot-all-features/CustomQABotAllFeatures.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.22.3" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.3" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.22.4" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.4" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Addresses #3948
#minor

> [!IMPORTANT]
> These changes depend on PR https://github.com/microsoft/BotBuilder-Samples/pull/3982 being merged, so the CI pipeline pass successfully with .NET 8.

## Description
This PR updates the CQA samples to target .NET 8

## Specific Changes
- Updated the following samples to target .NET 8
  - 12.customQABot
  - 48.customQABot-all-features

## Testing
These images show the updated bots working as expected.
12.customQABot
![imagen](https://github.com/southworks/BotBuilder-Samples/assets/62260472/ed848c7b-4b56-4d44-bc07-42720d1968cf)
48.customQABot-all-features
![imagen](https://github.com/southworks/BotBuilder-Samples/assets/62260472/e96ed9c7-e6bd-4bbe-aaaa-3b8aee844f8d)
