### PR TITLE
Fix 'uncaughtException: No such module: http_parser'

### DIFF
--- a/samples/typescript_nodejs/00.empty-bot/package.json
+++ b/samples/typescript_nodejs/00.empty-bot/package.json
@@ -22,6 +22,9 @@
         "replace": "~1.2.0",
         "restify": "~10.0.0"
     },
+    "overrides": {
+        "http-deceiver": "npm:http-deceiver-fixes@1.2.8"
+    },
     "devDependencies": {
         "@types/restify": "8.5.12",
         "@typescript-eslint/eslint-plugin": "^7.8.0",

--- a/samples/typescript_nodejs/02.echo-bot/package.json
+++ b/samples/typescript_nodejs/02.echo-bot/package.json
@@ -23,6 +23,9 @@
         "replace": "^1.2.0",
         "restify": "~10.0.0"
     },
+    "overrides": {
+        "http-deceiver": "npm:http-deceiver-fixes@1.2.8"
+    },
     "devDependencies": {
         "@types/dotenv": "6.1.1",
         "@types/node": "^16.11.6",

--- a/samples/typescript_nodejs/03.welcome-users/package.json
+++ b/samples/typescript_nodejs/03.welcome-users/package.json
@@ -22,6 +22,9 @@
         "replace": "~1.2.0",
         "restify": "~10.0.0"
     },
+    "overrides": {
+        "http-deceiver": "npm:http-deceiver-fixes@1.2.8"
+    },
     "devDependencies": {
         "@types/restify": "8.5.12",
         "@typescript-eslint/eslint-plugin": "^7.8.0",

--- a/samples/typescript_nodejs/05.multi-turn-prompt/package.json
+++ b/samples/typescript_nodejs/05.multi-turn-prompt/package.json
@@ -24,6 +24,9 @@
         "replace": "~1.2.0",
         "restify": "~10.0.0"
     },
+    "overrides": {
+        "http-deceiver": "npm:http-deceiver-fixes@1.2.8"
+    },
     "devDependencies": {
         "@types/restify": "8.5.12",
         "@typescript-eslint/eslint-plugin": "^7.8.0",

--- a/samples/typescript_nodejs/06.using-cards/package.json
+++ b/samples/typescript_nodejs/06.using-cards/package.json
@@ -24,6 +24,9 @@
         "replace": "~1.2.0",
         "restify": "~10.0.0"
     },
+    "overrides": {
+        "http-deceiver": "npm:http-deceiver-fixes@1.2.8"
+    },
     "devDependencies": {
         "@types/restify": "8.5.12",
         "@typescript-eslint/eslint-plugin": "^7.8.0",

--- a/samples/typescript_nodejs/16.proactive-messages/package.json
+++ b/samples/typescript_nodejs/16.proactive-messages/package.json
@@ -23,6 +23,9 @@
         "replace": "~1.2.0",
         "restify": "~10.0.0"
     },
+    "overrides": {
+        "http-deceiver": "npm:http-deceiver-fixes@1.2.8"
+    },
     "devDependencies": {
         "@types/dotenv": "6.1.1",
         "@types/restify": "8.5.12",


### PR DESCRIPTION
_Restify → spdy → http-deceiver_ chain crashes on `npm start` due to [DEP0111](https://nodejs.org/api/deprecations.html#DEP0111).

Upstream fixes are not yet merged and the library cannot be bumped. Use a patched version and override the dependency to restore expected behavior.

See: https://github.com/spdy-http2/http-deceiver/pull/7

Revert this commit once a fixed version is released and restify dependency is upgraded.