### PR TITLE
Update template-BotApp-with-rg.json

### DIFF
--- a/samples/python/02.echo-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/python/02.echo-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -239,7 +239,7 @@
         "linuxFxVersion": "PYTHON|3.9",
         "requestTracingEnabled": false,
         "remoteDebuggingEnabled": false,
-        "remoteDebuggingVersion": "VS2017",
+        "remoteDebuggingVersion": "VS2022",
         "httpLoggingEnabled": true,
         "logsDirectorySizeLimit": 35,
         "detailedErrorLoggingEnabled": false,


### PR DESCRIPTION
VS2017 isn't supported anymore

## Proposed Changes

Deployment fails because VS2017 isn't supported anymore. Updating default to VS2022.

