### PR TITLE
Update samples to support Node 22 version - JavaScript

### DIFF
--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|20-LTS"
+      "defaultValue": "NODE|22-LTS"
     },
     "appId": {
       "type": "string",
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/02.echo-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|20-LTS"
+      "defaultValue": "NODE|22-LTS"
     },
     "appId": {
       "type": "string",
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/03.welcome-users/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/05.multi-turn-prompt/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/06.using-cards/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/06.using-cards/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/06.using-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/06.using-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/07.using-adaptive-cards/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/08.suggested-actions/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/12.customQABot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/12.customQABot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/12.customQABot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/12.customQABot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|20-LTS"
+      "defaultValue": "NODE|22-LTS"
     },
     "appId": {
       "type": "string",
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/13.core-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|20-LTS"
+      "defaultValue": "NODE|22-LTS"
     },
     "appId": {
       "type": "string",
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/15.handling-attachments/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/16.proactive-messages/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/17.multilingual-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/18.bot-authentication/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/19.custom-dialogs/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/21.corebot-app-insights/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/23.facebook-events/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/24.bot-authentication-msgraph/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/43.complex-dialog/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/44.prompt-for-user-input/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/45.state-management/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/45.state-management/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/45.state-management/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/45.state-management/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/47.inspection/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/47.inspection/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/47.inspection/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/47.inspection/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/48.customQABot-all-features/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/48.customQABot-all-features/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/48.customQABot-all-features/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/48.customQABot-all-features/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/49.echo-proxy-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/49.echo-proxy-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/49.echo-proxy-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/49.echo-proxy-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/49.echo-proxy-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/49.echo-proxy-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|20-LTS"
+      "defaultValue": "NODE|22-LTS"
     },
     "appId": {
       "type": "string",
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/49.echo-proxy-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/49.echo-proxy-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|20-LTS"
+      "defaultValue": "NODE|22-LTS"
     },
     "appId": {
       "type": "string",
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/echo-skill-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/80.skills-simple-bot-to-bot/simple-root-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogRootBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/81.skills-skilldialog/dialogSkillBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/rootBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/82.skills-sso-cloudadapter/skillBot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|20-LTS"
+      "defaultValue": "NODE|22-LTS"
     },
     "appId": {
       "type": "string",
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/83.named-pipe-sample/named-pipe-bot/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|20-LTS"
+      "defaultValue": "NODE|22-LTS"
     },
     "appId": {
       "type": "string",
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -176,7 +176,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -194,7 +194,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|20-LTS"
+      "defaultValue": "NODE|22-LTS"
     },
     "appId": {
       "type": "string",
@@ -151,7 +151,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/84.bot-authentication-certificate/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|20-LTS"
+      "defaultValue": "NODE|22-LTS"
     },
     "appId": {
       "type": "string",
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|20-LTS"
+      "defaultValue": "NODE|22-LTS"
     },
     "appId": {
       "type": "string",
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/85.bot-authentication-sni/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|20-LTS"
+      "defaultValue": "NODE|22-LTS"
     },
     "appId": {
       "type": "string",
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/86.bot-authentication-fic/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/86.bot-authentication-fic/deploymentTemplates/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -158,7 +158,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/86.bot-authentication-fic/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/86.bot-authentication-fic/deploymentTemplates/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -175,7 +175,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/86.bot-authentication-fic/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
+++ b/samples/javascript_nodejs/86.bot-authentication-fic/deploymentTemplates/linux/deployUseExistResourceGroup/template-BotApp-with-rg.json
@@ -51,7 +51,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|20-LTS"
+      "defaultValue": "NODE|22-LTS"
     },
     "appId": {
       "type": "string",
@@ -137,7 +137,7 @@
           "appSettings": [
             {
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "~20"
+              "value": "~22"
             },
             {
               "name": "MicrosoftAppType",

--- a/samples/javascript_nodejs/86.bot-authentication-fic/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
+++ b/samples/javascript_nodejs/86.bot-authentication-fic/deploymentTemplates/linux/deployWithNewResourceGroup/template-BotApp-new-rg.json
@@ -48,7 +48,7 @@
     },
     "linuxFxVersion": {
       "type": "string",
-      "defaultValue": "NODE|20-LTS"
+      "defaultValue": "NODE|22-LTS"
     },
     "appId": {
       "type": "string",
@@ -156,7 +156,7 @@
                   "appSettings": [
                     {
                       "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                      "value": "~20"
+                      "value": "~22"
                     },
                     {
                       "name": "MicrosoftAppType",


### PR DESCRIPTION
#minor

## Description
This PR updates the ARM templates of the JavaScript samples to use Node 22 as default.

## Proposed Changes
- Updated Node to version 22 in all ARM templates for Windows and Linux.

## Testing
These images show the bot working after the deployment.
![image](https://github.com/user-attachments/assets/53f925d2-e558-4464-9ef6-2003be9b6b21)