### PR TITLE
[JS] Add support for MSI in the CQA sample

### DIFF
--- a/samples/javascript_nodejs/48.customQABot-all-features/.env
+++ b/samples/javascript_nodejs/48.customQABot-all-features/.env
@@ -5,6 +5,7 @@ MicrosoftAppTenantId=
 
 ProjectName=
 LanguageEndpointKey=
+LanguageManagedIdentityClientId=
 LanguageEndpointHostName=
 DefaultAnswer=
 DefaultWelcomeMessage=

--- a/samples/javascript_nodejs/48.customQABot-all-features/README.md
+++ b/samples/javascript_nodejs/48.customQABot-all-features/README.md
@@ -29,11 +29,36 @@ This bot was created using [Bot Framework][BF].
 - Go to `Deploy knowledge base` and click on `Deploy`.
 
 ### Connect your bot to the project.
-Follow these steps to update [.env file](.env).
+There are two ways the bot could authenticate to the Language resource.
+
+Pick one and follow these steps to update [.env file](.env) accordingly.
+
+1. Using an `Endpoint Key`: _provides an easier configuration by using a secret. Great way to test the bot locally_.
+
 - In the [Azure Portal][Azure], go to your resource.
 - Go to `Keys and Endpoint` under Resource Management.
 - Copy one of the keys as value of `LanguageEndpointKey` and Endpoint as value of `LanguageEndpointHostName` in [.env file](.env).
 - `ProjectName` is the name of the project created in [Language Studio][LS].
+- `LanguageManagedIdentityClientId` is not needed when using an Endpoint Key, so you can remove it from [.env file](.env).
+
+2. Using a `User Managed Identity` resource: _provides a more complex configuration by using a User Managed Identity resource. Great way to authenticate without the need of a secret_.
+- Create a [User Managed Identity][create-msi] resource in the same region as the Language resource.
+   - Copy the `ClientId` as value of `LanguageManagedIdentityClientId` in [.env file](.env).
+- In the [Azure Portal][Azure], go to the WebApp resource, where the bot is hosted.
+- Go to `Identity` under Settings and select `User assigned`. More information on Identity assignment can be found [here][webapp-msi].
+- Click on `Add` and select the User Managed Identity created in the previous step.
+- Click `Save` to assign the User Managed Identity to the WebApp resource.
+    - This will allow the WebApp to communicate with the Language resource using the User Managed Identity.
+- In the [Azure Portal][Azure], go to the Language resource.
+- Assign the following role in the `Access Control (IAM)` section. More information on role assignment can be found [here][language-custom-role].
+    - `Cognitive Services User`: _this role is required so the Managed Identity can access the keys of the Cognitive Service resource_.
+- In the Language resource, go to `Keys and Endpoint` under Resource Management.
+- Copy the `Endpoint` as value of `LanguageEndpointHostName` in [.env file](.env).
+- `ProjectName` is the name of the project created in [Language Studio][LS].
+- `LanguageEndpointKey` is not needed when using a User Managed Identity, so you can remove it from [.env file](.env).
+
+> [!NOTE]
+> This method requires [the bot to be deployed in Azure][deploy-bot], so the User Managed Identity can authenticate to the Language resource to get access to the keys.
 
 ## To try this sample
 
@@ -188,3 +213,7 @@ If you are new to Microsoft Azure, please refer to [Getting started with Azure][
 [Quickstart]: https://docs.microsoft.com/azure/cognitive-services/language-service/question-answering/quickstart/sdk
 [Azure]: https://portal.azure.com/
 [BFE]: https://github.com/Microsoft/BotFramework-Emulator/releases
+[deploy-bot]: #deploy-the-bot-to-azure
+[create-msi]: https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#create-a-user-assigned-managed-identity
+[language-custom-role]: https://learn.microsoft.com/en-us/azure/operator-service-manager/how-to-create-user-assigned-managed-identity#assign-custom-role-1
+[webapp-msi]: https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=portal%2Chttp

--- a/samples/javascript_nodejs/48.customQABot-all-features/dialogs/rootDialog.js
+++ b/samples/javascript_nodejs/48.customQABot-all-features/dialogs/rootDialog.js
@@ -28,7 +28,7 @@ const INCLUDE_UNSTRUCTURED_SOURCES = true;
 /**
  * Creates QnAMakerDialog instance with provided configuraton values.
  */
-const createQnAMakerDialog = (knowledgeBaseId, endpointKey, endpointHostName, defaultAnswer, enablePreciseAnswerRaw, displayPreciseAnswerOnlyRaw, useTeamsAdaptiveCard) => {
+const createQnAMakerDialog = (knowledgeBaseId, endpointKey, managedIdentityClientId, endpointHostName, defaultAnswer, enablePreciseAnswerRaw, displayPreciseAnswerOnlyRaw, useTeamsAdaptiveCard) => {
     let noAnswerActivity;
     if (typeof defaultAnswer === 'string' && defaultAnswer !== '') {
         noAnswerActivity = MessageFactory.text(defaultAnswer);
@@ -36,7 +36,7 @@ const createQnAMakerDialog = (knowledgeBaseId, endpointKey, endpointHostName, de
 
     const qnaMakerDialog = new QnAMakerDialog(
         knowledgeBaseId,
-        endpointKey,
+        undefined,
         endpointHostName,
         // @ts-ignore
         noAnswerActivity,
@@ -47,6 +47,12 @@ const createQnAMakerDialog = (knowledgeBaseId, endpointKey, endpointHostName, de
         ACTIVE_LEARNING_CARD_NO_MATCH_RESPONSE,
         RANKER_TYPE
     );
+
+    if (managedIdentityClientId) {
+        qnaMakerDialog.withManagedIdentityClientId(managedIdentityClientId);
+    } else {
+        qnaMakerDialog.withEndpointKey(endpointKey);
+    }
 
     qnaMakerDialog.enablePreciseAnswer = enablePreciseAnswerRaw === 'true';
     qnaMakerDialog.displayPreciseAnswerOnly = displayPreciseAnswerOnlyRaw === 'true';
@@ -63,21 +69,22 @@ class RootDialog extends ComponentDialog {
     /**
      * Root dialog for this bot. Creates a QnAMakerDialog.
      * @param {string} knowledgeBaseId Knowledge Base ID of the QnA Maker instance.
-     * @param {string} endpointKey Endpoint key needed to query QnA Maker.
+     * @param {any} endpointKey (optional) Endpoint key needed to query QnA Maker.
+     * @param {any} managedIdentityClientId (optional) Managed identity client ID to use for authentication.
      * @param {string} endpointHostName Host name of the QnA Maker instance.
      * @param {string} defaultAnswer (optional) Text used to create a fallback response when QnA Maker doesn't have an answer for a question.
      * @param {string} enablePreciseAnswer
      * @param {string} displayPreciseAnswerOnly
 
     */
-    constructor(knowledgeBaseId, endpointKey, endpointHostName, defaultAnswer, enablePreciseAnswer, displayPreciseAnswerOnly, useTeamsAdaptiveCard) {
+    constructor(knowledgeBaseId, endpointKey, managedIdentityClientId, endpointHostName, defaultAnswer, enablePreciseAnswer, displayPreciseAnswerOnly, useTeamsAdaptiveCard) {
         super(ROOT_DIALOG);
         // Initial waterfall dialog.
         this.addDialog(new WaterfallDialog(INITIAL_DIALOG, [
             this.startInitialDialog.bind(this)
         ]));
 
-        this.addDialog(createQnAMakerDialog(knowledgeBaseId, endpointKey, endpointHostName, defaultAnswer, enablePreciseAnswer, displayPreciseAnswerOnly, useTeamsAdaptiveCard));
+        this.addDialog(createQnAMakerDialog(knowledgeBaseId, endpointKey, managedIdentityClientId, endpointHostName, defaultAnswer, enablePreciseAnswer, displayPreciseAnswerOnly, useTeamsAdaptiveCard));
         this.initialDialogId = INITIAL_DIALOG;
     }
 


### PR DESCRIPTION
> [!IMPORTANT]
> This PR requires the feature introduced in [#4879](https://github.com/microsoft/botbuilder-js/pull/4879)

## Description
This PR adds support for User Managed Identity to the CQA sample. Providing a way to choose between using the EndpointKey or the MSI resource to authenticate to the Language service.

## Proposed Changes
  - Updated `index.js` to receive the new _LanguageManagedIdentityClientId_ property. Additionally, the deprecated _BotFrameworkAdapter_ was replaced by _CloudAdapter_.
  - Updated `RootDialog` to support both _EndpointKey_ and _MSI auth_ type for CQA resource.
  - Updated `README.md` to include the new MSI option and the required configuration.
  - Updated `.env` file to include the new _LanguageManagedIdentityClientId_ property.

## Testing
The following image shows both types of authentication working.
![image](https://github.com/user-attachments/assets/8770b860-72ee-4a6d-8f13-1f24ced5c7fd)